### PR TITLE
Issues/20

### DIFF
--- a/.changeset/rich-bees-change.md
+++ b/.changeset/rich-bees-change.md
@@ -1,0 +1,5 @@
+---
+'@trulysimple/tsargp-docs': patch
+---
+
+You can now set environment variables in the demo (e.g., `NO_COLOR=1`). This works even when performing completion. One caveat though: if you set variables inline with a command (e.g., `VAR1=1 VAR2=2 <cmd> ...`) they will persist through future invocations of any command. To reset variables, use the syntax `VAR=`.

--- a/cspell.json
+++ b/cspell.json
@@ -16,6 +16,7 @@
     "println",
     "compspec",
     "svgr",
+    "oclif",
     "codemirror",
     "CODEOWNERS"
   ],

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -35,6 +35,7 @@ export default [
       globals: {
         ...globals.browser,
         JSX: false,
+        process: false, // mocked by webpack
       },
     },
     plugins: {

--- a/packages/docs/pages/demo.mdx
+++ b/packages/docs/pages/demo.mdx
@@ -84,3 +84,9 @@ changes, then run the help option and see if:
 
 - words in the option descriptions get wrapped correctly
 - words in the usage and footer get wrapped correctly
+
+### Toggle styles
+
+- check if styles can be omitted with `NO_COLOR` (e.g., `NO_COLOR=1 ...`)
+- check if styles are emitted with `FORCE_COLOR` (e.g., `NO_COLOR=1 FORCE_COLOR=1 ...`)
+- check if styles are emitted when resetting (e.g., `NO_COLOR= FORCE_COLOR= ...`)

--- a/packages/docs/pages/docs/index.mdx
+++ b/packages/docs/pages/docs/index.mdx
@@ -25,7 +25,7 @@ title: Introduction - Docs
 Why use this library when there are already dozens of argument parsers on npm?
 
 The most distinctive feature is its _declarative_ API. Very few libraries on npm that we know of at
-the time of writing have this feature (and none of those support requirements between options). Most
+the time of writing have this feature (worth mentioning [meow] and [oclif]). Most
 others have either imperative or fluent interface, whereas **tsargp** offers a way to declare all of
 your command-line options in a single `object`.
 
@@ -82,3 +82,5 @@ complete -o default -C <your_cli_name> <your_cli_name>
 ```
 
 [SGR]: https://www.wikiwand.com/en/ANSI_escape_code#SGR_(Select_Graphic_Rendition)_parameters
+[meow]: https://www.npmjs.com/package/meow
+[oclif]: https://oclif.io/

--- a/packages/docs/pages/docs/library/options.mdx
+++ b/packages/docs/pages/docs/library/options.mdx
@@ -351,7 +351,15 @@ with [semantic version](#semantic-version).
 ### Function option
 
 The **function** option executes a generic callback function and saves its result as the option
-value. The following attributes can be specified.
+value. You can use it to perform many kinds of useful things, such as:
+
+- reading configuration from a file
+- altering the values of previous options
+- altering the option definitions in response to an option value
+  - e.g., if `--verbose` is set, add more help items to the [help format](#format--heading-style)
+    (or replace it altogether)
+
+The following attributes can be specified.
 
 #### Execute callback
 
@@ -371,6 +379,10 @@ call [`parseAsync`](parser.mdx#executing-callbacks) and await its result.
   parsing loop.
 </Callout>
 
+<Callout type="warning">
+  Altering the `rest` parameter will have _no_ effect on the original command-line arguments.
+</Callout>
+
 #### Break loop
 
 The `break` attribute, if present, tells the parser to exit the parsing loop immediately after
@@ -379,7 +391,7 @@ returning from the callback.
 <Callout type="warning">
   When setting this attribute, the requirements of all options specified up to the current iteration
   (including the function option) will be verified. Hence, you should make it clear in the help
-  message that any option required by the affected one must be specified before it.
+  message that any option required by the affected one must be specified _before_ it.
 </Callout>
 
 ### Command option
@@ -398,13 +410,13 @@ attributes and parses the remaining arguments for you.
 The `cmd` attribute is the callback function that should be executed. It is required and accepts
 two parameters:
 
-- `values` - the values parsed before the command
-- `cmdValues` - the values parsed after the command
+- `values` - the values parsed for the parent command
+- `cmdValues` - the values parsed for the command
 
 It should return the option value or `void{:ts}`. It can be asynchronous, in which case you should
 call [`parseAsync`](parser.mdx#executing-callbacks) and await its result. The simplest
-implementation would just return the values parsed for the command. In this way, they get stored in
-the option value and can be worked on after the parser returns from the parsing loop.
+implementation would just return `cmdValues`. This way, they are stored in the option value and
+can be handled after the parser returns from the parsing loop.
 
 <Callout type="info">
   When bash completion is in effect, this callback will _not_ be called. Otherwise, the parser will
@@ -415,12 +427,12 @@ the option value and can be worked on after the parser returns from the parsing 
 
 The `options` attribute is the set of option definitions for the command, and is required. You may
 also specify a (non-asynchronous) callback that returns the option definitions (this allows the
-implementation of [tail-recursive commands](../guides/commands.mdx)).
+implementation of [recursive commands](../guides/commands.mdx)).
 
 <Callout type="warning">
-  All incoming arguments will be parsed using the option definitions from this attribute, _not_
-  those in which the option was declared. Hence, you should make it clear in the help message that
-  all arguments pertaining to the command should be specified after it.
+  All incoming arguments will be parsed using the option definitions from this attribute, not those
+  in which the option was declared. Hence, you should make it clear in the help message that all
+  arguments pertaining to the command must be specified _after_ it.
 </Callout>
 
 ### Flag option
@@ -428,21 +440,21 @@ implementation of [tail-recursive commands](../guides/commands.mdx)).
 The **flag** option is unique in the sense that it is both niladic and has an intrinsic value
 (boolean). It differs from the [boolean option](#boolean-option) in that it does _not_ expect a
 parameter, although it may have the [required](#required) or the
-[default value](#default-value--callback) attribute for a `boolean{:ts}` data type.
+[default value](#default-value--callback) attribute for a `boolean{:ts}` data type, as well as the
+following (optional) attribute.
 
 <Callout type="info">
-  We could have reused the boolean option for this purpose and make the parameter optional, but it
-  would complicate the parser implementation unnecessarily. Besides, the flag option has a
-  particularly useful feature, which is described below.
+  We could have reused the boolean option for this purpose and made the parameter optional, but it
+  would complicate the parser implementation. One benefit of this limitation is that it avoids
+  ambiguity about whether arguments are positional or not (e.g., in `-f 1`, is `1` a parameter to
+  `-f` or a positional argument?).
 </Callout>
-
-It has the following optional attribute.
 
 #### Negation names
 
 The `negationNames` attribute specifies alternate option names that can be used to turn the option
-value `false{:ts}` (e.g., _--no-flag_). This is useful in scripting scenarios where a flag that has
-been previously specified must be reset by a supplementary list of arguments.
+value `false{:ts}` (e.g., _--no-flag_). This is particularly useful in scripting scenarios where a
+flag that has been previously specified must be reset by a supplementary list of arguments.
 
 ## Non-niladic options
 

--- a/packages/docs/pages/docs/library/styles.mdx
+++ b/packages/docs/pages/docs/library/styles.mdx
@@ -174,9 +174,15 @@ Another paragraph
 ### Text wrapping
 
 Text is wrapped according to a configured _width_: the number of terminal columns by which to limit
-each line of text. When a width of zero (or `undefined{:ts}`) is provided, the terminal string
-instance will suppress inline styles and omit control sequences that it would otherwise use for
-rendering text in a terminal.
+each line of text. When a width of zero or `undefined{:ts}` is provided (which may happen if the
+output is being redirected), the terminal string instance will suppress styles and control sequences
+that it would otherwise use to render text in a terminal.
+
+<Callout type="info">
+  You can force omission of styles regardless of the terminal width by setting the `NO_COLOR`
+  environment variable. Reciprocally, you can force emission of styles regardless of the terminal
+  width by setting the `FORCE_COLOR` environment variable.
+</Callout>
 
 #### Indentation level
 

--- a/packages/docs/theme.config.jsx
+++ b/packages/docs/theme.config.jsx
@@ -4,7 +4,7 @@ export default {
     link: 'https://github.com/trulysimple/tsargp',
   },
   faviconGlyph: 'ts',
-  docsRepositoryBase: 'https://github.com/trulysimple/tsargp/tree/main/docs',
+  docsRepositoryBase: 'https://github.com/trulysimple/tsargp/tree/main/packages/docs',
   footer: {
     text: (
       <span>


### PR DESCRIPTION
The `docsRepositoryBase` setting in the docs theme configuration was updated to point to the correct path in the repository, i.e., `packages/docs`.

The demo page was updated to parse environment variables (e.g., `NO_COLOR=1`). This works even when performing completion. There's one caveat though: when setting variables inline with a command (e.g., `VAR1=1 VAR2=2 <cmd> ...`) they will persist through future invocations of any command. In order to reset variables, the syntax `VAR=` can be used.

Many other parts of the documentation were uptaded to give more information about a particular feature or usage scneraio.

Closes #20 
