### PR TITLE
Issues/24

### DIFF
--- a/.changeset/breezy-oranges-approve.md
+++ b/.changeset/breezy-oranges-approve.md
@@ -2,4 +2,4 @@
 'tsargp': minor
 ---
 
-Added a new `envVar` attribute to options that have a value, to read the value from an environment variable.
+Added a new `envVar` attribute to options that have a value, to read the value from an environment variable. Also, function and command options now have the ability to define `default` values.

--- a/.changeset/breezy-oranges-approve.md
+++ b/.changeset/breezy-oranges-approve.md
@@ -1,0 +1,5 @@
+---
+'tsargp': minor
+---
+
+Added a new `envVar` attribute to options that have a value, to read the value from an environment variable.

--- a/.changeset/yellow-spies-fix.md
+++ b/.changeset/yellow-spies-fix.md
@@ -1,0 +1,5 @@
+---
+'@trulysimple/tsargp-docs': patch
+---
+
+The documentation was updated to include the new `envVar` attribute, as well as to group attributes that are shared by valued options into a new section called "Value attributes".

--- a/packages/docs/pages/docs/library/options.mdx
+++ b/packages/docs/pages/docs/library/options.mdx
@@ -94,6 +94,48 @@ option. It has the following optional properties:
 - `param` - the style of the option paramater
 - `descr` - the style of the option description
 
+#### External reference
+
+The `link` attribute is the URL of an external resource or media, that is included in the help
+message if specified.
+
+### Value attributes
+
+All option types that may have a value share a set of attributes, which are described below.
+
+#### Required
+
+The `required` attribute indicates that the option is _always_ required, regardless of other
+options. Mutually exclusive with [default value](#default-value--callback).
+
+#### Default value | callback
+
+The `default` attribute, if present, specifies the default option value or a callback that returns
+the default value. This value is set as the option's value at the end of the parsing loop _if_ the
+option was specified neither on the command-line nor as an
+[environment variable](#environment-variable). Mutually exclusive with [required](#required).
+
+If the value is not known beforehand (e.g., if it depends on the values of other options), you may
+want to use a callback to inspect parsed values and determine the default value based on those
+values. This callback accepts one parameter:
+
+- `values` - the parsed values
+
+<Callout type="info">
+  If a callback is used, it will _not_ be displayed as the default value in the help message.
+</Callout>
+
+<Callout type="default">
+  In the case of [function options](#function-option) and [command options](#command-option), you
+  may specify any value as the default. If an object is used, you can add a `toString: () => string`
+  property which will be used to render the value in the help message, e.g.:
+  ```ts
+  toString() {
+    return JSON.stringify(this);
+  }
+  ```
+</Callout>
+
 #### Requirements
 
 The `requires` attribute, if present, specifies the option requirements, which can be either:
@@ -116,31 +158,14 @@ corresponding value. If an expression, then it is evaluated as follows:
   and `null{:ts}` values to signify required _absence_.
 </Callout>
 
-#### External reference
+#### Environment variable
 
-The `link` attribute is the URL of an external resource or media, that is included in the help
-message if specified.
+The `envVar` attribute, if present, specifies the name of an environment variable from which the
+option value will be read, in case the option is not specified on the command-line.
 
 ### Parameter attributes
 
 All non-niladic option types share a set of attributes, which are described below.
-
-#### Required
-
-The `required` attribute indicates that the option is _always_ required, independently of other
-options. Mutually exclusive with [default value](#default-value--callback).
-
-#### Default value | callback
-
-The `default` attribute, if present, specifies either the default option value or a callback that
-returns the default value. This value is set as the option's value at the end of the parsing loop
-_if_ the option was not specified on the command-line. Mutually exclusive with [required](#required).
-
-If the value is not known beforehand (e.g., if it depends on the values of other options), you may
-want to use a callback to inspect parsed values and determine the default value based on those
-values. This callback accepts one parameter:
-
-- `values` - the parsed values
 
 #### Example value
 

--- a/packages/docs/pages/docs/library/options.mdx
+++ b/packages/docs/pages/docs/library/options.mdx
@@ -161,7 +161,8 @@ corresponding value. If an expression, then it is evaluated as follows:
 #### Environment variable
 
 The `envVar` attribute, if present, specifies the name of an environment variable from which the
-option value will be read, in case the option is not specified on the command-line.
+option value will be read, in case the option is not specified on the command-line. Explicitly _not_
+available for [function options](#function-option) and [command options](#command-option).
 
 ### Parameter attributes
 
@@ -224,7 +225,7 @@ enclosed in a promise. Mutually exclusive with [separator](#separator) and
 
 The `enums` attribute, if present, specifies enumerated values that the option accepts as parameter.
 Any parameter that does not equal one of these values (after normalization) will cause an error to
-be thrown. Explicitly not available for the [boolean option](#boolean-option). Mutually exclusive
+be thrown. Explicitly _not_ available for the [boolean option](#boolean-option). Mutually exclusive
 with [regular expression](#regular-expression) and [numeric range](#numeric-range).
 
 ### String attributes

--- a/packages/docs/pages/docs/library/parser.mdx
+++ b/packages/docs/pages/docs/library/parser.mdx
@@ -15,10 +15,14 @@ The result of argument parsing is an object that contains the option values corr
 option definitions given in the parser constructor. There are two main ways to get the values, as
 explained below.
 
+<Callout type="info">
+  The initial value of any valued option is `undefined{:ts}`.
+</Callout>
+
 ### Using a newly-created object
 
-This is the easiest, most common method: you just call `parse` and use its result. This method
-accepts two optional parameters:
+This is the easiest, most common method: you just call `parse` and use the returned option values.
+This method accepts two optional parameters:
 
 - `command` - the raw command line (`string{:ts}`) or the command-line arguments (`string[]{:ts}`)
 - `config` - the [parse configuration](#parse-configuration)
@@ -44,9 +48,9 @@ parameters as the previous one, except for an additional (first) parameter:
 
 - `values` - the option values to parse into
 
-Existing initial values are preserved until they get overriden by values passed in the command-line.
-When using TypeScript, this parameter will be type-checked at compile-time against the expected type
-of the option values for a given set of option definitions.
+Existing values are preserved until they get overriden by values passed either in the command-line
+or in environment variables. When using TypeScript, this parameter will be type-checked at compile
+time against the expected type of the option values for a given set of option definitions.
 
 <Callout type="default">
   You may want to use IntelliSense to peak at the resulting type of the `parse` method (or declare a

--- a/packages/tsargp/lib/formatter.ts
+++ b/packages/tsargp/lib/formatter.ts
@@ -1,15 +1,7 @@
 //--------------------------------------------------------------------------------------------------
 // Imports and Exports
 //--------------------------------------------------------------------------------------------------
-import type {
-  Option,
-  Options,
-  Requires,
-  ValuedOption,
-  RequiresVal,
-  ArrayOption,
-  ParamOption,
-} from './options';
+import type { Option, Options, Requires, ValuedOption, RequiresVal, ArrayOption } from './options';
 import type { Style } from './styles';
 import type { Concrete, ConcreteStyles, OptionValidator } from './validator';
 
@@ -488,7 +480,7 @@ function getNameWidths(options: Options): Array<number> {
  */
 function formatValue(
   option: ValuedOption,
-  value: ParamOption['example'],
+  value: unknown,
   result: TerminalString,
   styles: ConcreteStyles,
   style: Style,
@@ -505,7 +497,7 @@ function formatValue(
       return formatFunctions.s(value as string, styles, style, result);
     case 'number':
       return formatFunctions.n(value as number, styles, style, result);
-    case 'strings': {
+    case 'strings':
       return formatArray(
         option,
         value as ReadonlyArray<string>,
@@ -515,8 +507,7 @@ function formatValue(
         style,
         inDesc,
       );
-    }
-    case 'numbers': {
+    case 'numbers':
       return formatArray(
         option,
         value as ReadonlyArray<number>,
@@ -526,11 +517,8 @@ function formatValue(
         style,
         inDesc,
       );
-    }
-    default: {
-      const _exhaustiveCheck: never = option;
-      return _exhaustiveCheck;
-    }
+    default:
+      formatFunctions.p(value, styles, style, result);
   }
 }
 

--- a/packages/tsargp/lib/formatter.ts
+++ b/packages/tsargp/lib/formatter.ts
@@ -421,7 +421,7 @@ class HelpFormatter {
     style: Style,
     result: TerminalString,
   ) {
-    if (option.requires) {
+    if ('requires' in option && option.requires) {
       const requires = option.requires;
       result.splitText(phrase, () => {
         formatRequirements(this.options, requires, styles, style, result);

--- a/packages/tsargp/lib/options.ts
+++ b/packages/tsargp/lib/options.ts
@@ -50,6 +50,7 @@ export type {
   WithRegex,
   WithParam,
   WithValue,
+  WithEnvVar,
   WithParamName,
   WithParse,
   WithParseDelimited,
@@ -539,6 +540,12 @@ type WithValue<T> = (WithDefault<T> | WithRequired) & {
    * The option requirements.
    */
   readonly requires?: Requires;
+};
+
+/**
+ * Defines attributes common to all options that accept environment variables.
+ */
+type WithEnvVar = {
   /**
    * The name of an environment variable to read from, if the option is not specified in the
    * command-line.
@@ -551,6 +558,7 @@ type WithValue<T> = (WithDefault<T> | WithRequired) & {
  */
 type BooleanOption = WithType<'boolean'> &
   WithParam &
+  WithEnvVar &
   WithValue<boolean> &
   (WithExample<boolean> | WithParamName) &
   WithParse<boolean>;
@@ -560,6 +568,7 @@ type BooleanOption = WithType<'boolean'> &
  */
 type StringOption = WithType<'string'> &
   WithParam &
+  WithEnvVar &
   WithValue<string> &
   (WithExample<string> | WithParamName) &
   WithString &
@@ -570,6 +579,7 @@ type StringOption = WithType<'string'> &
  */
 type NumberOption = WithType<'number'> &
   WithParam &
+  WithEnvVar &
   WithValue<number> &
   (WithExample<number> | WithParamName) &
   WithNumber &
@@ -580,6 +590,7 @@ type NumberOption = WithType<'number'> &
  */
 type StringsOption = WithType<'strings'> &
   WithParam &
+  WithEnvVar &
   WithValue<ReadonlyArray<string>> &
   (WithExample<ReadonlyArray<string>> | WithParamName) &
   WithString &
@@ -591,6 +602,7 @@ type StringsOption = WithType<'strings'> &
  */
 type NumbersOption = WithType<'numbers'> &
   WithParam &
+  WithEnvVar &
   WithValue<ReadonlyArray<number>> &
   (WithExample<ReadonlyArray<number>> | WithParamName) &
   WithNumber &
@@ -601,6 +613,7 @@ type NumbersOption = WithType<'numbers'> &
  * An option that has a boolean value and is enabled if specified (or disabled if negated).
  */
 type FlagOption = WithType<'flag'> &
+  WithEnvVar &
   WithValue<boolean> & {
     /**
      * The names used for negation (e.g., '--no-flag').

--- a/packages/tsargp/lib/options.ts
+++ b/packages/tsargp/lib/options.ts
@@ -44,12 +44,12 @@ export type {
   WithDefault,
   WithDelimited,
   WithExample,
-  WithNegation,
   WithNumber,
   WithEnums,
   WithRange,
   WithRegex,
   WithParam,
+  WithEnvVar,
   WithParamName,
   WithParse,
   WithParseDelimited,
@@ -536,21 +536,27 @@ type WithNumber = (WithEnums<number> | WithRange) & {
 };
 
 /**
- * Defines attributes for a flag option with negation.
+ * Defines attributes common to all options that may have environment variables.
  */
-type WithNegation = {
+type WithEnvVar = {
   /**
-   * The names used for negation (e.g., '--no-flag').
+   * The name of an environment variable to read from, if the option is not specified in the
+   * command-line.
    */
-  readonly negationNames?: ReadonlyArray<string>;
+  readonly envVar?: string;
 };
+
+/**
+ * Defines attributes common to all options that have values.
+ */
+type WithValue<T> = (WithDefault<T> | WithRequired) & WithEnvVar;
 
 /**
  * An option that has a boolean value (accepts a single boolean parameter).
  */
 type BooleanOption = WithType<'boolean'> &
   WithParam &
-  (WithDefault<boolean> | WithRequired) &
+  WithValue<boolean> &
   (WithExample<boolean> | WithParamName) &
   WithParse<boolean>;
 
@@ -559,7 +565,7 @@ type BooleanOption = WithType<'boolean'> &
  */
 type StringOption = WithType<'string'> &
   WithParam &
-  (WithDefault<string> | WithRequired) &
+  WithValue<string> &
   (WithExample<string> | WithParamName) &
   WithString &
   WithParse<string>;
@@ -569,7 +575,7 @@ type StringOption = WithType<'string'> &
  */
 type NumberOption = WithType<'number'> &
   WithParam &
-  (WithDefault<number> | WithRequired) &
+  WithValue<number> &
   (WithExample<number> | WithParamName) &
   WithNumber &
   WithParse<number>;
@@ -579,7 +585,7 @@ type NumberOption = WithType<'number'> &
  */
 type StringsOption = WithType<'strings'> &
   WithParam &
-  (WithDefault<ReadonlyArray<string>> | WithRequired) &
+  WithValue<ReadonlyArray<string>> &
   (WithExample<ReadonlyArray<string>> | WithParamName) &
   WithString &
   WithArray &
@@ -590,7 +596,7 @@ type StringsOption = WithType<'strings'> &
  */
 type NumbersOption = WithType<'numbers'> &
   WithParam &
-  (WithDefault<ReadonlyArray<number>> | WithRequired) &
+  WithValue<ReadonlyArray<number>> &
   (WithExample<ReadonlyArray<number>> | WithParamName) &
   WithNumber &
   WithArray &
@@ -599,7 +605,13 @@ type NumbersOption = WithType<'numbers'> &
 /**
  * An option that has a boolean value and is enabled if specified (or disabled if negated).
  */
-type FlagOption = WithType<'flag'> & (WithDefault<boolean> | WithRequired) & WithNegation;
+type FlagOption = WithType<'flag'> &
+  WithValue<boolean> & {
+    /**
+     * The names used for negation (e.g., '--no-flag').
+     */
+    readonly negationNames?: ReadonlyArray<string>;
+  };
 
 /**
  * An option that executes a callback function.

--- a/packages/tsargp/lib/options.ts
+++ b/packages/tsargp/lib/options.ts
@@ -50,6 +50,7 @@ export type {
   WithRegex,
   WithParam,
   WithEnvVar,
+  WithRequires,
   WithParamName,
   WithParse,
   WithParseDelimited,
@@ -265,10 +266,6 @@ type WithType<T extends string> = {
    * The option deprecation reason. It may contain inline styles.
    */
   readonly deprecated?: string;
-  /**
-   * The option requirements.
-   */
-  readonly requires?: Requires;
   /**
    * A reference to an external resource.
    */
@@ -547,9 +544,19 @@ type WithEnvVar = {
 };
 
 /**
+ * Defines attributes common to all options that may have requirements.
+ */
+type WithRequires = {
+  /**
+   * The option requirements.
+   */
+  readonly requires?: Requires;
+};
+
+/**
  * Defines attributes common to all options that have values.
  */
-type WithValue<T> = (WithDefault<T> | WithRequired) & WithEnvVar;
+type WithValue<T> = (WithDefault<T> | WithRequired) & WithEnvVar & WithRequires;
 
 /**
  * An option that has a boolean value (accepts a single boolean parameter).
@@ -616,32 +623,34 @@ type FlagOption = WithType<'flag'> &
 /**
  * An option that executes a callback function.
  */
-type FunctionOption = WithType<'function'> & {
-  /**
-   * The callback function. If asynchronous, you should call `ArgumentParser.parseAsync` and await
-   * its result.
-   */
-  readonly exec: ExecuteCallback;
-  /**
-   * True to break the parsing loop.
-   */
-  readonly break?: true;
-};
+type FunctionOption = WithType<'function'> &
+  WithRequires & {
+    /**
+     * The callback function. If asynchronous, you should call `ArgumentParser.parseAsync` and await
+     * its result.
+     */
+    readonly exec: ExecuteCallback;
+    /**
+     * True to break the parsing loop.
+     */
+    readonly break?: true;
+  };
 
 /**
  * An option that executes a command.
  */
-type CommandOption = WithType<'command'> & {
-  /**
-   * The callback function. If asynchronous, you should call `ArgumentParser.parseAsync` and await
-   * its result.
-   */
-  readonly cmd: CommandCallback;
-  /**
-   * The command options or a callback that returns the options (for use with recursive commands).
-   */
-  readonly options: Options | (() => Options);
-};
+type CommandOption = WithType<'command'> &
+  WithRequires & {
+    /**
+     * The callback function. If asynchronous, you should call `ArgumentParser.parseAsync` and await
+     * its result.
+     */
+    readonly cmd: CommandCallback;
+    /**
+     * The command options or a callback that returns the options (for use with recursive commands).
+     */
+    readonly options: Options | (() => Options);
+  };
 
 /**
  * An option that throws a help message.

--- a/packages/tsargp/lib/parser.ts
+++ b/packages/tsargp/lib/parser.ts
@@ -462,9 +462,9 @@ class ParserLoop {
         if ('envVar' in option && option.envVar) {
           const value = process?.env[option.envVar];
           if (value) {
-            if (option.type === 'flag') {
-              this.values[key] = isTrue(value);
-            } else if (!isNiladic(option)) {
+            if (isNiladic(option)) {
+              this.values[key] = option.type === 'flag' ? isTrue(value) : value;
+            } else {
               if (isArray(option)) {
                 resetValue(this.values, key, option);
               }

--- a/packages/tsargp/lib/parser.ts
+++ b/packages/tsargp/lib/parser.ts
@@ -30,7 +30,15 @@ import type {
 
 import { tf, ErrorItem } from './enums';
 import { HelpFormatter } from './formatter';
-import { RequiresAll, RequiresNot, RequiresOne, isArray, isVariadic, isNiladic } from './options';
+import {
+  RequiresAll,
+  RequiresNot,
+  RequiresOne,
+  isArray,
+  isVariadic,
+  isNiladic,
+  isValued,
+} from './options';
 import { ErrorMessage, HelpMessage, TerminalString, style } from './styles';
 import { OptionValidator, defaultConfig, formatFunctions } from './validator';
 import { assert, checkRequiredArray, gestaltSimilarity, getArgs, isTrue } from './utils';
@@ -214,7 +222,7 @@ class ParserLoop {
     for (const key in validator.options) {
       if (!(key in values)) {
         const option = validator.options[key];
-        if (option.type !== 'help' && option.type !== 'version') {
+        if (isValued(option)) {
           values[key] = undefined;
         }
       }
@@ -456,7 +464,7 @@ class ParserLoop {
           if (value) {
             if (option.type === 'flag') {
               this.values[key] = isTrue(value);
-            } else {
+            } else if (!isNiladic(option)) {
               if (isArray(option)) {
                 resetValue(this.values, key, option);
               }

--- a/packages/tsargp/lib/parser.ts
+++ b/packages/tsargp/lib/parser.ts
@@ -462,8 +462,8 @@ class ParserLoop {
         if ('envVar' in option && option.envVar) {
           const value = process?.env[option.envVar];
           if (value) {
-            if (isNiladic(option)) {
-              this.values[key] = option.type === 'flag' ? isTrue(value) : value;
+            if (option.type === 'flag') {
+              this.values[key] = isTrue(value);
             } else {
               if (isArray(option)) {
                 resetValue(this.values, key, option);

--- a/packages/tsargp/lib/parser.ts
+++ b/packages/tsargp/lib/parser.ts
@@ -400,7 +400,6 @@ class ParserLoop {
     if (this.completing) {
       return false; // skip special options during completion
     }
-    this.checkRequired();
     if (option.type === 'help') {
       handleHelp(this.validator, option);
     } else if (option.version) {
@@ -461,13 +460,12 @@ class ParserLoop {
               if (isArray(option)) {
                 resetValue(this.values, key, option);
               }
-              parseValue(this.validator, this.values, key, option, key, value);
+              parseValue(this.validator, this.values, key, option, option.envVar, value);
             }
             continue;
           }
         }
         if ('required' in option && option.required) {
-          const option = this.validator.options[key];
           const name = option.preferredName ?? '';
           throw this.validator.error(ErrorItem.missingRequiredOption, { o: name });
         }
@@ -478,7 +476,7 @@ class ParserLoop {
     }
     for (const key of this.specifiedKeys) {
       const option = this.validator.options[key];
-      if (option.requires) {
+      if ('requires' in option && option.requires) {
         const error = new TerminalString();
         if (!this.checkRequires(option.requires, error)) {
           const name = option.preferredName ?? '';

--- a/packages/tsargp/lib/utils.ts
+++ b/packages/tsargp/lib/utils.ts
@@ -1,7 +1,7 @@
 //--------------------------------------------------------------------------------------------------
 // Imports and Exports
 //--------------------------------------------------------------------------------------------------
-export { assert, getArgs, checkRequiredArray, gestaltSimilarity, splitPhrase };
+export { assert, getArgs, checkRequiredArray, gestaltSimilarity, splitPhrase, isTrue };
 
 //--------------------------------------------------------------------------------------------------
 // Functions
@@ -171,3 +171,12 @@ function splitPhrase(phrase: string): Array<string> {
  * @param _condition The condition
  */
 function assert(_condition: unknown): asserts _condition {}
+
+/**
+ * Converts a string to boolean.
+ * @param str The string value
+ * @returns True if the string evaluates to true
+ */
+function isTrue(str: string): boolean {
+  return !(Number(str) == 0 || str.trim().match(/^\s*false\s*$/i));
+}

--- a/packages/tsargp/lib/validator.ts
+++ b/packages/tsargp/lib/validator.ts
@@ -310,7 +310,7 @@ class OptionValidator {
         this.validateValue(key, option, option.example);
       }
       // no need to verify flag option default value
-      if (option.requires) {
+      if ('requires' in option && option.requires) {
         this.validateRequirements(key, option.requires);
       }
       if (option.type === 'version' && option.version === '') {

--- a/packages/tsargp/lib/validator.ts
+++ b/packages/tsargp/lib/validator.ts
@@ -227,7 +227,6 @@ type Concrete<T> = Exclude<
  */
 class OptionValidator {
   readonly names = new Map<string, string>();
-  readonly required = new Array<string>();
   readonly positional: Positional | undefined;
 
   /**
@@ -249,9 +248,6 @@ class OptionValidator {
         }
         const marker = typeof option.positional === 'string' ? option.positional : undefined;
         this.positional = { key, name: option.preferredName ?? '', option, marker };
-      }
-      if ('required' in option && option.required) {
-        this.required.push(key);
       }
     }
   }

--- a/packages/tsargp/test/formatter.spec.ts
+++ b/packages/tsargp/test/formatter.spec.ts
@@ -23,6 +23,36 @@ describe('HelpFormatter', () => {
         const message = new HelpFormatter(new OptionValidator(options, config)).formatHelp();
         expect(message.wrap(0)).toEqual('  -f, --function    A function option\n');
       });
+
+      it('should handle a function option with a default value', () => {
+        const options = {
+          function: {
+            type: 'function',
+            names: ['-f', '--function'],
+            desc: 'A function option.',
+            exec: () => {},
+            default: true,
+          },
+        } as const satisfies Options;
+        const message = new HelpFormatter(new OptionValidator(options, config)).formatHelp();
+        expect(message.wrap(0)).toEqual(
+          '  -f, --function    A function option. Defaults to <true>.\n',
+        );
+      });
+
+      it('should handle a function option with a default callback', () => {
+        const options = {
+          function: {
+            type: 'function',
+            names: ['-f', '--function'],
+            desc: 'A function option',
+            exec: () => {},
+            default: () => true,
+          },
+        } as const satisfies Options;
+        const message = new HelpFormatter(new OptionValidator(options, config)).formatHelp();
+        expect(message.wrap(0)).toEqual('  -f, --function    A function option\n');
+      });
     });
 
     describe('flag', () => {
@@ -312,6 +342,32 @@ describe('HelpFormatter', () => {
         expect(message.wrap(0)).toEqual(
           '  -f, --flag    A flag option. Can be negated with -no-f or --no-flag.\n',
         );
+      });
+
+      it('should handle a flag option with a default value', () => {
+        const options = {
+          flag: {
+            type: 'flag',
+            names: ['-f', '--flag'],
+            desc: 'A flag option.',
+            default: true,
+          },
+        } as const satisfies Options;
+        const message = new HelpFormatter(new OptionValidator(options, config)).formatHelp();
+        expect(message.wrap(0)).toEqual('  -f, --flag    A flag option. Defaults to true.\n');
+      });
+
+      it('should handle a flag option with a default callback', () => {
+        const options = {
+          flag: {
+            type: 'flag',
+            names: ['-f', '--flag'],
+            desc: 'A flag option',
+            default: () => true,
+          },
+        } as const satisfies Options;
+        const message = new HelpFormatter(new OptionValidator(options, config)).formatHelp();
+        expect(message.wrap(0)).toEqual('  -f, --flag    A flag option\n');
       });
     });
 

--- a/packages/tsargp/test/parser.spec.ts
+++ b/packages/tsargp/test/parser.spec.ts
@@ -539,6 +539,63 @@ describe('ArgumentParser', () => {
         const parser = new ArgumentParser(options, config);
         expect(parser.parse(['-f2', '-f1'])).toEqual({ function: undefined, flag: true });
       });
+
+      it('should handle a function option with an environment variable', () => {
+        const options = {
+          function: {
+            type: 'function',
+            names: ['-f'],
+            envVar: 'FUNCTION',
+            exec: vi.fn(),
+          },
+        } as const satisfies Options;
+        const parser = new ArgumentParser(options, config);
+        process.env['FUNCTION'] = 'abc';
+        expect(parser.parse([])).toEqual({ function: 'abc' });
+        expect(options.function.exec).not.toHaveBeenCalled();
+      });
+
+      it('should handle a function option with a default value', () => {
+        const options = {
+          function: {
+            type: 'function',
+            names: ['-f'],
+            default: false,
+            exec: vi.fn(),
+          },
+        } as const satisfies Options;
+        const parser = new ArgumentParser(options, config);
+        expect(parser.parse([])).toEqual({ function: false });
+        expect(options.function.exec).not.toHaveBeenCalled();
+      });
+
+      it('should handle a function option with a default callback', () => {
+        const options = {
+          function: {
+            type: 'function',
+            names: ['-f'],
+            default: () => false,
+            exec: vi.fn(),
+          },
+        } as const satisfies Options;
+        const parser = new ArgumentParser(options, config);
+        expect(parser.parse([])).toEqual({ function: false });
+        expect(options.function.exec).not.toHaveBeenCalled();
+      });
+
+      it('should handle a function option with an async default callback', () => {
+        const options = {
+          function: {
+            type: 'function',
+            names: ['-f'],
+            default: async () => false,
+            exec: vi.fn(),
+          },
+        } as const satisfies Options;
+        const parser = new ArgumentParser(options, config);
+        expect(parser.parse([])).toEqual({ function: expect.toResolve(false) });
+        expect(options.function.exec).not.toHaveBeenCalled();
+      });
     });
 
     describe('command', () => {
@@ -675,6 +732,67 @@ describe('ArgumentParser', () => {
         expect(options.command.options).toHaveBeenCalled();
         const cmdValues = expect.objectContaining({ flag: true });
         expect(options.command.cmd).toHaveBeenCalledWith(expect.anything(), cmdValues);
+      });
+
+      it('should handle a command option with an environment variable', () => {
+        const options = {
+          command: {
+            type: 'command',
+            names: ['-c'],
+            envVar: 'COMMAND',
+            options: {},
+            cmd: vi.fn(),
+          },
+        } as const satisfies Options;
+        const parser = new ArgumentParser(options, config);
+        process.env['COMMAND'] = 'abc';
+        expect(parser.parse([])).toEqual({ command: 'abc' });
+        expect(options.command.cmd).not.toHaveBeenCalled();
+      });
+
+      it('should handle a command option with a default value', () => {
+        const options = {
+          command: {
+            type: 'command',
+            names: ['-c'],
+            default: false,
+            options: {},
+            cmd: vi.fn(),
+          },
+        } as const satisfies Options;
+        const parser = new ArgumentParser(options, config);
+        expect(parser.parse([])).toEqual({ command: false });
+        expect(options.command.cmd).not.toHaveBeenCalled();
+      });
+
+      it('should handle a command option with a default callback', () => {
+        const options = {
+          command: {
+            type: 'command',
+            names: ['-c'],
+            default: () => false,
+            options: {},
+            cmd: vi.fn(),
+          },
+        } as const satisfies Options;
+        const parser = new ArgumentParser(options, config);
+        expect(parser.parse([])).toEqual({ command: false });
+        expect(options.command.cmd).not.toHaveBeenCalled();
+      });
+
+      it('should handle a command option with an async default callback', () => {
+        const options = {
+          command: {
+            type: 'command',
+            names: ['-c'],
+            default: async () => false,
+            options: {},
+            cmd: vi.fn(),
+          },
+        } as const satisfies Options;
+        const parser = new ArgumentParser(options, config);
+        expect(parser.parse([])).toEqual({ command: expect.toResolve(false) });
+        expect(options.command.cmd).not.toHaveBeenCalled();
       });
     });
 

--- a/packages/tsargp/test/parser.spec.ts
+++ b/packages/tsargp/test/parser.spec.ts
@@ -540,21 +540,6 @@ describe('ArgumentParser', () => {
         expect(parser.parse(['-f2', '-f1'])).toEqual({ function: undefined, flag: true });
       });
 
-      it('should handle a function option with an environment variable', () => {
-        const options = {
-          function: {
-            type: 'function',
-            names: ['-f'],
-            envVar: 'FUNCTION',
-            exec: vi.fn(),
-          },
-        } as const satisfies Options;
-        const parser = new ArgumentParser(options, config);
-        process.env['FUNCTION'] = 'abc';
-        expect(parser.parse([])).toEqual({ function: 'abc' });
-        expect(options.function.exec).not.toHaveBeenCalled();
-      });
-
       it('should handle a function option with a default value', () => {
         const options = {
           function: {
@@ -732,22 +717,6 @@ describe('ArgumentParser', () => {
         expect(options.command.options).toHaveBeenCalled();
         const cmdValues = expect.objectContaining({ flag: true });
         expect(options.command.cmd).toHaveBeenCalledWith(expect.anything(), cmdValues);
-      });
-
-      it('should handle a command option with an environment variable', () => {
-        const options = {
-          command: {
-            type: 'command',
-            names: ['-c'],
-            envVar: 'COMMAND',
-            options: {},
-            cmd: vi.fn(),
-          },
-        } as const satisfies Options;
-        const parser = new ArgumentParser(options, config);
-        process.env['COMMAND'] = 'abc';
-        expect(parser.parse([])).toEqual({ command: 'abc' });
-        expect(options.command.cmd).not.toHaveBeenCalled();
       });
 
       it('should handle a command option with a default value', () => {

--- a/packages/tsargp/test/utils.spec.ts
+++ b/packages/tsargp/test/utils.spec.ts
@@ -1,7 +1,7 @@
 import type { AsyncExpectationResult, MatcherState } from '@vitest/expect';
 import { describe, expect, it } from 'vitest';
 import { type ConcreteError, defaultConfig } from '../lib';
-import { checkRequiredArray, gestaltSimilarity, getArgs, splitPhrase } from '../lib/utils';
+import { checkRequiredArray, gestaltSimilarity, getArgs, splitPhrase, isTrue } from '../lib/utils';
 
 interface CustomMatchers<R = unknown> {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -185,5 +185,28 @@ describe('splitPhrase', () => {
 
   it('should handle a phrase with groups with empty alternatives', () => {
     expect(splitPhrase('(|) is fun')).toEqual([' is fun', ' is fun']);
+  });
+});
+
+describe('isTrue', () => {
+  it('should return false on zero', () => {
+    expect(isTrue('')).toBeFalsy();
+    expect(isTrue('0')).toBeFalsy();
+    expect(isTrue(' 0 ')).toBeFalsy();
+    expect(isTrue('0.0')).toBeFalsy();
+  });
+
+  it('should return false on false', () => {
+    expect(isTrue('false')).toBeFalsy();
+    expect(isTrue(' false ')).toBeFalsy();
+    expect(isTrue('FalsE')).toBeFalsy();
+    expect(isTrue(' FalsE ')).toBeFalsy();
+  });
+
+  it('should return true on any other string', () => {
+    expect(isTrue('1')).toBeTruthy();
+    expect(isTrue(' 1 ')).toBeTruthy();
+    expect(isTrue('a')).toBeTruthy();
+    expect(isTrue(' A ')).toBeTruthy();
   });
 });


### PR DESCRIPTION
A new `envVar` attribute was added to options that have a value, to read the value from an environment variable when it is not specified on the command-line.

The `requires` attribute was removed from special options, since these options do not have values (they only throw a message, so there's no point in checking their requirements).

The `default` attribute was added to executing options, with an `unknown` value type. This allows program authors to define any value as the default for function and command options.

A new section called "Value attributes" was added to the Options page. It includes the atrtibutes common to all valued option types, but with one caveat: the `envVar` attribute is not available for executing options.

Closes #24 
