### PR TITLE
Issues/21

### DIFF
--- a/.changeset/commit.cjs
+++ b/.changeset/commit.cjs
@@ -1,7 +1,3 @@
-function getAddMessage(changeset) {
-  return `[changeset] ${changeset.summary}`;
-}
-
 function getVersionMessage(releasePlan) {
   const releases = releasePlan.releases.filter((release) => release.type !== 'none');
   const lines = [`[release] Releasing ${releases.length} package(s)`];
@@ -12,6 +8,5 @@ function getVersionMessage(releasePlan) {
 }
 
 exports['default'] = {
-  getAddMessage,
   getVersionMessage,
 };

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://unpkg.com/@changesets/config@3.0.0/schema.json",
   "changelog": ["@changesets/changelog-github", { "repo": "trulysimple/tsargp" }],
-  "commit": ["./commit.cjs", {}],
+  "commit": "./commit.cjs",
   "fixed": [],
   "linked": [],
   "access": "public",

--- a/.changeset/tiny-tables-confess.md
+++ b/.changeset/tiny-tables-confess.md
@@ -1,0 +1,6 @@
+---
+'tsargp': patch
+---
+
+You can now set the `NO_COLOR` environment variable to _omit_ styles from error and help messages.
+You can also set `FORCE_COLOR` to _emit_ styles even when the output is being redirected.

--- a/packages/tsargp/examples/demo.options.ts
+++ b/packages/tsargp/examples/demo.options.ts
@@ -59,7 +59,7 @@ export default {
     footer: `
     MIT License.
     Copyright (c) 2024
-    ${style(tf.bold, tf.italic, fg.cyan)}TrulySimple${style(tf.clear)}
+    ${style(tf.bold, tf.italic)}TrulySimple${style(tf.clear)}
 
     Report a bug:
     ${style(tf.faint)}https://github.com/trulysimple/tsargp/issues${style(tf.clear)}`,

--- a/packages/tsargp/lib/parser.ts
+++ b/packages/tsargp/lib/parser.ts
@@ -261,8 +261,8 @@ class ParserLoop {
         } catch (err) {
           // do not propagate errors during completion
           if (!this.completing) {
-            if (suggestName(option)) {
-              handleUnknown(this.validator, value, err as ErrorMessage);
+            if (err instanceof ErrorMessage && suggestName(option)) {
+              handleUnknown(this.validator, value, err);
             }
             throw err;
           }

--- a/packages/tsargp/lib/styles.ts
+++ b/packages/tsargp/lib/styles.ts
@@ -461,7 +461,7 @@ class ErrorMessage extends Error {
    * @param emitStyles True if styles should be emitted
    * @returns The message to be printed on a terminal
    */
-  wrap(width = process.stderr.columns, emitStyles = !omitStyles(width)): string {
+  wrap(width = process.stderr.columns ?? 0, emitStyles = !omitStyles(width)): string {
     const result = new Array<string>();
     this.str.wrapToWidth(result, 0, width, emitStyles);
     if (emitStyles) {
@@ -488,7 +488,7 @@ class HelpMessage extends Array<TerminalString> {
    * @param emitStyles True if styles should be emitted
    * @returns The message to be printed on a terminal
    */
-  wrap(width = process.stdout.columns, emitStyles = !omitStyles(width)): string {
+  wrap(width = process.stdout.columns ?? 0, emitStyles = !omitStyles(width)): string {
     const result = new Array<string>();
     let column = 0;
     for (const str of this) {

--- a/packages/tsargp/test/styles.spec.ts
+++ b/packages/tsargp/test/styles.spec.ts
@@ -160,156 +160,186 @@ describe('TerminalString', () => {
       it('should not wrap', () => {
         const str = new TerminalString();
         const result = new Array<string>();
-        str.splitText('abc def').wrapToWidth(result, 0);
+        str.splitText('abc def').wrapToWidth(result, 0, 0, false);
         expect(result).toEqual(['abc', ' def']);
+      });
+
+      it('should omit styles', () => {
+        const str = new TerminalString();
+        const result = new Array<string>();
+        str.splitText(`abc${style(tf.clear)}def`).wrapToWidth(result, 0, 0, false);
+        expect(result).toEqual(['abcdef']);
+      });
+
+      it('should emit styles', () => {
+        const str = new TerminalString();
+        const result = new Array<string>();
+        str.splitText(`abc${style(tf.clear)}def`).wrapToWidth(result, 0, 0, true);
+        expect(result).toEqual(['abc' + style(tf.clear) + 'def']);
       });
 
       it('should preserve indentation', () => {
         const str = new TerminalString(2);
         const result = new Array<string>();
-        str.addWord('abc').wrapToWidth(result, 0);
+        str.addWord('abc').wrapToWidth(result, 0, 0, false);
         expect(result).toEqual(['  ', 'abc']);
       });
 
       it('should not preserve indentation if the string is empty', () => {
         const str = new TerminalString(2);
         const result = new Array<string>();
-        str.wrapToWidth(result, 0);
+        str.wrapToWidth(result, 0, 0, false);
         expect(result).toEqual([]);
       });
 
       it('should not preserve indentation if the string starts with a line break', () => {
         const str = new TerminalString(2);
         const result = new Array<string>();
-        str.addBreaks(1).wrapToWidth(result, 0);
+        str.addBreaks(1).wrapToWidth(result, 0, 0, false);
         expect(result).toEqual(['\n']);
       });
 
       it('should shorten the current line (1)', () => {
         const str = new TerminalString(0);
         const result = ['  '];
-        str.splitText('abc def').wrapToWidth(result, 2);
+        str.splitText('abc def').wrapToWidth(result, 2, 0, false);
         expect(result).toEqual(['abc', ' def']);
       });
 
       it('should shorten the current line (2)', () => {
         const str = new TerminalString(0);
         const result = ['   '];
-        str.splitText('abc def').wrapToWidth(result, 2);
+        str.splitText('abc def').wrapToWidth(result, 2, 0, false);
         expect(result).toEqual([' ', 'abc', ' def']);
       });
 
       it('should not shorten the current line if the string is empty', () => {
         const str = new TerminalString(0);
         const result = ['  '];
-        str.wrapToWidth(result, 2);
+        str.wrapToWidth(result, 2, 0, false);
         expect(result).toEqual(['  ']);
       });
 
       it('should not shorten the current line if the string starts with a line break', () => {
         const str = new TerminalString(0);
         const result = ['  '];
-        str.addBreaks(1).wrapToWidth(result, 2);
+        str.addBreaks(1).wrapToWidth(result, 2, 0, false);
         expect(result).toEqual(['  ', '\n']);
       });
 
       it('should preserve line breaks', () => {
         const str = new TerminalString(0);
         const result = new Array<string>();
-        str.splitText('abc\n\ndef').wrapToWidth(result, 0);
+        str.splitText('abc\n\ndef').wrapToWidth(result, 0, 0, false);
         expect(result).toEqual(['abc', '\n\n', 'def']);
       });
 
       it('should remove styles', () => {
         const str = new TerminalString(0);
         const result = new Array<string>();
-        str.splitText(`abc${style(tf.clear)} ${style(tf.clear)} def`).wrapToWidth(result, 0);
+        str
+          .splitText(`abc${style(tf.clear)} ${style(tf.clear)} def`)
+          .wrapToWidth(result, 0, 0, false);
         expect(result).toEqual(['abc', ' def']);
       });
     });
 
     describe('when a width is provided', () => {
+      it('should omit styles', () => {
+        const str = new TerminalString();
+        const result = new Array<string>();
+        str.splitText(`abc${style(tf.clear)}def`).wrapToWidth(result, 0, 10, false);
+        expect(result).toEqual(['abcdef']);
+      });
+
+      it('should emit styles', () => {
+        const str = new TerminalString();
+        const result = new Array<string>();
+        str.splitText(`abc${style(tf.clear)}def`).wrapToWidth(result, 0, 10, true);
+        expect(result).toEqual(['abc' + style(tf.clear) + 'def']);
+      });
+
       it('should wrap relative to the beginning when the largest word does not fit the width (1)', () => {
         const str = new TerminalString(1);
         const result = new Array<string>();
-        str.splitText('abc largest').wrapToWidth(result, 0, 5);
+        str.splitText('abc largest').wrapToWidth(result, 0, 5, false);
         expect(result).toEqual(['abc', '\nlargest']);
       });
 
       it('should wrap relative to the beginning when the largest word does not fit the width (2)', () => {
         const str = new TerminalString(1);
         const result = new Array<string>();
-        str.splitText('abc largest').wrapToWidth(result, 1, 5);
+        str.splitText('abc largest').wrapToWidth(result, 1, 5, false);
         expect(result).toEqual(['\n', 'abc', '\nlargest']);
       });
 
       it('should wrap relative to the beginning when the largest word does not fit the width (3)', () => {
         const str = new TerminalString(1);
         const result = new Array<string>();
-        str.addBreaks(1).splitText('abc largest').wrapToWidth(result, 1, 5);
+        str.addBreaks(1).splitText('abc largest').wrapToWidth(result, 1, 5, false);
         expect(result).toEqual(['\n', 'abc', '\nlargest']);
       });
 
       it('should wrap with a move sequence when the largest word fits the width (1)', () => {
         const str = new TerminalString(1);
         const result = new Array<string>();
-        str.splitText('abc largest').wrapToWidth(result, 1, 15);
+        str.splitText('abc largest').wrapToWidth(result, 1, 15, false);
         expect(result).toEqual(['abc', ' largest']);
       });
 
       it('should wrap with a move sequence when the largest word fits the width (2)', () => {
         const str = new TerminalString(1);
         const result = new Array<string>();
-        str.splitText('abc largest').wrapToWidth(result, 2, 15);
+        str.splitText('abc largest').wrapToWidth(result, 2, 15, false);
         expect(result).toEqual([move(2, mv.cha), 'abc', ' largest']);
       });
 
       it('should wrap with a move sequence when the largest word fits the width (3)', () => {
         const str = new TerminalString(2);
         const result = new Array<string>();
-        str.splitText('abc largest').wrapToWidth(result, 1, 15);
+        str.splitText('abc largest').wrapToWidth(result, 1, 15, false);
         expect(result).toEqual([move(3, mv.cha), 'abc', ' largest']);
       });
 
       it('should wrap with a move sequence when the largest word fits the width (4)', () => {
         const str = new TerminalString(1);
         const result = new Array<string>();
-        str.splitText('abc largest').wrapToWidth(result, 1, 10);
+        str.splitText('abc largest').wrapToWidth(result, 1, 10, false);
         expect(result).toEqual(['abc', `\n${move(2, mv.cha)}largest`]);
       });
 
       it('should wrap with a move sequence when the largest word fits the width (5)', () => {
         const str = new TerminalString();
         const result = new Array<string>();
-        str.splitText('abc largest').wrapToWidth(result, 0, 15);
+        str.splitText('abc largest').wrapToWidth(result, 0, 15, false);
         expect(result).toEqual(['abc', ' largest']);
       });
 
       it('should wrap with a move sequence when the largest word fits the width (6)', () => {
         const str = new TerminalString();
         const result = new Array<string>();
-        str.splitText('abc largest').wrapToWidth(result, 1, 15);
+        str.splitText('abc largest').wrapToWidth(result, 1, 15, false);
         expect(result).toEqual([move(1, mv.cha), 'abc', ' largest']);
       });
 
       it('should wrap with a move sequence when the largest word fits the width (7)', () => {
         const str = new TerminalString();
         const result = new Array<string>();
-        str.addBreaks(1).splitText('abc largest').wrapToWidth(result, 1, 15);
+        str.addBreaks(1).splitText('abc largest').wrapToWidth(result, 1, 15, false);
         expect(result).toEqual(['\n', 'abc', ' largest']);
       });
 
       it('should wrap with a move sequence when the largest word fits the width (8)', () => {
         const str = new TerminalString(1);
         const result = new Array<string>();
-        str.addBreaks(1).splitText('abc largest').wrapToWidth(result, 2, 15);
+        str.addBreaks(1).splitText('abc largest').wrapToWidth(result, 2, 15, false);
         expect(result).toEqual(['\n', `${move(2, mv.cha)}abc`, ' largest']);
       });
 
       it('should wrap with a move sequence when the largest word fits the width (9)', () => {
         const str = new TerminalString(2);
         const result = new Array<string>();
-        str.addBreaks(1).splitText('abc largest').wrapToWidth(result, 1, 15);
+        str.addBreaks(1).splitText('abc largest').wrapToWidth(result, 1, 15, false);
         expect(result).toEqual(['\n', `${move(3, mv.cha)}abc`, ' largest']);
       });
     });
@@ -322,7 +352,9 @@ describe('ErrorMessage', () => {
     str.splitText('type script');
     const err = new ErrorMessage(str);
     expect(err.message).toMatch(/type script/);
-    expect(err.wrap(0)).toEqual('type script');
+    expect(err.wrap(0, false)).toEqual('type script');
+    expect(err.wrap(0, true)).toEqual('type script' + style(tf.clear));
+    expect(err.wrap(11, false)).toEqual('type script');
     expect(err.wrap(11)).toEqual('type script' + style(tf.clear));
   });
 
@@ -343,7 +375,9 @@ describe('HelpMessage', () => {
     const help = new HelpMessage();
     help.push(str);
     expect(help.toString()).toMatch(/type script/);
-    expect(help.wrap(0)).toEqual('type script');
+    expect(help.wrap(0, false)).toEqual('type script');
+    expect(help.wrap(0, true)).toEqual('type script' + style(tf.clear));
+    expect(help.wrap(11, false)).toEqual('type script');
     expect(help.wrap(11)).toEqual('type script' + style(tf.clear));
   });
 });

--- a/packages/tsargp/test/styles.spec.ts
+++ b/packages/tsargp/test/styles.spec.ts
@@ -164,20 +164,6 @@ describe('TerminalString', () => {
         expect(result).toEqual(['abc', ' def']);
       });
 
-      it('should omit styles', () => {
-        const str = new TerminalString();
-        const result = new Array<string>();
-        str.splitText(`abc${style(tf.clear)}def`).wrapToWidth(result, 0, 0, false);
-        expect(result).toEqual(['abcdef']);
-      });
-
-      it('should emit styles', () => {
-        const str = new TerminalString();
-        const result = new Array<string>();
-        str.splitText(`abc${style(tf.clear)}def`).wrapToWidth(result, 0, 0, true);
-        expect(result).toEqual(['abc' + style(tf.clear) + 'def']);
-      });
-
       it('should preserve indentation', () => {
         const str = new TerminalString(2);
         const result = new Array<string>();
@@ -234,7 +220,7 @@ describe('TerminalString', () => {
         expect(result).toEqual(['abc', '\n\n', 'def']);
       });
 
-      it('should remove styles', () => {
+      it('should omit styles', () => {
         const str = new TerminalString(0);
         const result = new Array<string>();
         str
@@ -242,23 +228,18 @@ describe('TerminalString', () => {
           .wrapToWidth(result, 0, 0, false);
         expect(result).toEqual(['abc', ' def']);
       });
-    });
-
-    describe('when a width is provided', () => {
-      it('should omit styles', () => {
-        const str = new TerminalString();
-        const result = new Array<string>();
-        str.splitText(`abc${style(tf.clear)}def`).wrapToWidth(result, 0, 10, false);
-        expect(result).toEqual(['abcdef']);
-      });
 
       it('should emit styles', () => {
         const str = new TerminalString();
         const result = new Array<string>();
-        str.splitText(`abc${style(tf.clear)}def`).wrapToWidth(result, 0, 10, true);
-        expect(result).toEqual(['abc' + style(tf.clear) + 'def']);
+        str
+          .splitText(`abc${style(tf.clear)} ${style(tf.clear)} def`)
+          .wrapToWidth(result, 0, 0, true);
+        expect(result).toEqual(['abc' + style(tf.clear), style(tf.clear), ' def']);
       });
+    });
 
+    describe('when a width is provided', () => {
       it('should wrap relative to the beginning when the largest word does not fit the width (1)', () => {
         const str = new TerminalString(1);
         const result = new Array<string>();
@@ -342,6 +323,24 @@ describe('TerminalString', () => {
         str.addBreaks(1).splitText('abc largest').wrapToWidth(result, 1, 15, false);
         expect(result).toEqual(['\n', `${move(3, mv.cha)}abc`, ' largest']);
       });
+
+      it('should omit styles', () => {
+        const str = new TerminalString(0);
+        const result = new Array<string>();
+        str
+          .splitText(`abc${style(tf.clear)} ${style(tf.clear)} def`)
+          .wrapToWidth(result, 0, 10, false);
+        expect(result).toEqual(['abc', ' def']);
+      });
+
+      it('should emit styles', () => {
+        const str = new TerminalString();
+        const result = new Array<string>();
+        str
+          .splitText(`abc${style(tf.clear)} ${style(tf.clear)} def`)
+          .wrapToWidth(result, 0, 10, true);
+        expect(result).toEqual(['abc' + style(tf.clear), style(tf.clear), ' def']);
+      });
     });
   });
 });
@@ -355,7 +354,7 @@ describe('ErrorMessage', () => {
     expect(err.wrap(0, false)).toEqual('type script');
     expect(err.wrap(0, true)).toEqual('type script' + style(tf.clear));
     expect(err.wrap(11, false)).toEqual('type script');
-    expect(err.wrap(11)).toEqual('type script' + style(tf.clear));
+    expect(err.wrap(11, true)).toEqual('type script' + style(tf.clear));
   });
 
   it('should be thrown and caught', () => {
@@ -378,6 +377,6 @@ describe('HelpMessage', () => {
     expect(help.wrap(0, false)).toEqual('type script');
     expect(help.wrap(0, true)).toEqual('type script' + style(tf.clear));
     expect(help.wrap(11, false)).toEqual('type script');
-    expect(help.wrap(11)).toEqual('type script' + style(tf.clear));
+    expect(help.wrap(11, true)).toEqual('type script' + style(tf.clear));
   });
 });


### PR DESCRIPTION
A new `omitStyles` function was added in `packages/tsargp/lib/styles.ts` to check the necessary environment variables:

- `FORCE_COLOR` to emit styles even when the output is being redirected
- `NO_COLOR` to omit styles _if_ `FORCE_COLOR` is not set
- `TERM=dumb` to omit styles, _if_ none of the previous variables was set

Note that, if the terminal width is zero (or undefined), and `FORCE_COLOR` is not set, styles will be omitted regardless of the values of the other two variables.

A new parameter was added to the `wrap` method of both `ErrorMessage` and `HelpMessage` classes:

- `emitStyles` - `boolean` - true if styles should be emitted - defaults to `!omitStyles(width)`

Likewise for the `wrapToWidth` method of the `TerminalString` class, except that it is required in this case.

> [!NOTE]
> The `getAddMessage` function was removed from `.changeset/commit.cjs` because the `changeset add` command was [ignoring git commit failures](https://github.com/changesets/changesets/issues/1326), which might happen in the pre-commit hook. As a result, contributors will now have to commit the changeset file manually.

Closes #21 
