### PR TITLE
Issues/44

### DIFF
--- a/.changeset/young-plants-push.md
+++ b/.changeset/young-plants-push.md
@@ -1,0 +1,5 @@
+---
+'tsargp': minor
+---
+
+The package was refactored to remove unneeded exports, which reduced the footprint of the minified module.

--- a/packages/tsargp/lib/enums.ts
+++ b/packages/tsargp/lib/enums.ts
@@ -4,13 +4,7 @@
 export {
   ErrorItem,
   HelpItem,
-  MoveCommand as mv,
-  MoveToCommand as mt,
-  EditCommand as ed,
-  ScrollCommand as sc,
-  StyleCommand as st,
-  MarginCommand as mg,
-  MiscCommand as ms,
+  ControlSequence as cs,
   TypeFace as tf,
   Foreground as fg,
   Background as bg,
@@ -228,9 +222,10 @@ const enum HelpItem {
 }
 
 /**
- * A single-parameter cursor movement command.
+ * A control sequence introducer command.
+ * @see https://xtermjs.org/docs/api/vtfeatures/#csi
  */
-const enum MoveCommand {
+const enum ControlSequence {
   /**
    * Cursor Up. Move cursor Ps times up (default=1).
    */
@@ -275,22 +270,6 @@ const enum MoveCommand {
    * Vertical Position Relative. Move cursor Ps times down (default=1).
    */
   vpr = 'e',
-}
-
-/**
- * A two-parameter cursor movement command.
- */
-const enum MoveToCommand {
-  /**
-   * Cursor Position. Set cursor to position [Ps, Ps] (default = [1, 1]).
-   */
-  cup = 'H',
-}
-
-/**
- * A single-parameter edit command.
- */
-const enum EditCommand {
   /**
    * Erase In Display. Erase various parts of the viewport.
    */
@@ -335,12 +314,6 @@ const enum EditCommand {
    * Delete Columns. Delete Ps columns at cursor position.
    */
   dcl = "'~",
-}
-
-/**
- * A single-parameter scroll command.
- */
-const enum ScrollCommand {
   /**
    * Scroll Left. Scroll viewport Ps times to the left.
    */
@@ -357,33 +330,27 @@ const enum ScrollCommand {
    * Scroll Down. Scroll Ps lines down (default=1).
    */
   sd = 'T',
-}
-
-/**
- * A multi-parameter text style command.
- */
-const enum StyleCommand {
   /**
-   * Select Graphic Rendition. Set/Reset various text attributes.
+   * Device Status Report. Request cursor position (CPR) with Ps = 6.
    */
-  sgr = 'm',
-}
-
-/**
- * A two-parameter margin command.
- */
-const enum MarginCommand {
+  dsr = 'n',
+  /**
+   * Set Cursor Style.
+   */
+  scs = 'SPq',
+  /**
+   * Cursor Position. Set cursor to position [Ps, Ps] (default = [1, 1]).
+   */
+  cup = 'H',
   /**
    * Set Top and Bottom Margins. Set top and bottom margins of the viewport [top;bottom] (default =
    * viewport size).
    */
   tbm = 'r',
-}
-
-/**
- * A miscellaneous command.
- */
-const enum MiscCommand {
+  /**
+   * Select Graphic Rendition. Set/Reset various text attributes.
+   */
+  sgr = 'm',
   /**
    * Set Mode. Set various terminal modes.
    */
@@ -393,17 +360,9 @@ const enum MiscCommand {
    */
   rm = 'l',
   /**
-   * Device Status Report. Request cursor position (CPR) with Ps = 6.
-   */
-  dsr = 'n',
-  /**
    * Soft Terminal Reset. Reset several terminal attributes to initial state.
    */
   str = '!p',
-  /**
-   * Set Cursor Style.
-   */
-  scs = 'SPq',
   /**
    * Save Cursor. Save cursor position, charmap and text attributes.
    */

--- a/packages/tsargp/lib/enums.ts
+++ b/packages/tsargp/lib/enums.ts
@@ -1,9 +1,7 @@
 //--------------------------------------------------------------------------------------------------
-// Imports and Exports
+// Exports
 //--------------------------------------------------------------------------------------------------
 export {
-  ErrorItem,
-  HelpItem,
   ControlSequence as cs,
   TypeFace as tf,
   Foreground as fg,
@@ -18,7 +16,7 @@ export {
  * The kind of items that can be thrown as error messages.
  */
 // Internal note: this needs to be defined before `defaultConfig`, otherwise bun chokes.
-const enum ErrorItem {
+export const enum ErrorItem {
   /**
    * Raised by the parser when an option parameter fails to be parsed.
    */
@@ -142,7 +140,7 @@ const enum ErrorItem {
 /**
  * The kind of items that can be shown in the option description.
  */
-const enum HelpItem {
+export const enum HelpItem {
   /**
    * The option synopsis.
    */
@@ -271,6 +269,10 @@ const enum ControlSequence {
    */
   vpr = 'e',
   /**
+   * Cursor Position. Set cursor to position [Ps, Ps] (default = [1, 1]).
+   */
+  cup = 'H',
+  /**
    * Erase In Display. Erase various parts of the viewport.
    */
   ed = 'J',
@@ -331,26 +333,14 @@ const enum ControlSequence {
    */
   sd = 'T',
   /**
-   * Device Status Report. Request cursor position (CPR) with Ps = 6.
+   * Select Graphic Rendition. Set/Reset various text attributes.
    */
-  dsr = 'n',
-  /**
-   * Set Cursor Style.
-   */
-  scs = 'SPq',
-  /**
-   * Cursor Position. Set cursor to position [Ps, Ps] (default = [1, 1]).
-   */
-  cup = 'H',
+  sgr = 'm',
   /**
    * Set Top and Bottom Margins. Set top and bottom margins of the viewport [top;bottom] (default =
    * viewport size).
    */
   tbm = 'r',
-  /**
-   * Select Graphic Rendition. Set/Reset various text attributes.
-   */
-  sgr = 'm',
   /**
    * Set Mode. Set various terminal modes.
    */
@@ -360,9 +350,17 @@ const enum ControlSequence {
    */
   rm = 'l',
   /**
+   * Device Status Report. Request cursor position (CPR) with Ps = 6.
+   */
+  dsr = 'n',
+  /**
    * Soft Terminal Reset. Reset several terminal attributes to initial state.
    */
   str = '!p',
+  /**
+   * Set Cursor Style.
+   */
+  scs = 'SPq',
   /**
    * Save Cursor. Save cursor position, charmap and text attributes.
    */

--- a/packages/tsargp/lib/formatter.ts
+++ b/packages/tsargp/lib/formatter.ts
@@ -3,7 +3,8 @@
 //--------------------------------------------------------------------------------------------------
 import type { Option, Options, Requires, ValuedOption, RequiresVal, ArrayOption } from './options';
 import type { Style } from './styles';
-import type { Concrete, ConcreteStyles, OptionValidator } from './validator';
+import type { Concrete } from './utils';
+import type { ConcreteStyles, OptionValidator } from './validator';
 
 import { tf, HelpItem } from './enums';
 import { RequiresAll, RequiresNot, RequiresOne, isArray, isVariadic, isNiladic } from './options';

--- a/packages/tsargp/lib/formatter.ts
+++ b/packages/tsargp/lib/formatter.ts
@@ -1,5 +1,5 @@
 //--------------------------------------------------------------------------------------------------
-// Imports and Exports
+// Imports
 //--------------------------------------------------------------------------------------------------
 import type { Option, Options, Requires, ValuedOption, RequiresVal, ArrayOption } from './options';
 import type { Style } from './styles';
@@ -12,15 +12,13 @@ import { HelpMessage, TerminalString, style } from './styles';
 import { formatFunctions } from './validator';
 import { assert, splitPhrase } from './utils';
 
-export { HelpFormatter, type HelpConfig };
-
 //--------------------------------------------------------------------------------------------------
 // Types
 //--------------------------------------------------------------------------------------------------
 /**
  * The help format configuration.
  */
-type HelpConfig = {
+export type HelpConfig = {
   /**
    * The indentation level for each column.
    */
@@ -190,7 +188,7 @@ const defaultConfig: ConcreteFormat = {
 /**
  * Implements formatting of help messages for a set of option definitions.
  */
-class HelpFormatter {
+export class HelpFormatter {
   private readonly options: Options;
   private readonly styles: ConcreteStyles;
   private readonly groups = new Map<string, Array<HelpEntry>>();

--- a/packages/tsargp/lib/index.ts
+++ b/packages/tsargp/lib/index.ts
@@ -1,11 +1,11 @@
 export type * from './options';
 export type * from './utils';
+export type * from './validator';
 
 export * from './enums';
 export * from './formatter';
 export * from './parser';
 export * from './styles';
 
-export type { ErrorStyles, ErrorConfig, ConcreteError } from './validator';
 export { req, RequiresAll, RequiresOne, RequiresNot } from './options';
 export { OptionValidator } from './validator';

--- a/packages/tsargp/lib/index.ts
+++ b/packages/tsargp/lib/index.ts
@@ -1,6 +1,11 @@
+export type * from './options';
+export type * from './utils';
+
 export * from './enums';
 export * from './formatter';
-export * from './options';
 export * from './parser';
 export * from './styles';
-export * from './validator';
+
+export type { ErrorStyles, ErrorConfig, ConcreteError } from './validator';
+export { req, RequiresAll, RequiresOne, RequiresNot } from './options';
+export { OptionValidator } from './validator';

--- a/packages/tsargp/lib/options.ts
+++ b/packages/tsargp/lib/options.ts
@@ -1,66 +1,9 @@
 //--------------------------------------------------------------------------------------------------
-// Imports and Exports
+// Imports
 //--------------------------------------------------------------------------------------------------
 import type { HelpConfig } from './formatter';
 import type { Style } from './styles';
 import type { Resolve, Writable, URL } from './utils';
-
-export type {
-  ParseCallback,
-  ResolveCallback,
-  ExecuteCallback,
-  CompleteCallback,
-  CommandCallback,
-  DefaultCallback,
-  Option,
-  Options,
-  OptionDataType,
-  OptionValues,
-  CastToOptionValues,
-  OptionStyles,
-  StringOption,
-  NumberOption,
-  FlagOption,
-  BooleanOption,
-  StringsOption,
-  NumbersOption,
-  FunctionOption,
-  CommandOption,
-  HelpOption,
-  VersionOption,
-  SpecialOption,
-  ExecutingOption,
-  SingleOption,
-  ArrayOption,
-  NiladicOption,
-  ParamOption,
-  ValuedOption,
-  Requires,
-  RequiresExp,
-  RequiresVal,
-  ParamValue,
-  WithArray,
-  WithDefault,
-  WithDelimited,
-  WithExample,
-  WithNumber,
-  WithEnums,
-  WithRange,
-  WithRegex,
-  WithParam,
-  WithValue,
-  WithEnvVar,
-  WithParamName,
-  WithParse,
-  WithParseDelimited,
-  WithRequired,
-  WithResolve,
-  WithString,
-  WithType,
-  WithVersion,
-};
-
-export { req, RequiresAll, RequiresOne, RequiresNot, isNiladic, isArray, isValued, isVariadic };
 
 //--------------------------------------------------------------------------------------------------
 // Constants
@@ -68,7 +11,7 @@ export { req, RequiresAll, RequiresOne, RequiresNot, isNiladic, isArray, isValue
 /**
  * A helper object to create option requirement expressions.
  */
-const req = {
+export const req = {
   /**
    * Creates a requirement expression that is satisfied only when all items are satisfied.
    * @param items The requirement items
@@ -103,7 +46,7 @@ const req = {
 /**
  * A set of styles for displaying an option on the terminal.
  */
-type OptionStyles = {
+export type OptionStyles = {
   /**
    * The style of the option names.
    */
@@ -121,35 +64,35 @@ type OptionStyles = {
 /**
  * A requirement expression that is satisfied only when all items are satisfied.
  */
-class RequiresAll {
+export class RequiresAll {
   constructor(readonly items: Array<Requires>) {}
 }
 
 /**
  * A requirement expression that is satisfied when at least one item is satisfied.
  */
-class RequiresOne {
+export class RequiresOne {
   constructor(readonly items: Array<Requires>) {}
 }
 
 /**
  * A requirement expression that is satisfied when the item is not satisfied.
  */
-class RequiresNot {
+export class RequiresNot {
   constructor(readonly item: Requires) {}
 }
 
 /**
  * A requirement expression.
  */
-type RequiresExp = RequiresNot | RequiresAll | RequiresOne;
+export type RequiresExp = RequiresNot | RequiresAll | RequiresOne;
 
 /**
  * An object that maps option keys to required values.
  *
  * Values can be `undefined` to indicate presence, or `null` to indicate absence.
  */
-type RequiresVal = { [key: string]: ParamOption['example'] | null };
+export type RequiresVal = { [key: string]: ParamOption['example'] | null };
 
 /**
  * An option requirement can be either:
@@ -158,7 +101,7 @@ type RequiresVal = { [key: string]: ParamOption['example'] | null };
  * - an object that maps option keys to required values; or
  * - a requirement expression.
  */
-type Requires = string | RequiresVal | RequiresExp;
+export type Requires = string | RequiresVal | RequiresExp;
 
 /**
  * A callback to parse the value of option parameters. Any specified normalization or constraint
@@ -169,13 +112,13 @@ type Requires = string | RequiresVal | RequiresExp;
  * @param value The parameter value
  * @returns The parsed value
  */
-type ParseCallback<T> = (values: CastToOptionValues, name: string, value: string) => T;
+export type ParseCallback<T> = (values: CastToOptionValues, name: string, value: string) => T;
 
 /**
  * A module-relative resolution function (i.e., scoped to a module). To be used in non-browser
  * environments only.
  */
-type ResolveCallback = (specifier: string) => string;
+export type ResolveCallback = (specifier: string) => string;
 
 /**
  * A callback for default values.
@@ -183,7 +126,7 @@ type ResolveCallback = (specifier: string) => string;
  * @param values The values parsed so far
  * @returns The default value
  */
-type DefaultCallback<T> = (values: CastToOptionValues) => T | Promise<T>;
+export type DefaultCallback<T> = (values: CastToOptionValues) => T | Promise<T>;
 
 /**
  * A callback for function options.
@@ -192,7 +135,11 @@ type DefaultCallback<T> = (values: CastToOptionValues) => T | Promise<T>;
  * @param rest The remaining command-line arguments
  * @returns The option value
  */
-type ExecuteCallback = (values: CastToOptionValues, comp: boolean, rest: Array<string>) => unknown;
+export type ExecuteCallback = (
+  values: CastToOptionValues,
+  comp: boolean,
+  rest: Array<string>,
+) => unknown;
 
 /**
  * A callback for command options.
@@ -200,7 +147,10 @@ type ExecuteCallback = (values: CastToOptionValues, comp: boolean, rest: Array<s
  * @param cmdValues The values parsed after the command
  * @returns The option value
  */
-type CommandCallback = (values: CastToOptionValues, cmdValues: CastToOptionValues) => unknown;
+export type CommandCallback = (
+  values: CastToOptionValues,
+  cmdValues: CastToOptionValues,
+) => unknown;
 
 /**
  * A callback for option completion.
@@ -209,7 +159,7 @@ type CommandCallback = (values: CastToOptionValues, cmdValues: CastToOptionValue
  * @param rest The remaining command-line arguments
  * @returns The list of completion words
  */
-type CompleteCallback = (
+export type CompleteCallback = (
   values: CastToOptionValues,
   comp: string,
   rest: Array<string>,
@@ -219,7 +169,7 @@ type CompleteCallback = (
  * Defines attributes common to all options.
  * @template T The option type
  */
-type WithType<T extends string> = {
+export type WithType<T extends string> = {
   /**
    * The option type.
    */
@@ -269,7 +219,7 @@ type WithType<T extends string> = {
 /**
  * Defines attributes for a required option.
  */
-type WithRequired = {
+export type WithRequired = {
   /**
    * True if the option is always required.
    */
@@ -284,7 +234,7 @@ type WithRequired = {
  * Defines attributes for a default value.
  * @template T The default data type
  */
-type WithDefault<T> = {
+export type WithDefault<T> = {
   /**
    * The option default value or a callback that returns the default value.
    *
@@ -304,7 +254,7 @@ type WithDefault<T> = {
 /**
  * Defines attributes common to all options that accept parameters.
  */
-type WithParam = {
+export type WithParam = {
   /**
    * Allows positional arguments. There may be at most one option with this setting.
    *
@@ -326,7 +276,7 @@ type WithParam = {
  * Defines attributes for an example value.
  * @template T The example data type
  */
-type WithExample<T> = {
+export type WithExample<T> = {
   /**
    * The option example value. Replaces the option type in the help message parameter column.
    */
@@ -340,7 +290,7 @@ type WithExample<T> = {
 /**
  * Defines attributes for a parameter name.
  */
-type WithParamName = {
+export type WithParamName = {
   /**
    * The option parameter name. Replaces the option type in the help message parameter column.
    */
@@ -354,7 +304,7 @@ type WithParamName = {
 /**
  * Defines attributes for a custom callback that parses single-value parameters.
  */
-type WithParse<T> = {
+export type WithParse<T> = {
   /**
    * A custom function to parse the value of the option parameter.
    */
@@ -372,7 +322,7 @@ type WithParse<T> = {
 /**
  * Defines attributes for a custom callback that parses delimited-value parameters.
  */
-type WithParseDelimited<T> = {
+export type WithParseDelimited<T> = {
   /**
    * A custom function to parse the delimited values of the option parameter. If specified, the
    * option accepts a single parameter.
@@ -391,7 +341,7 @@ type WithParseDelimited<T> = {
 /**
  * Defines attributes for an option that accepts delimited-value parameters.
  */
-type WithDelimited = {
+export type WithDelimited = {
   /**
    * The parameter value separator. If specified, the option accepts a single parameter.
    */
@@ -409,7 +359,7 @@ type WithDelimited = {
 /**
  * Defines attributes common to all options that have array values.
  */
-type WithArray = {
+export type WithArray = {
   /**
    * True if duplicate elements should be removed.
    */
@@ -428,7 +378,7 @@ type WithArray = {
  * Defines attributes for an enumeration constraint.
  * @template T The enumeration data type
  */
-type WithEnums<T> = {
+export type WithEnums<T> = {
   /**
    * The enumerated values.
    */
@@ -446,7 +396,7 @@ type WithEnums<T> = {
 /**
  * Defines attributes for a regex constraint.
  */
-type WithRegex = {
+export type WithRegex = {
   /**
    * The regular expression.
    */
@@ -460,7 +410,7 @@ type WithRegex = {
 /**
  * Defines attributes for a range constraint.
  */
-type WithRange = {
+export type WithRange = {
   /**
    * The (closed) numeric range. You may want to use `[-Infinity, Infinity]` to disallow `NaN`.
    */
@@ -474,7 +424,7 @@ type WithRange = {
 /**
  * Defines the version attribute of a version option.
  */
-type WithVersion = {
+export type WithVersion = {
   /**
    * The semantic version (e.g., 0.1.0) or version information. It is not validated, but cannot be
    * empty. It may contain inline styles.
@@ -489,7 +439,7 @@ type WithVersion = {
 /**
  * Defines the resolve attribute of a version option.
  */
-type WithResolve = {
+export type WithResolve = {
   /**
    * A resolution function scoped to the module where a `package.json` file should be searched. Use
    * `import.meta.resolve`. Use in non-browser environments only. This results in an asynchronous
@@ -505,7 +455,7 @@ type WithResolve = {
 /**
  * Defines attributes common to all options that accept string parameters.
  */
-type WithString = (WithEnums<string> | WithRegex) & {
+export type WithString = (WithEnums<string> | WithRegex) & {
   /**
    * True if the values should be trimmed (remove leading and trailing whitespace).
    */
@@ -519,7 +469,7 @@ type WithString = (WithEnums<string> | WithRegex) & {
 /**
  * Defines attributes common to all options that accept number parameters.
  */
-type WithNumber = (WithEnums<number> | WithRange) & {
+export type WithNumber = (WithEnums<number> | WithRange) & {
   /**
    * The kind of rounding to apply.
    */
@@ -529,7 +479,7 @@ type WithNumber = (WithEnums<number> | WithRange) & {
 /**
  * Defines attributes common to all options that have values.
  */
-type WithValue<T> = (WithDefault<T> | WithRequired) & {
+export type WithValue<T> = (WithDefault<T> | WithRequired) & {
   /**
    * The option requirements.
    */
@@ -539,7 +489,7 @@ type WithValue<T> = (WithDefault<T> | WithRequired) & {
 /**
  * Defines attributes common to all options that accept environment variables.
  */
-type WithEnvVar = {
+export type WithEnvVar = {
   /**
    * The name of an environment variable to read from, if the option is not specified in the
    * command-line.
@@ -550,7 +500,7 @@ type WithEnvVar = {
 /**
  * An option that has a boolean value (accepts a single boolean parameter).
  */
-type BooleanOption = WithType<'boolean'> &
+export type BooleanOption = WithType<'boolean'> &
   WithParam &
   WithEnvVar &
   WithValue<boolean> &
@@ -560,7 +510,7 @@ type BooleanOption = WithType<'boolean'> &
 /**
  * An option that has a string value (accepts a single string parameter).
  */
-type StringOption = WithType<'string'> &
+export type StringOption = WithType<'string'> &
   WithParam &
   WithEnvVar &
   WithValue<string> &
@@ -571,7 +521,7 @@ type StringOption = WithType<'string'> &
 /**
  * An option that has a number value (accepts a single number parameter).
  */
-type NumberOption = WithType<'number'> &
+export type NumberOption = WithType<'number'> &
   WithParam &
   WithEnvVar &
   WithValue<number> &
@@ -582,7 +532,7 @@ type NumberOption = WithType<'number'> &
 /**
  * An option that has a string array value (may accept single or multiple parameters).
  */
-type StringsOption = WithType<'strings'> &
+export type StringsOption = WithType<'strings'> &
   WithParam &
   WithEnvVar &
   WithValue<ReadonlyArray<string>> &
@@ -594,7 +544,7 @@ type StringsOption = WithType<'strings'> &
 /**
  * An option that has a number array value (may accept single or multiple parameters).
  */
-type NumbersOption = WithType<'numbers'> &
+export type NumbersOption = WithType<'numbers'> &
   WithParam &
   WithEnvVar &
   WithValue<ReadonlyArray<number>> &
@@ -606,7 +556,7 @@ type NumbersOption = WithType<'numbers'> &
 /**
  * An option that has a boolean value and is enabled if specified (or disabled if negated).
  */
-type FlagOption = WithType<'flag'> &
+export type FlagOption = WithType<'flag'> &
   WithEnvVar &
   WithValue<boolean> & {
     /**
@@ -618,7 +568,7 @@ type FlagOption = WithType<'flag'> &
 /**
  * An option that executes a callback function.
  */
-type FunctionOption = WithType<'function'> &
+export type FunctionOption = WithType<'function'> &
   WithValue<unknown> & {
     /**
      * The callback function. If asynchronous, you should call `ArgumentParser.parseAsync` and await
@@ -634,7 +584,7 @@ type FunctionOption = WithType<'function'> &
 /**
  * An option that executes a command.
  */
-type CommandOption = WithType<'command'> &
+export type CommandOption = WithType<'command'> &
   WithValue<unknown> & {
     /**
      * The callback function. If asynchronous, you should call `ArgumentParser.parseAsync` and await
@@ -650,7 +600,7 @@ type CommandOption = WithType<'command'> &
 /**
  * An option that throws a help message.
  */
-type HelpOption = WithType<'help'> & {
+export type HelpOption = WithType<'help'> & {
   /**
    * The usage message. This goes before everything else.
    */
@@ -678,52 +628,52 @@ type HelpOption = WithType<'help'> & {
 /**
  * An option that throws a semantic version.
  */
-type VersionOption = WithType<'version'> & (WithVersion | WithResolve);
+export type VersionOption = WithType<'version'> & (WithVersion | WithResolve);
 
 /**
  * An option that performs some predefined action.
  */
-type SpecialOption = HelpOption | VersionOption;
+export type SpecialOption = HelpOption | VersionOption;
 
 /**
  * An option that performs a user-defined action.
  */
-type ExecutingOption = FunctionOption | CommandOption;
+export type ExecutingOption = FunctionOption | CommandOption;
 
 /**
  * An option that accepts no parameters.
  */
-type NiladicOption = FlagOption | ExecutingOption | SpecialOption;
+export type NiladicOption = FlagOption | ExecutingOption | SpecialOption;
 
 /**
  * A single-valued option that accepts a single parameter.
  */
-type SingleOption = BooleanOption | StringOption | NumberOption;
+export type SingleOption = BooleanOption | StringOption | NumberOption;
 
 /**
  * An array-valued option that may accept multiple parameters.
  */
-type ArrayOption = StringsOption | NumbersOption;
+export type ArrayOption = StringsOption | NumbersOption;
 
 /**
  * An option that accepts any kind of parameter.
  */
-type ParamOption = SingleOption | ArrayOption;
+export type ParamOption = SingleOption | ArrayOption;
 
 /**
  * An option that has a default value.
  */
-type ValuedOption = FlagOption | ExecutingOption | ParamOption;
+export type ValuedOption = FlagOption | ExecutingOption | ParamOption;
 
 /**
  * An option definition. (finally)
  */
-type Option = NiladicOption | ParamOption;
+export type Option = NiladicOption | ParamOption;
 
 /**
  * A collection of option definitions.
  */
-type Options = Readonly<Record<string, Option>>;
+export type Options = Readonly<Record<string, Option>>;
 
 /**
  * The data type of an option with a default value.
@@ -816,7 +766,7 @@ type OptionDataType<T extends Option> = T extends FunctionOption
  * A generic collection of option values.
  * @template T The type of the option definitions
  */
-type OptionValues<T extends Options> = Resolve<{
+export type OptionValues<T extends Options> = Resolve<{
   -readonly [key in keyof T as T[key] extends SpecialOption ? never : key]: OptionDataType<T[key]>;
 }>;
 
@@ -824,13 +774,13 @@ type OptionValues<T extends Options> = Resolve<{
  * An opaque collection of option values. It should be cast to
  * {@link OptionValues}`<typeof _your_options_>` or to the type of your values class.
  */
-type CastToOptionValues = Record<string, unknown>;
+export type CastToOptionValues = Record<string, unknown>;
 
 /**
  * The concrete data type of the option value of a non-niladic option.
  * @internal
  */
-type ParamValue = Writable<Exclude<ParamOption['example'], undefined>>;
+export type ParamValue = Writable<Exclude<ParamOption['example'], undefined>>;
 
 //--------------------------------------------------------------------------------------------------
 // Functions
@@ -841,7 +791,7 @@ type ParamValue = Writable<Exclude<ParamOption['example'], undefined>>;
  * @returns True if the option is niladic
  * @internal
  */
-function isNiladic(option: Option): option is NiladicOption {
+export function isNiladic(option: Option): option is NiladicOption {
   return ['flag', 'function', 'help', 'version', 'command'].includes(option.type);
 }
 
@@ -851,7 +801,7 @@ function isNiladic(option: Option): option is NiladicOption {
  * @returns True if the option is an array option
  * @internal
  */
-function isArray(option: Option): option is ArrayOption {
+export function isArray(option: Option): option is ArrayOption {
   return option.type === 'strings' || option.type === 'numbers';
 }
 
@@ -861,7 +811,7 @@ function isArray(option: Option): option is ArrayOption {
  * @returns True if the option is a valued option
  * @internal
  */
-function isValued(option: Option): option is ValuedOption {
+export function isValued(option: Option): option is ValuedOption {
   return option.type !== 'help' && option.type !== 'version';
 }
 
@@ -871,7 +821,7 @@ function isValued(option: Option): option is ValuedOption {
  * @returns True if the option is variadic
  * @internal
  */
-function isVariadic(option: ArrayOption): boolean {
+export function isVariadic(option: ArrayOption): boolean {
   return (
     !('separator' in option && option.separator) &&
     !('parseDelimited' in option && option.parseDelimited)

--- a/packages/tsargp/lib/options.ts
+++ b/packages/tsargp/lib/options.ts
@@ -3,10 +3,9 @@
 //--------------------------------------------------------------------------------------------------
 import type { HelpConfig } from './formatter';
 import type { Style } from './styles';
-import type { URL as _URL } from 'url';
+import type { Resolve, Writable, URL } from './utils';
 
 export type {
-  URL,
   ParseCallback,
   ResolveCallback,
   ExecuteCallback,
@@ -101,11 +100,6 @@ const req = {
 //--------------------------------------------------------------------------------------------------
 // Types
 //--------------------------------------------------------------------------------------------------
-/**
- * For some reason the global definition of `URL` has issues with static methods.
- */
-interface URL extends _URL {}
-
 /**
  * A set of styles for displaying an option on the terminal.
  */
@@ -833,19 +827,8 @@ type OptionValues<T extends Options> = Resolve<{
 type CastToOptionValues = Record<string, unknown>;
 
 /**
- * A helper type to resolve types in IntelliSense.
- * @template T The type to be resolved
- */
-type Resolve<T> = T & unknown;
-
-/**
- * A helper type to remove the readonly attribute from a type.
- * @template T The source type
- */
-type Writable<T> = { -readonly [P in keyof T]: T[P] };
-
-/**
- * The concrete data type of the option value of a non-niladic option. Used internally.
+ * The concrete data type of the option value of a non-niladic option.
+ * @internal
  */
 type ParamValue = Writable<Exclude<ParamOption['example'], undefined>>;
 
@@ -856,6 +839,7 @@ type ParamValue = Writable<Exclude<ParamOption['example'], undefined>>;
  * Tests if an option is niladic (i.e., accepts no parameter).
  * @param option The option definition
  * @returns True if the option is niladic
+ * @internal
  */
 function isNiladic(option: Option): option is NiladicOption {
   return ['flag', 'function', 'help', 'version', 'command'].includes(option.type);
@@ -865,6 +849,7 @@ function isNiladic(option: Option): option is NiladicOption {
  * Tests if an option is an array option (i.e., has an array value).
  * @param option The option definition
  * @returns True if the option is an array option
+ * @internal
  */
 function isArray(option: Option): option is ArrayOption {
   return option.type === 'strings' || option.type === 'numbers';
@@ -874,6 +859,7 @@ function isArray(option: Option): option is ArrayOption {
  * Tests if an option is a valued option (i.e., has a value).
  * @param option The option definition
  * @returns True if the option is a valued option
+ * @internal
  */
 function isValued(option: Option): option is ValuedOption {
   return option.type !== 'help' && option.type !== 'version';
@@ -883,6 +869,7 @@ function isValued(option: Option): option is ValuedOption {
  * Tests if an array option is variadic (i.e., accepts multiple parameters).
  * @param option The option definition
  * @returns True if the option is variadic
+ * @internal
  */
 function isVariadic(option: ArrayOption): boolean {
   return (

--- a/packages/tsargp/lib/parser.ts
+++ b/packages/tsargp/lib/parser.ts
@@ -1,5 +1,5 @@
 //--------------------------------------------------------------------------------------------------
-// Imports and Exports
+// Imports
 //--------------------------------------------------------------------------------------------------
 import type {
   ParamOption,
@@ -43,8 +43,6 @@ import { ErrorMessage, HelpMessage, TerminalString, style } from './styles';
 import { OptionValidator, defaultConfig, formatFunctions } from './validator';
 import { assert, checkRequiredArray, gestaltSimilarity, getArgs, isTrue } from './utils';
 
-export { ArgumentParser, OpaqueArgumentParser, type ParseConfig };
-
 //--------------------------------------------------------------------------------------------------
 // Constants
 //--------------------------------------------------------------------------------------------------
@@ -64,7 +62,7 @@ const enum ArgKind {
 /**
  * The parse configuration.
  */
-type ParseConfig = {
+export type ParseConfig = {
   /**
    * The program name.
    */
@@ -81,7 +79,7 @@ type ParseConfig = {
 /**
  * Implements parsing of command-line arguments into option values.
  */
-class OpaqueArgumentParser {
+export class OpaqueArgumentParser {
   private readonly validator: OptionValidator;
 
   /**
@@ -138,7 +136,7 @@ class OpaqueArgumentParser {
  * Implements parsing of command-line arguments into option values.
  * @template T The type of the option definitions
  */
-class ArgumentParser<T extends Options> extends OpaqueArgumentParser {
+export class ArgumentParser<T extends Options> extends OpaqueArgumentParser {
   /**
    * Creates an argument parser based on a set of option definitions.
    * @param options The option definitions

--- a/packages/tsargp/lib/styles.ts
+++ b/packages/tsargp/lib/styles.ts
@@ -1,21 +1,10 @@
 //--------------------------------------------------------------------------------------------------
 // Imports and Exports
 //--------------------------------------------------------------------------------------------------
-import { cs, tf, fg, bg, ul } from './enums';
 import type { Alias, Enumerate } from './utils';
+import { cs, tf, fg, bg, ul } from './enums';
 
-export type { CSI, Decimal, FgColor, BgColor, UlColor, StyleAttr, Style, Sequence, FormatCallback };
-
-export {
-  TerminalString,
-  ErrorMessage,
-  HelpMessage,
-  seq,
-  style,
-  foreground as fg8,
-  background as bg8,
-  underline as ul8,
-};
+export { sequence as seq, sgr as style, foreground as fg8, background as bg8, underline as ul8 };
 
 //--------------------------------------------------------------------------------------------------
 // Constants
@@ -41,49 +30,49 @@ const regex = {
  * @template P The type of the sequence parameter
  * @template C The type of the sequence command
  */
-type CSI<P extends string, C extends cs> = `\x9b${P}${C}`;
+export type CSI<P extends string, C extends cs> = `\x9b${P}${C}`;
 
 /**
  * A control sequence.
  */
-type Sequence = CSI<string, cs> | '';
+export type Sequence = CSI<string, cs> | '';
 
 /**
  * A select graphics rendition sequence.
  */
-type Style = CSI<string, cs.sgr> | '';
+export type Style = CSI<string, cs.sgr> | '';
 
 /**
  * An 8-bit decimal number.
  */
-type Decimal = Alias<Enumerate<256>>;
+export type Decimal = Alias<Enumerate<256>>;
 
 /**
  * An 8-bit foreground color.
  */
-type FgColor = [38, 5, Decimal];
+export type FgColor = [38, 5, Decimal];
 
 /**
  * An 8-bit background color.
  */
-type BgColor = [48, 5, Decimal];
+export type BgColor = [48, 5, Decimal];
 
 /**
  * An 8-bit underline color.
  */
-type UlColor = [58, 5, Decimal];
+export type UlColor = [58, 5, Decimal];
 
 /**
  * A text styling attribute.
  */
-type StyleAttr = tf | fg | bg | ul | FgColor | BgColor | UlColor;
+export type StyleAttr = tf | fg | bg | ul | FgColor | BgColor | UlColor;
 
 /**
  * A callback that processes a format specifier when splitting text.
  * @param this The terminal string to append to
  * @param spec The format specifier (e.g., '%s')
  */
-type FormatCallback = (this: TerminalString, spec: string) => void;
+export type FormatCallback = (this: TerminalString, spec: string) => void;
 
 //--------------------------------------------------------------------------------------------------
 // Classes
@@ -91,7 +80,7 @@ type FormatCallback = (this: TerminalString, spec: string) => void;
 /**
  * Implements concatenation of strings that can be printed on a terminal.
  */
-class TerminalString {
+export class TerminalString {
   private merge = false;
 
   /**
@@ -320,7 +309,7 @@ class TerminalString {
       }
     } else if (start) {
       if (width >= start + Math.max(...this.lengths)) {
-        indent = seq(cs.cha, start + 1);
+        indent = sequence(cs.cha, start + 1);
         if (!firstIsBreak && column != start) {
           result.push(indent);
         }
@@ -331,7 +320,7 @@ class TerminalString {
         start = 0;
       }
     } else if (!firstIsBreak && column) {
-      result.push(seq(cs.cha, 1));
+      result.push(sequence(cs.cha, 1));
     }
     column = start;
     for (let i = 0; i < this.strings.length; ++i) {
@@ -373,7 +362,7 @@ class TerminalString {
 /**
  * An error message.
  */
-class ErrorMessage extends Error {
+export class ErrorMessage extends Error {
   /**
    * Creates an error message
    * @param str The terminal string
@@ -399,7 +388,7 @@ class ErrorMessage extends Error {
     const result = new Array<string>();
     this.str.wrapToWidth(result, 0, width, emitStyles);
     if (emitStyles) {
-      result.push(style(tf.clear));
+      result.push(sgr(tf.clear));
     }
     return result.join('');
   }
@@ -408,7 +397,7 @@ class ErrorMessage extends Error {
 /**
  * A help message.
  */
-class HelpMessage extends Array<TerminalString> {
+export class HelpMessage extends Array<TerminalString> {
   /**
    * @returns the message to be printed on a terminal
    */
@@ -429,7 +418,7 @@ class HelpMessage extends Array<TerminalString> {
       column = str.wrapToWidth(result, column, width, emitStyles);
     }
     if (emitStyles) {
-      result.push(style(tf.clear));
+      result.push(sgr(tf.clear));
     }
     return result.join('');
   }
@@ -457,7 +446,7 @@ function omitStyles(width: number): boolean {
  * @param params The sequence parameters
  * @returns The control sequence
  */
-function seq<T extends cs>(cmd: T, ...params: Array<number>): CSI<string, T> {
+function sequence<T extends cs>(cmd: T, ...params: Array<number>): CSI<string, T> {
   return `\x9b${params.join(';')}${cmd}`;
 }
 
@@ -466,8 +455,8 @@ function seq<T extends cs>(cmd: T, ...params: Array<number>): CSI<string, T> {
  * @param attrs The text styling attributes
  * @returns The SGR sequence
  */
-function style(...attrs: Array<StyleAttr>): Style {
-  return seq(cs.sgr, ...attrs.flat());
+function sgr(...attrs: Array<StyleAttr>): Style {
+  return sequence(cs.sgr, ...attrs.flat());
 }
 
 /**

--- a/packages/tsargp/lib/utils.ts
+++ b/packages/tsargp/lib/utils.ts
@@ -1,10 +1,7 @@
 //--------------------------------------------------------------------------------------------------
-// Imports and Exports
+// Imports
 //--------------------------------------------------------------------------------------------------
 import type { URL as _URL } from 'url';
-
-export type { Alias, Enumerate, Concrete, Resolve, Writable, URL };
-export { assert, getArgs, checkRequiredArray, gestaltSimilarity, splitPhrase, isTrue };
 
 //--------------------------------------------------------------------------------------------------
 // Types
@@ -13,13 +10,13 @@ export { assert, getArgs, checkRequiredArray, gestaltSimilarity, splitPhrase, is
  * A helper type to alias another type while eliding type resolution in IntelliSense.
  * @template T The type to be aliased
  */
-type Alias<T> = T extends T ? T : T;
+export type Alias<T> = T extends T ? T : T;
 
 /**
  * A helper type to enumerate numbers.
  * @template N The type of last enumerated number
  */
-type Enumerate<N extends number, Acc extends Array<number> = []> = Acc['length'] extends N
+export type Enumerate<N extends number, Acc extends Array<number> = []> = Acc['length'] extends N
   ? Acc[number]
   : Enumerate<N, [...Acc, Acc['length']]>;
 
@@ -27,7 +24,7 @@ type Enumerate<N extends number, Acc extends Array<number> = []> = Acc['length']
  * A helper type to remove optionality from types and properties.
  * @template T The source type
  */
-type Concrete<T> = Exclude<
+export type Concrete<T> = Exclude<
   {
     [K in keyof T]-?: Concrete<T[K]>;
   },
@@ -38,18 +35,18 @@ type Concrete<T> = Exclude<
  * A helper type to resolve types in IntelliSense.
  * @template T The type to be resolved
  */
-type Resolve<T> = T & unknown;
+export type Resolve<T> = T & unknown;
 
 /**
  * A helper type to remove the readonly attribute from a type.
  * @template T The source type
  */
-type Writable<T> = { -readonly [P in keyof T]: T[P] };
+export type Writable<T> = { -readonly [P in keyof T]: T[P] };
 
 /**
  * For some reason the global definition of `URL` has issues with static methods.
  */
-interface URL extends _URL {}
+export interface URL extends _URL {}
 
 //--------------------------------------------------------------------------------------------------
 // Functions
@@ -59,8 +56,9 @@ interface URL extends _URL {}
  * @param line The command line
  * @param compIndex The completion index, if any
  * @returns The list of arguments
+ * @internal
  */
-function getArgs(line: string, compIndex: number = NaN): Array<string> {
+export function getArgs(line: string, compIndex: number = NaN): Array<string> {
   /** @ignore */
   function append(char: string) {
     if (arg === undefined) {
@@ -115,8 +113,9 @@ function getArgs(line: string, compIndex: number = NaN): Array<string> {
  * @param negate True if the requirement should be negated
  * @param unique True if array elements should be unique
  * @returns True if the requirement was satisfied
+ * @internal
  */
-function checkRequiredArray<T extends string | number>(
+export function checkRequiredArray<T extends string | number>(
   actual: ReadonlyArray<T>,
   expected: ReadonlyArray<T>,
   negate: boolean,
@@ -199,8 +198,9 @@ function matchingCharacters(S: string, T: string): number {
  * @param T The target string
  * @returns The similarity between the two strings
  * @see https://www.wikiwand.com/en/Gestalt_pattern_matching
+ * @internal
  */
-function gestaltSimilarity(S: string, T: string): number {
+export function gestaltSimilarity(S: string, T: string): number {
   return (2 * matchingCharacters(S, T)) / (S.length + T.length);
 }
 
@@ -208,8 +208,9 @@ function gestaltSimilarity(S: string, T: string): number {
  * Split a phrase into multiple alternatives
  * @param phrase The phrase string
  * @returns The phrase alternatives
+ * @internal
  */
-function splitPhrase(phrase: string): Array<string> {
+export function splitPhrase(phrase: string): Array<string> {
   const [l, c, r] = phrase.split(/\(([^)|]*\|[^)]*)\)/, 3);
   return c ? c.split('|').map((alt) => l + alt + r) : [l];
 }
@@ -217,14 +218,16 @@ function splitPhrase(phrase: string): Array<string> {
 /**
  * Asserts that a condition is true. This is a no-op.
  * @param _condition The condition
+ * @internal
  */
-function assert(_condition: unknown): asserts _condition {}
+export function assert(_condition: unknown): asserts _condition {}
 
 /**
  * Converts a string to boolean.
  * @param str The string value
  * @returns True if the string evaluates to true
+ * @internal
  */
-function isTrue(str: string): boolean {
+export function isTrue(str: string): boolean {
   return !(Number(str) == 0 || str.trim().match(/^\s*false\s*$/i));
 }

--- a/packages/tsargp/lib/utils.ts
+++ b/packages/tsargp/lib/utils.ts
@@ -1,7 +1,55 @@
 //--------------------------------------------------------------------------------------------------
 // Imports and Exports
 //--------------------------------------------------------------------------------------------------
+import type { URL as _URL } from 'url';
+
+export type { Alias, Enumerate, Concrete, Resolve, Writable, URL };
 export { assert, getArgs, checkRequiredArray, gestaltSimilarity, splitPhrase, isTrue };
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+/**
+ * A helper type to alias another type while eliding type resolution in IntelliSense.
+ * @template T The type to be aliased
+ */
+type Alias<T> = T extends T ? T : T;
+
+/**
+ * A helper type to enumerate numbers.
+ * @template N The type of last enumerated number
+ */
+type Enumerate<N extends number, Acc extends Array<number> = []> = Acc['length'] extends N
+  ? Acc[number]
+  : Enumerate<N, [...Acc, Acc['length']]>;
+
+/**
+ * A helper type to remove optionality from types and properties.
+ * @template T The source type
+ */
+type Concrete<T> = Exclude<
+  {
+    [K in keyof T]-?: Concrete<T[K]>;
+  },
+  undefined
+>;
+
+/**
+ * A helper type to resolve types in IntelliSense.
+ * @template T The type to be resolved
+ */
+type Resolve<T> = T & unknown;
+
+/**
+ * A helper type to remove the readonly attribute from a type.
+ * @template T The source type
+ */
+type Writable<T> = { -readonly [P in keyof T]: T[P] };
+
+/**
+ * For some reason the global definition of `URL` has issues with static methods.
+ */
+interface URL extends _URL {}
 
 //--------------------------------------------------------------------------------------------------
 // Functions

--- a/packages/tsargp/lib/validator.ts
+++ b/packages/tsargp/lib/validator.ts
@@ -2,7 +2,6 @@
 // Imports and Exports
 //--------------------------------------------------------------------------------------------------
 import type {
-  URL,
   Option,
   Options,
   Requires,
@@ -16,21 +15,14 @@ import type {
   ParamValue,
 } from './options';
 import type { Style } from './styles';
+import type { Concrete, URL } from './utils';
 
 import { tf, fg, ErrorItem } from './enums';
 import { RequiresAll, RequiresOne, RequiresNot, isNiladic, isArray } from './options';
 import { style, TerminalString, ErrorMessage } from './styles';
 import { assert } from './utils';
 
-export type {
-  Positional,
-  Concrete,
-  ErrorStyles,
-  ErrorConfig,
-  ConcreteStyles,
-  ConcreteError,
-  FormatFunction,
-};
+export type { Positional, ErrorStyles, ErrorConfig, ConcreteStyles, ConcreteError, FormatFunction };
 export { OptionValidator, defaultConfig, formatFunctions };
 
 //--------------------------------------------------------------------------------------------------
@@ -38,6 +30,7 @@ export { OptionValidator, defaultConfig, formatFunctions };
 //--------------------------------------------------------------------------------------------------
 /**
  * The error formatting functions.
+ * @internal
  */
 const formatFunctions = {
   /**
@@ -76,6 +69,7 @@ const formatFunctions = {
 
 /**
  * The default error messages configuration.
+ * @internal
  */
 const defaultConfig: ConcreteError = {
   styles: {
@@ -126,7 +120,8 @@ const defaultConfig: ConcreteError = {
 // Types
 //--------------------------------------------------------------------------------------------------
 /**
- * Information regarding a positional option. Used internally.
+ * Information regarding a positional option.
+ * @internal
  */
 type Positional = {
   key: string;
@@ -137,6 +132,7 @@ type Positional = {
 
 /**
  * A set of formatting functions for error messages.
+ * @internal
  */
 type FormatFunction = (
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -205,19 +201,9 @@ type ConcreteError = Concrete<ErrorConfig>;
 
 /**
  * A concrete version of the error message styles.
+ * @internal
  */
 type ConcreteStyles = ConcreteError['styles'];
-
-/**
- * A helper type to remove optionality from types and properties.
- * @template T The source type
- */
-type Concrete<T> = Exclude<
-  {
-    [K in keyof T]-?: Concrete<T[K]>;
-  },
-  undefined
->;
 
 //--------------------------------------------------------------------------------------------------
 // Classes

--- a/packages/tsargp/lib/validator.ts
+++ b/packages/tsargp/lib/validator.ts
@@ -1,5 +1,5 @@
 //--------------------------------------------------------------------------------------------------
-// Imports and Exports
+// Imports
 //--------------------------------------------------------------------------------------------------
 import type {
   Option,
@@ -22,9 +22,6 @@ import { RequiresAll, RequiresOne, RequiresNot, isNiladic, isArray } from './opt
 import { style, TerminalString, ErrorMessage } from './styles';
 import { assert } from './utils';
 
-export type { Positional, ErrorStyles, ErrorConfig, ConcreteStyles, ConcreteError, FormatFunction };
-export { OptionValidator, defaultConfig, formatFunctions };
-
 //--------------------------------------------------------------------------------------------------
 // Constants
 //--------------------------------------------------------------------------------------------------
@@ -32,7 +29,7 @@ export { OptionValidator, defaultConfig, formatFunctions };
  * The error formatting functions.
  * @internal
  */
-const formatFunctions = {
+export const formatFunctions = {
   /**
    * The boolean formatting function.
    */
@@ -71,7 +68,7 @@ const formatFunctions = {
  * The default error messages configuration.
  * @internal
  */
-const defaultConfig: ConcreteError = {
+export const defaultConfig: ConcreteError = {
   styles: {
     boolean: style(fg.yellow),
     string: style(fg.green),
@@ -123,7 +120,7 @@ const defaultConfig: ConcreteError = {
  * Information regarding a positional option.
  * @internal
  */
-type Positional = {
+export type Positional = {
   key: string;
   name: string;
   option: Option;
@@ -134,7 +131,7 @@ type Positional = {
  * A set of formatting functions for error messages.
  * @internal
  */
-type FormatFunction = (
+export type FormatFunction = (
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   value: any,
   styles: ConcreteStyles,
@@ -145,7 +142,7 @@ type FormatFunction = (
 /**
  * A set of styles for displaying text on the terminal.
  */
-type ErrorStyles = {
+export type ErrorStyles = {
   /**
    * The style of boolean values.
    */
@@ -183,7 +180,7 @@ type ErrorStyles = {
 /**
  * The error messages configuration.
  */
-type ErrorConfig = {
+export type ErrorConfig = {
   /**
    * The error message styles
    */
@@ -197,13 +194,13 @@ type ErrorConfig = {
 /**
  * A concrete version of the error messages configuration.
  */
-type ConcreteError = Concrete<ErrorConfig>;
+export type ConcreteError = Concrete<ErrorConfig>;
 
 /**
  * A concrete version of the error message styles.
  * @internal
  */
-type ConcreteStyles = ConcreteError['styles'];
+export type ConcreteStyles = ConcreteError['styles'];
 
 //--------------------------------------------------------------------------------------------------
 // Classes
@@ -211,7 +208,7 @@ type ConcreteStyles = ConcreteError['styles'];
 /**
  * Implements a compilation of option definitions.
  */
-class OptionValidator {
+export class OptionValidator {
   readonly names = new Map<string, string>();
   readonly positional: Positional | undefined;
 

--- a/packages/tsargp/test/styles.spec.ts
+++ b/packages/tsargp/test/styles.spec.ts
@@ -1,26 +1,27 @@
 import { describe, expect, it, vi } from 'vitest';
-import { TerminalString, ErrorMessage, HelpMessage, tf, ed, sc, mv } from '../lib';
-import { move, moveTo, edit, style, margin, scroll, fg8, bg8, ul8 } from '../lib';
+import { cs, tf, fg, bg, ul, seq, style, fg8, bg8, ul8 } from '../lib';
+import { TerminalString, ErrorMessage, HelpMessage } from '../lib';
 
 describe('TerminalString', () => {
   describe('addStyle', () => {
     it('should add text with sequences', () => {
-      const str = new TerminalString();
-      str.addSequence(move(1, mv.cbt));
-      str.addSequence(scroll(1, sc.sd));
-      str.addSequence(margin(1, 2));
+      const str = new TerminalString()
+        .addSequence(seq(cs.rcp))
+        .addSequence(seq(cs.cbt, 1))
+        .addSequence(seq(cs.tbm, 1, 2))
+        .addSequence(seq(cs.rm, 1, 2, 3));
       expect(str).toHaveLength(0);
-      expect(str.strings).toHaveLength(3);
-      expect(str.strings[0]).toEqual('\x9b1Z');
-      expect(str.strings[1]).toEqual('\x9b1T');
+      expect(str.strings).toHaveLength(4);
+      expect(str.strings[0]).toEqual('\x9bu');
+      expect(str.strings[1]).toEqual('\x9b1Z');
       expect(str.strings[2]).toEqual('\x9b1;2r');
+      expect(str.strings[3]).toEqual('\x9b1;2;3l');
     });
   });
 
   describe('addWord', () => {
     it('should add words without sequences', () => {
-      const str = new TerminalString();
-      str.addWord('type').addWord('script');
+      const str = new TerminalString().addWord('type').addWord('script');
       expect(str).toHaveLength(10);
       expect(str.strings).toHaveLength(2);
       expect(str.strings[0]).toEqual('type');
@@ -30,18 +31,20 @@ describe('TerminalString', () => {
 
   describe('addAndRevert', () => {
     it('should add a word with surrounding sequences', () => {
-      const str = new TerminalString();
-      str.addAndRevert(style(fg8(0), bg8(0), ul8(0)), 'type', edit(1, ed.dch));
+      const str = new TerminalString().addAndRevert(
+        style(fg8(0), bg8(0), ul8(0)),
+        'type',
+        style(tf.clear),
+      );
       expect(str).toHaveLength(4);
       expect(str.strings).toHaveLength(1);
-      expect(str.strings[0]).toEqual('\x9b38;5;0;48;5;0;58;5;0m' + 'type' + '\x9b1P');
+      expect(str.strings[0]).toEqual('\x9b38;5;0;48;5;0;58;5;0m' + 'type' + '\x9b0m');
     });
   });
 
   describe('addOpening', () => {
     it('should add opening words to a word', () => {
-      const str = new TerminalString();
-      str.addOpening('[').addOpening('"').addWord('type');
+      const str = new TerminalString().addOpening('[').addOpening('"').addWord('type');
       expect(str).toHaveLength(6);
       expect(str.strings).toHaveLength(1);
       expect(str.strings[0]).toEqual('["type');
@@ -50,10 +53,8 @@ describe('TerminalString', () => {
 
   describe('addOther', () => {
     it('should add the strings from the other string', () => {
-      const str1 = new TerminalString();
-      const str2 = new TerminalString();
-      str1.splitText('type script').setMerge();
-      str2.addOther(str1).splitText(': is fun');
+      const str1 = new TerminalString().splitText('type script').setMerge();
+      const str2 = new TerminalString().addOther(str1).splitText(': is fun');
       expect(str2).toHaveLength(16);
       expect(str2.strings).toHaveLength(4);
       expect(str2.strings[0]).toEqual('type');
@@ -65,27 +66,28 @@ describe('TerminalString', () => {
 
   describe('addClosing', () => {
     it('should add a closing word when there are no strings', () => {
-      const str = new TerminalString();
-      str.addClosing(']');
+      const str = new TerminalString().addClosing(']');
       expect(str).toHaveLength(1);
       expect(str.strings).toHaveLength(1);
       expect(str.strings[0]).toEqual(']');
     });
 
     it('should add closing words to the last word', () => {
-      const str = new TerminalString();
-      str.addWord('type').addSequence(moveTo(1, 2)).addClosing(']').addClosing('.');
+      const str = new TerminalString()
+        .addWord('type')
+        .addSequence(style(fg.default, bg.default, ul.default))
+        .addClosing(']')
+        .addClosing('.');
       expect(str).toHaveLength(6);
       expect(str.strings).toHaveLength(2);
       expect(str.strings[0]).toEqual('type');
-      expect(str.strings[1]).toEqual('\x9b1;2H].');
+      expect(str.strings[1]).toEqual('\x9b39;49;59m].');
     });
   });
 
   describe('splitText', () => {
     it('should split text with emojis', () => {
-      const str = new TerminalString();
-      str.splitText(`⚠️ type script`);
+      const str = new TerminalString().splitText(`⚠️ type script`);
       expect(str).toHaveLength(12);
       expect(str.strings).toHaveLength(3);
       expect(str.strings[0]).toEqual('⚠️');
@@ -94,8 +96,7 @@ describe('TerminalString', () => {
     });
 
     it('should split text with style sequences', () => {
-      const str = new TerminalString();
-      str.splitText(`${style(tf.clear)}type script${style(tf.clear)}`);
+      const str = new TerminalString().splitText(`${style(tf.clear)}type script${style(tf.clear)}`);
       expect(str).toHaveLength(10);
       expect(str.strings).toHaveLength(2);
       expect(str.strings[0]).toEqual('\x9b0mtype');
@@ -103,8 +104,7 @@ describe('TerminalString', () => {
     });
 
     it('should split text with paragraphs', () => {
-      const str = new TerminalString();
-      str.splitText('type\nscript\n\nis\nfun');
+      const str = new TerminalString().splitText('type\nscript\n\nis\nfun');
       expect(str).toHaveLength(15);
       expect(str.strings).toHaveLength(5);
       expect(str.strings[0]).toEqual('type');
@@ -115,8 +115,7 @@ describe('TerminalString', () => {
     });
 
     it('should split text with list items', () => {
-      const str = new TerminalString();
-      str.splitText('type:\n- script\n1. is fun');
+      const str = new TerminalString().splitText('type:\n- script\n1. is fun');
       expect(str).toHaveLength(19);
       expect(str.strings).toHaveLength(8);
       expect(str.strings[0]).toEqual('type:');
@@ -130,11 +129,10 @@ describe('TerminalString', () => {
     });
 
     it('should split text with format specifiers', () => {
-      const str = new TerminalString();
-      const format = vi.fn().mockImplementation(() => {
-        str.addWord('abc');
+      const format = vi.fn().mockImplementation(function (this: TerminalString) {
+        this.addWord('abc');
       });
-      str.splitText('type' + '%s script is %n' + 'fun', format);
+      const str = new TerminalString().splitText('type' + '%s script is %n' + 'fun', format);
       expect(str).toHaveLength(21);
       expect(str.strings).toHaveLength(4);
       expect(str.strings[0]).toEqual('type' + 'abc');
@@ -147,11 +145,10 @@ describe('TerminalString', () => {
     });
 
     it('should not add a line break to the first list item', () => {
-      const str = new TerminalString();
-      const format = vi.fn().mockImplementation(() => {
-        str.splitText('- item\n* item\n1. item');
+      const format = vi.fn().mockImplementation(function (this: TerminalString) {
+        this.splitText('- item\n* item\n1. item');
       });
-      str.splitText('%s', format);
+      const str = new TerminalString().splitText('%s', format);
       expect(str).toHaveLength(16);
       expect(str.strings).toHaveLength(8);
       expect(str.strings[0]).toEqual('-');
@@ -168,201 +165,186 @@ describe('TerminalString', () => {
   describe('wrapToWidth', () => {
     describe('when no width is provided', () => {
       it('should not wrap', () => {
-        const str = new TerminalString();
         const result = new Array<string>();
-        str.splitText('abc def').wrapToWidth(result, 0, 0, false);
+        new TerminalString().splitText('abc def').wrapToWidth(result, 0, 0, false);
         expect(result).toEqual(['abc', ' def']);
       });
 
       it('should preserve indentation', () => {
-        const str = new TerminalString(2);
         const result = new Array<string>();
-        str.addWord('abc').wrapToWidth(result, 0, 0, false);
+        new TerminalString(2).addWord('abc').wrapToWidth(result, 0, 0, false);
         expect(result).toEqual(['  ', 'abc']);
       });
 
       it('should not preserve indentation if the string is empty', () => {
-        const str = new TerminalString(2);
         const result = new Array<string>();
-        str.wrapToWidth(result, 0, 0, false);
+        new TerminalString(2).wrapToWidth(result, 0, 0, false);
         expect(result).toEqual([]);
       });
 
       it('should not preserve indentation if the string starts with a line break', () => {
-        const str = new TerminalString(2);
         const result = new Array<string>();
-        str.addBreaks(1).wrapToWidth(result, 0, 0, false);
+        new TerminalString(2).addBreaks(1).wrapToWidth(result, 0, 0, false);
         expect(result).toEqual(['\n']);
       });
 
       it('should shorten the current line (1)', () => {
-        const str = new TerminalString(0);
         const result = ['  '];
-        str.splitText('abc def').wrapToWidth(result, 2, 0, false);
+        new TerminalString(0).splitText('abc def').wrapToWidth(result, 2, 0, false);
         expect(result).toEqual(['abc', ' def']);
       });
 
       it('should shorten the current line (2)', () => {
-        const str = new TerminalString(0);
         const result = ['   '];
-        str.splitText('abc def').wrapToWidth(result, 2, 0, false);
+        new TerminalString(0).splitText('abc def').wrapToWidth(result, 2, 0, false);
         expect(result).toEqual([' ', 'abc', ' def']);
       });
 
       it('should not shorten the current line if the string is empty', () => {
-        const str = new TerminalString(0);
         const result = ['  '];
-        str.wrapToWidth(result, 2, 0, false);
+        new TerminalString(0).wrapToWidth(result, 2, 0, false);
         expect(result).toEqual(['  ']);
       });
 
       it('should not shorten the current line if the string starts with a line break', () => {
-        const str = new TerminalString(0);
         const result = ['  '];
-        str.addBreaks(1).wrapToWidth(result, 2, 0, false);
+        new TerminalString(0).addBreaks(1).wrapToWidth(result, 2, 0, false);
         expect(result).toEqual(['  ', '\n']);
       });
 
       it('should preserve line breaks', () => {
-        const str = new TerminalString(0);
         const result = new Array<string>();
-        str.splitText('abc\n\ndef').wrapToWidth(result, 0, 0, false);
+        new TerminalString(0).splitText('abc\n\ndef').wrapToWidth(result, 0, 0, false);
         expect(result).toEqual(['abc', '\n\n', 'def']);
       });
 
       it('should omit styles', () => {
-        const str = new TerminalString(0);
         const result = new Array<string>();
-        str
+        new TerminalString(0)
           .splitText(`abc${style(tf.clear)} ${style(tf.clear)} def`)
           .wrapToWidth(result, 0, 0, false);
         expect(result).toEqual(['abc', ' def']);
       });
 
       it('should emit styles', () => {
-        const str = new TerminalString();
         const result = new Array<string>();
-        str
+        new TerminalString()
           .splitText(`abc${style(tf.clear)} ${style(tf.clear)} def`)
           .wrapToWidth(result, 0, 0, true);
         expect(result).toEqual(['abc' + style(tf.clear), style(tf.clear), ' def']);
       });
 
       it('should preserve emojis', () => {
-        const str = new TerminalString();
         const result = new Array<string>();
-        str.splitText('⚠️ abc').wrapToWidth(result, 0, 0, false);
+        new TerminalString().splitText('⚠️ abc').wrapToWidth(result, 0, 0, false);
         expect(result).toEqual(['⚠️', ' abc']);
       });
     });
 
     describe('when a width is provided', () => {
       it('should wrap relative to the beginning when the largest word does not fit the width (1)', () => {
-        const str = new TerminalString(1);
         const result = new Array<string>();
-        str.splitText('abc largest').wrapToWidth(result, 0, 5, false);
+        new TerminalString(1).splitText('abc largest').wrapToWidth(result, 0, 5, false);
         expect(result).toEqual(['abc', '\nlargest']);
       });
 
       it('should wrap relative to the beginning when the largest word does not fit the width (2)', () => {
-        const str = new TerminalString(1);
         const result = new Array<string>();
-        str.splitText('abc largest').wrapToWidth(result, 1, 5, false);
+        new TerminalString(1).splitText('abc largest').wrapToWidth(result, 1, 5, false);
         expect(result).toEqual(['\n', 'abc', '\nlargest']);
       });
 
       it('should wrap relative to the beginning when the largest word does not fit the width (3)', () => {
-        const str = new TerminalString(1);
         const result = new Array<string>();
-        str.addBreaks(1).splitText('abc largest').wrapToWidth(result, 1, 5, false);
+        new TerminalString(1)
+          .addBreaks(1)
+          .splitText('abc largest')
+          .wrapToWidth(result, 1, 5, false);
         expect(result).toEqual(['\n', 'abc', '\nlargest']);
       });
 
       it('should wrap with a move sequence when the largest word fits the width (1)', () => {
-        const str = new TerminalString(1);
         const result = new Array<string>();
-        str.splitText('abc largest').wrapToWidth(result, 1, 15, false);
+        new TerminalString(1).splitText('abc largest').wrapToWidth(result, 1, 15, false);
         expect(result).toEqual(['abc', ' largest']);
       });
 
       it('should wrap with a move sequence when the largest word fits the width (2)', () => {
-        const str = new TerminalString(1);
         const result = new Array<string>();
-        str.splitText('abc largest').wrapToWidth(result, 2, 15, false);
-        expect(result).toEqual([move(2, mv.cha), 'abc', ' largest']);
+        new TerminalString(1).splitText('abc largest').wrapToWidth(result, 2, 15, false);
+        expect(result).toEqual([seq(cs.cha, 2), 'abc', ' largest']);
       });
 
       it('should wrap with a move sequence when the largest word fits the width (3)', () => {
-        const str = new TerminalString(2);
         const result = new Array<string>();
-        str.splitText('abc largest').wrapToWidth(result, 1, 15, false);
-        expect(result).toEqual([move(3, mv.cha), 'abc', ' largest']);
+        new TerminalString(2).splitText('abc largest').wrapToWidth(result, 1, 15, false);
+        expect(result).toEqual([seq(cs.cha, 3), 'abc', ' largest']);
       });
 
       it('should wrap with a move sequence when the largest word fits the width (4)', () => {
-        const str = new TerminalString(1);
         const result = new Array<string>();
-        str.splitText('abc largest').wrapToWidth(result, 1, 10, false);
-        expect(result).toEqual(['abc', `\n${move(2, mv.cha)}largest`]);
+        new TerminalString(1).splitText('abc largest').wrapToWidth(result, 1, 10, false);
+        expect(result).toEqual(['abc', `\n${seq(cs.cha, 2)}largest`]);
       });
 
       it('should wrap with a move sequence when the largest word fits the width (5)', () => {
-        const str = new TerminalString();
         const result = new Array<string>();
-        str.splitText('abc largest').wrapToWidth(result, 0, 15, false);
+        new TerminalString().splitText('abc largest').wrapToWidth(result, 0, 15, false);
         expect(result).toEqual(['abc', ' largest']);
       });
 
       it('should wrap with a move sequence when the largest word fits the width (6)', () => {
-        const str = new TerminalString();
         const result = new Array<string>();
-        str.splitText('abc largest').wrapToWidth(result, 1, 15, false);
-        expect(result).toEqual([move(1, mv.cha), 'abc', ' largest']);
+        new TerminalString().splitText('abc largest').wrapToWidth(result, 1, 15, false);
+        expect(result).toEqual([seq(cs.cha, 1), 'abc', ' largest']);
       });
 
       it('should wrap with a move sequence when the largest word fits the width (7)', () => {
-        const str = new TerminalString();
         const result = new Array<string>();
-        str.addBreaks(1).splitText('abc largest').wrapToWidth(result, 1, 15, false);
+        new TerminalString()
+          .addBreaks(1)
+          .splitText('abc largest')
+          .wrapToWidth(result, 1, 15, false);
         expect(result).toEqual(['\n', 'abc', ' largest']);
       });
 
       it('should wrap with a move sequence when the largest word fits the width (8)', () => {
-        const str = new TerminalString(1);
         const result = new Array<string>();
-        str.addBreaks(1).splitText('abc largest').wrapToWidth(result, 2, 15, false);
-        expect(result).toEqual(['\n', move(2, mv.cha), 'abc', ' largest']);
+        new TerminalString(1)
+          .addBreaks(1)
+          .splitText('abc largest')
+          .wrapToWidth(result, 2, 15, false);
+        expect(result).toEqual(['\n', seq(cs.cha, 2), 'abc', ' largest']);
       });
 
       it('should wrap with a move sequence when the largest word fits the width (9)', () => {
-        const str = new TerminalString(2);
         const result = new Array<string>();
-        str.addBreaks(1).splitText('abc largest').wrapToWidth(result, 1, 15, false);
-        expect(result).toEqual(['\n', move(3, mv.cha), 'abc', ' largest']);
+        new TerminalString(2)
+          .addBreaks(1)
+          .splitText('abc largest')
+          .wrapToWidth(result, 1, 15, false);
+        expect(result).toEqual(['\n', seq(cs.cha, 3), 'abc', ' largest']);
       });
 
       it('should omit styles', () => {
-        const str = new TerminalString(0);
         const result = new Array<string>();
-        str
+        new TerminalString(0)
           .splitText(`abc${style(tf.clear)} ${style(tf.clear)} def`)
           .wrapToWidth(result, 0, 10, false);
         expect(result).toEqual(['abc', ' def']);
       });
 
       it('should emit styles', () => {
-        const str = new TerminalString();
         const result = new Array<string>();
-        str
+        new TerminalString()
           .splitText(`abc${style(tf.clear)} ${style(tf.clear)} def`)
           .wrapToWidth(result, 0, 10, true);
         expect(result).toEqual(['abc' + style(tf.clear), style(tf.clear), ' def']);
       });
 
       it('should preserve emojis', () => {
-        const str = new TerminalString();
         const result = new Array<string>();
-        str.splitText('⚠️ abc').wrapToWidth(result, 0, 10, false);
+        new TerminalString().splitText('⚠️ abc').wrapToWidth(result, 0, 10, false);
         expect(result).toEqual(['⚠️', ' abc']);
       });
     });
@@ -371,8 +353,7 @@ describe('TerminalString', () => {
 
 describe('ErrorMessage', () => {
   it('should wrap the error message', () => {
-    const str = new TerminalString(0);
-    str.splitText('type script');
+    const str = new TerminalString(0).splitText('type script');
     const err = new ErrorMessage(str);
     expect(err.message).toMatch(/type script/);
     expect(err.wrap(0, false)).toEqual('type script');
@@ -382,21 +363,17 @@ describe('ErrorMessage', () => {
   });
 
   it('should be thrown and caught', () => {
-    const str = new TerminalString(0);
-    str.splitText('type script');
-    const err = new ErrorMessage(str);
+    const str = new TerminalString(0).splitText('type script');
     expect(() => {
-      throw err;
+      throw new ErrorMessage(str);
     }).toThrow('type script');
   });
 });
 
 describe('HelpMessage', () => {
   it('should wrap the help message', () => {
-    const str = new TerminalString(0);
-    str.splitText('type script');
-    const help = new HelpMessage();
-    help.push(str);
+    const str = new TerminalString(0).splitText('type script');
+    const help = new HelpMessage(str);
     expect(help.toString()).toMatch(/type script/);
     expect(help.wrap(0, false)).toEqual('type script');
     expect(help.wrap(0, true)).toEqual('type script' + style(tf.clear));

--- a/packages/tsargp/test/styles.spec.ts
+++ b/packages/tsargp/test/styles.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
-import { cs, tf, fg, bg, ul, seq, style, fg8, bg8, ul8 } from '../lib';
 import { TerminalString, ErrorMessage, HelpMessage } from '../lib';
+import { cs, tf, fg, bg, ul, seq, style, fg8, bg8, ul8 } from '../lib';
 
 describe('TerminalString', () => {
   describe('addStyle', () => {

--- a/packages/tsargp/test/utils.spec.ts
+++ b/packages/tsargp/test/utils.spec.ts
@@ -1,6 +1,6 @@
 import type { AsyncExpectationResult, MatcherState } from '@vitest/expect';
 import { describe, expect, it } from 'vitest';
-import { type ConcreteError, defaultConfig } from '../lib';
+import { type ConcreteError, defaultConfig } from '../lib/validator';
 import { checkRequiredArray, gestaltSimilarity, getArgs, splitPhrase, isTrue } from '../lib/utils';
 
 interface CustomMatchers<R = unknown> {

--- a/packages/tsargp/tsconfig.json
+++ b/packages/tsargp/tsconfig.json
@@ -4,6 +4,7 @@
     "types": ["bun"],
     "noEmit": false,
     "incremental": true,
+    "stripInternal": true,
     "allowImportingTsExtensions": false,
     "verbatimModuleSyntax": false, // https://github.com/microsoft/TypeScript/issues/40344
     "disableSourceOfProjectReferenceRedirect": true

--- a/packages/tsargp/typedoc.json
+++ b/packages/tsargp/typedoc.json
@@ -5,10 +5,5 @@
   "githubPages": false,
   "excludeExternals": true,
   "treatWarningsAsErrors": true,
-  "intentionallyNotExported": [
-    "ArrayDataType",
-    "DefaultDataType",
-    "DelimitedDataType",
-    "SingleDataType"
-  ]
+  "intentionallyNotExported": ["OptionDataType"]
 }

--- a/packages/tsargp/typedoc.json
+++ b/packages/tsargp/typedoc.json
@@ -6,23 +6,9 @@
   "excludeExternals": true,
   "treatWarningsAsErrors": true,
   "intentionallyNotExported": [
-    "Alias",
     "ArrayDataType",
-    "CSI",
-    "Decimal",
     "DefaultDataType",
     "DelimitedDataType",
-    "formatBoolean",
-    "formatNumber",
-    "formatOption",
-    "formatParam",
-    "formatRegExp",
-    "formatString",
-    "formatTerm",
-    "formatURL",
-    "Misc",
-    "Resolve",
-    "SingleDataType",
-    "Writable"
+    "SingleDataType"
   ]
 }


### PR DESCRIPTION
The `tsargp` package was refactored to remove unneeded exports, which reduced the footprint of the minified module by 0.36KB.

Some bindings were marked with the `@internal` tag, in order to strip them from the emitted declaration files. This also helped reduce the overall package size.

Control sequence enumerations have been unified into a single `ControlSequence`, and related functions for creating sequences have been unified into a single `seq` function. This did not affect the `Style` type nor the `style` function: they were preserved as specializations.

> [!NOTE]
> Henceforth, marking a type with the `@internal` tag will strip it from declaration files. This should be used with care: only use it for types that are not referenced by any other exported type.

Closes #44 
