### PR TITLE
Issues/38

### DIFF
--- a/.changeset/chatty-ears-judge.md
+++ b/.changeset/chatty-ears-judge.md
@@ -1,0 +1,5 @@
+---
+'tsargp': patch
+---
+
+The datatype of a required option was fixed to be non-optional (i.e., it cannot be `undefined`).

--- a/packages/tsargp/lib/options.ts
+++ b/packages/tsargp/lib/options.ts
@@ -719,7 +719,9 @@ type DefaultDataType<T extends ValuedOption> =
     ? Writable<R>
     : T extends { default: infer D }
       ? Writable<D>
-      : undefined;
+      : T extends { required: true }
+        ? never
+        : undefined;
 
 /**
  * The data type of a non-niladic option.


### PR DESCRIPTION
The `DefaultDataType` was fixed to check for the `required` attribute.

Closes #38 
