### PR TITLE
Issues/9

### DIFF
--- a/.changeset/healthy-seals-suffer.md
+++ b/.changeset/healthy-seals-suffer.md
@@ -1,0 +1,5 @@
+---
+'@trulysimple/tsargp-docs': patch
+---
+
+The Parser page was updated to document the new `progName` field of the parse configuration, as well as add a new section to explain how the process title is updated by the parser.

--- a/.changeset/six-camels-jam.md
+++ b/.changeset/six-camels-jam.md
@@ -1,0 +1,5 @@
+---
+'tsargp': minor
+---
+
+`ParseConfig` has a new field called `progName` which specifies the program name used to update the process title. It defaults to the basename of the executing script (if no command is provided), or to the command name, in case a raw command-line string is provided.

--- a/packages/docs/pages/docs/library/parser.mdx
+++ b/packages/docs/pages/docs/library/parser.mdx
@@ -26,7 +26,7 @@ accepts two optional parameters:
 Normally you should _not_ need to pass these parameters, as they have sensible default values:
 
 - `command` - `process.env['COMP_LINE']{:ts}` or `process.argv.slice(2){:ts}`
-- `config.progName` - `undefined{:ts}` or `process.argv[1].split(/[\\/]/).at(-1){:ts}`
+- `config.progName` - command name from `command` or `process.argv[1].split(/[\\/]/).at(-1){:ts}`
 - `config.compIndex` - `Number(process.env['COMP_POINT']){:ts}` or `undefined{:ts}`
 
 If you feel the need to configure the parser, make sure to first understand how
@@ -266,5 +266,5 @@ The process title would be updated in the following way:
 3. `node myscript.js cmd1` - the title at the start of the `cmd1` command
 4. `node myscript.js cmd1 cmd2` - the title at the start of the `cmd2` command
 
-The title will remain this way after the parser returns. Other option names are not used, because
+The title will remain unchanged after the parser returns. Other option names are not used, because
 they would pollute the output of process management utilities such as `ps`.

--- a/packages/docs/pages/docs/library/parser.mdx
+++ b/packages/docs/pages/docs/library/parser.mdx
@@ -26,6 +26,7 @@ accepts two optional parameters:
 Normally you should _not_ need to pass these parameters, as they have sensible default values:
 
 - `command` - `process.env['COMP_LINE']{:ts}` or `process.argv.slice(2){:ts}`
+- `config.progName` - `undefined{:ts}` or `process.argv[1].split(/[\\/]/).at(-1){:ts}`
 - `config.compIndex` - `Number(process.env['COMP_POINT']){:ts}` or `undefined{:ts}`
 
 If you feel the need to configure the parser, make sure to first understand how
@@ -58,8 +59,14 @@ This method returns a promise that can be awaited in order to resolve async
 
 ## Parse configuration
 
-The parsing procedure can be configured with a `ParseConfig` object that (currently) has only one
-optional property, as described below.
+The parsing procedure can be configured with a `ParseConfig` object that has a few optional
+properties, as described below.
+
+### Program name
+
+The `progName` property is a custom name for the program, which is used to update the process title.
+It defaults to the basename of the executing script (if no command-line is explicitly provided) or
+to the command name (in case a raw command-line string is provided).
 
 ### Completion index
 
@@ -242,3 +249,22 @@ with normal parameters, the value may contain any number of equal signs, and eve
 
 [Bash docs]: https://www.gnu.org/software/bash/manual/html_node/Programmable-Completion.html
 [Gestalt algorithm]: https://www.wikiwand.com/en/Gestalt_pattern_matching
+
+### Process title
+
+The process title will be updated to reflect the current command being executed. This includes the
+main script and any nested commands. For example, if the command-line is:
+
+```sh
+./path/to/myscript.js -flag0 cmd1 -flag1 cmd2 args...
+```
+
+The process title would be updated in the following way:
+
+1. `node` - this the starting title, before any update
+2. `node myscript.js` - the title at the beginning of the parsing loop
+3. `node myscript.js cmd1` - the title at the start of the `cmd1` command
+4. `node myscript.js cmd1 cmd2` - the title at the start of the `cmd2` command
+
+The title will remain this way after the parser returns. Other option names are not used, because
+they would pollute the output of process management utilities such as `ps`.

--- a/packages/tsargp/lib/parser.ts
+++ b/packages/tsargp/lib/parser.ts
@@ -109,16 +109,16 @@ class OpaqueArgumentParser {
   parseInto(
     values: CastToOptionValues,
     command = process?.env['COMP_LINE'] ?? process?.argv.slice(2) ?? [],
-    config: ParseConfig = {
-      progName: typeof command === 'string' ? undefined : process?.argv[1].split(/[\\/]/).at(-1),
-      compIndex: Number(process?.env['COMP_POINT']),
-    },
+    config: ParseConfig = { compIndex: Number(process?.env['COMP_POINT']) },
   ): Promise<Array<void>> {
     let args, progName;
     if (typeof command === 'string') {
       [progName, ...args] = getArgs(command, config.compIndex);
     } else {
       [progName, args] = [config.progName, command];
+      if (!progName) {
+        progName = process?.argv[1].split(/[\\/]/).at(-1);
+      }
     }
     const completing = (config.compIndex ?? -1) >= 0;
     const loop = new ParserLoop(this.validator, values, args, completing, progName);

--- a/packages/tsargp/lib/styles.ts
+++ b/packages/tsargp/lib/styles.ts
@@ -463,7 +463,7 @@ class ErrorMessage extends Error {
    * @param emitStyles True if styles should be emitted
    * @returns The message to be printed on a terminal
    */
-  wrap(width = process.stderr.columns ?? 0, emitStyles = !omitStyles(width)): string {
+  wrap(width = process?.stderr?.columns ?? 0, emitStyles = !omitStyles(width)): string {
     const result = new Array<string>();
     this.str.wrapToWidth(result, 0, width, emitStyles);
     if (emitStyles) {
@@ -490,7 +490,7 @@ class HelpMessage extends Array<TerminalString> {
    * @param emitStyles True if styles should be emitted
    * @returns The message to be printed on a terminal
    */
-  wrap(width = process.stdout.columns ?? 0, emitStyles = !omitStyles(width)): string {
+  wrap(width = process?.stdout?.columns ?? 0, emitStyles = !omitStyles(width)): string {
     const result = new Array<string>();
     let column = 0;
     for (const str of this) {
@@ -513,8 +513,8 @@ class HelpMessage extends Array<TerminalString> {
  */
 function omitStyles(width: number): boolean {
   return (
-    !process.env['FORCE_COLOR'] &&
-    (!width || !!process.env['NO_COLOR'] || process.env['TERM'] === 'dumb')
+    !process?.env['FORCE_COLOR'] &&
+    (!width || !!process?.env['NO_COLOR'] || process?.env['TERM'] === 'dumb')
   );
 }
 

--- a/packages/tsargp/test/parser.spec.ts
+++ b/packages/tsargp/test/parser.spec.ts
@@ -4,6 +4,10 @@ import { errorConfig as config } from './utils.spec';
 
 describe('ArgumentParser', () => {
   describe('parse', () => {
+    it('should handle empty command', () => {
+      expect(new ArgumentParser({}).validate().parse('')).toEqual({});
+    });
+
     it('should handle zero arguments', () => {
       expect(new ArgumentParser({}).validate().parse([])).toEqual({});
     });


### PR DESCRIPTION
A new field called `progName` was added to `ParseConfig`, that allows program authors to specify a custom program name to be used to update the process title.

The Parser page of the documentation was updated to reflect the above change, as well as add a new section to explain how the process title is updated by the parser.

> [!NOTE]
> The idea proposed in the related issue was not a good one to implement, since changes to the `process.title` have some restrictions imposed by the underlying operating system, as explained in the [Node.js documentation](https://nodejs.org/api/process.html#processtitle)

Closes #9 
