### PR TITLE
Issues/35

### DIFF
--- a/.changeset/sour-dolls-jump.md
+++ b/.changeset/sour-dolls-jump.md
@@ -1,0 +1,5 @@
+---
+'tsargp': patch
+---
+
+The data type of an option with `enums` was fixed. Now it will have a union base type, as expected.

--- a/packages/tsargp/examples/demo.options.ts
+++ b/packages/tsargp/examples/demo.options.ts
@@ -62,7 +62,7 @@ export default {
     ${style(tf.bold, tf.italic)}TrulySimple${style(tf.clear)}
 
     Report a bug:
-    ${style(tf.faint)}https://github.com/trulysimple/tsargp/issues${style(tf.clear)}`,
+    ${style(tf.faint)}https://github.com/trulysimple/tsargp/issues`,
   },
   /**
    * A version option that throws the package version.

--- a/packages/tsargp/examples/demo.ts
+++ b/packages/tsargp/examples/demo.ts
@@ -3,7 +3,7 @@ import { ArgumentParser } from 'tsargp';
 import options from './demo.options.js';
 
 /**
- * An interface for the option values. (To make sure that they abide by it.)
+ * An interface for the option values. (To make sure that they comply with it.)
  */
 interface Values {
   flag: boolean | undefined;

--- a/packages/tsargp/examples/demo.ts
+++ b/packages/tsargp/examples/demo.ts
@@ -2,8 +2,25 @@
 import { ArgumentParser } from 'tsargp';
 import options from './demo.options.js';
 
+/**
+ * An interface for the option values. (To make sure that they abide by it.)
+ */
+interface Values {
+  flag: boolean | undefined;
+  command: number | undefined;
+  boolean: boolean;
+  stringRegex: string;
+  numberRange: number;
+  stringEnum: 'one' | 'two' | undefined;
+  numberEnum: 1 | 2 | undefined;
+  stringsRegex: string[];
+  numbersRange: number[];
+  stringsEnum: Array<'one' | 'two'> | undefined;
+  numbersEnum: Array<1 | 2> | undefined;
+}
+
 try {
-  const values = await new ArgumentParser(options).parseAsync();
+  const values: Values = await new ArgumentParser(options).parseAsync();
   if (!values.command) {
     console.log(values);
   }

--- a/packages/tsargp/lib/formatter.ts
+++ b/packages/tsargp/lib/formatter.ts
@@ -398,7 +398,7 @@ class HelpFormatter {
       this.format[item](option, phrase, this.styles, descStyle, result);
     }
     if (result.strings.length > len) {
-      result.addBreaks(1).addSequence(style(tf.clear));
+      result.addSequence(style(tf.clear)).addBreaks(1); // add ending breaks after styles
     } else {
       result.strings.length = 1;
       result.strings[0] = '\n';

--- a/packages/tsargp/lib/options.ts
+++ b/packages/tsargp/lib/options.ts
@@ -746,7 +746,7 @@ type ParamDataType<T extends ParamOption, D, E> = T extends
  * @template T The option definition type
  * @template D The option value data type
  */
-type EnumsDataType<T extends ParamOption, D> = T extends { enums: Array<infer E> } ? E : D;
+type EnumsDataType<T extends ParamOption, D> = T extends { enums: ReadonlyArray<infer E> } ? E : D;
 
 /**
  * The data type of a (possibly) delimited array-valued option.

--- a/packages/tsargp/lib/parser.ts
+++ b/packages/tsargp/lib/parser.ts
@@ -664,7 +664,7 @@ function handleHelp(validator: OptionValidator, option: HelpOption): never {
     } else {
       heading.splitText(group).addClosing(':');
     }
-    return heading.addBreaks(2).addSequence(style(tf.clear));
+    return heading.addSequence(style(tf.clear)).addBreaks(2); // add ending breaks after styles
   }
   const help = new HelpMessage();
   if (option.usage) {

--- a/packages/tsargp/lib/styles.ts
+++ b/packages/tsargp/lib/styles.ts
@@ -410,6 +410,10 @@ class TerminalString {
         column = 0;
         continue;
       }
+      if (!column && indent) {
+        result.push(indent);
+        column = start;
+      }
       const len = this.lengths[i];
       if (!len) {
         if (emitStyles) {
@@ -420,10 +424,7 @@ class TerminalString {
       if (!emitStyles) {
         str = str.replace(regex.styles, '');
       }
-      if (!column) {
-        result.push(indent + str);
-        column = start + len;
-      } else if (column === start) {
+      if (column === start) {
         result.push(str);
         column += len;
       } else if (!width || column + 1 + len <= width) {

--- a/packages/tsargp/test/styles.spec.ts
+++ b/packages/tsargp/test/styles.spec.ts
@@ -83,6 +83,16 @@ describe('TerminalString', () => {
   });
 
   describe('splitText', () => {
+    it('should split text with emojis', () => {
+      const str = new TerminalString();
+      str.splitText(`⚠️ type script`);
+      expect(str).toHaveLength(12);
+      expect(str.strings).toHaveLength(3);
+      expect(str.strings[0]).toEqual('⚠️');
+      expect(str.strings[1]).toEqual('type');
+      expect(str.strings[2]).toEqual('script');
+    });
+
     it('should split text with style sequences', () => {
       const str = new TerminalString();
       str.splitText(`${style(tf.clear)}type script${style(tf.clear)}`);
@@ -237,6 +247,13 @@ describe('TerminalString', () => {
           .wrapToWidth(result, 0, 0, true);
         expect(result).toEqual(['abc' + style(tf.clear), style(tf.clear), ' def']);
       });
+
+      it('should preserve emojis', () => {
+        const str = new TerminalString();
+        const result = new Array<string>();
+        str.splitText('⚠️ abc').wrapToWidth(result, 0, 0, false);
+        expect(result).toEqual(['⚠️', ' abc']);
+      });
     });
 
     describe('when a width is provided', () => {
@@ -314,14 +331,14 @@ describe('TerminalString', () => {
         const str = new TerminalString(1);
         const result = new Array<string>();
         str.addBreaks(1).splitText('abc largest').wrapToWidth(result, 2, 15, false);
-        expect(result).toEqual(['\n', `${move(2, mv.cha)}abc`, ' largest']);
+        expect(result).toEqual(['\n', move(2, mv.cha), 'abc', ' largest']);
       });
 
       it('should wrap with a move sequence when the largest word fits the width (9)', () => {
         const str = new TerminalString(2);
         const result = new Array<string>();
         str.addBreaks(1).splitText('abc largest').wrapToWidth(result, 1, 15, false);
-        expect(result).toEqual(['\n', `${move(3, mv.cha)}abc`, ' largest']);
+        expect(result).toEqual(['\n', move(3, mv.cha), 'abc', ' largest']);
       });
 
       it('should omit styles', () => {
@@ -340,6 +357,13 @@ describe('TerminalString', () => {
           .splitText(`abc${style(tf.clear)} ${style(tf.clear)} def`)
           .wrapToWidth(result, 0, 10, true);
         expect(result).toEqual(['abc' + style(tf.clear), style(tf.clear), ' def']);
+      });
+
+      it('should preserve emojis', () => {
+        const str = new TerminalString();
+        const result = new Array<string>();
+        str.splitText('⚠️ abc').wrapToWidth(result, 0, 10, false);
+        expect(result).toEqual(['⚠️', ' abc']);
       });
     });
   });


### PR DESCRIPTION
The `EnumsDataType` was fixed to use a `ReadonlyArray` instead of a normal array.

Some improvements were made to the `TerminalString.wrapToWidth` method, so when `FORCE_COLOR` is set, it outputs text lines with better disposition of style sequences.

Closes #35 
