### PR TITLE
Issues/10

### DIFF
--- a/.changeset/cool-dots-complain.md
+++ b/.changeset/cool-dots-complain.md
@@ -1,0 +1,5 @@
+---
+'@trulysimple/tsargp-docs': minor
+---
+
+The Options page was updated to document the new `requiredIf` attribute for valued options. An example was added in the respective section to explain the difference between this attribute and the traditional `requires`.

--- a/.changeset/nasty-mirrors-teach.md
+++ b/.changeset/nasty-mirrors-teach.md
@@ -2,4 +2,4 @@
 'tsargp': minor
 ---
 
-A new attribute called `requiredIf` was added to valued options, to indicate the option's conditional requirements. Similarly, a new enumerator was added to `HelpItem` to print this attribute in the help message. The same was done with the previously added `envVar` attribute, which had been forgotten. Both the parser and the formatter were updated to handle conditional option requirements.
+A new attribute called `requiredIf` was added to valued options, to indicate the option's conditional requirements. Similarly, a new enumerator was added to `HelpItem` to print this attribute in the help message. Both the parser and the formatter were updated to handle conditional option requirements.

--- a/.changeset/nasty-mirrors-teach.md
+++ b/.changeset/nasty-mirrors-teach.md
@@ -1,0 +1,5 @@
+---
+'tsargp': minor
+---
+
+A new attribute called `requiredIf` was added to valued options, to indicate the option's conditional requirements. Similarly, a new enumerator was added to `HelpItem` to print this attribute in the help message. The same was done with the previously added `envVar` attribute, which had been forgotten. Both the parser and the formatter were updated to handle conditional option requirements.

--- a/packages/docs/pages/docs/library/formatter.mdx
+++ b/packages/docs/pages/docs/library/formatter.mdx
@@ -162,6 +162,7 @@ description, and in what order. It is an array whose values can be one of the en
 - `deprecated` - reports if the option is deprecated, and why
 - `link` - the external resource reference, if any
 - `envVar` - the option's environment variable, if any
+- `requiredIf` - the option's conditional requirements, if any
 
 The default is to print all items in the order listed above.
 
@@ -192,6 +193,7 @@ and grouped in parentheses, as can be seen in the default values listed below:
 - `deprecated` - `'Deprecated for %s.'{:ts}`
 - `link` - `'Refer to %s for details.'{:ts}`
 - `envVar` - `'Can be specified through the %s environment variable.'{:ts}`
+- `requiredIf` - `'Required if %s.'{:ts}`
 
 These phrases will be formatted according to [text formatting](styles.mdx#text-splitting) rules.
 

--- a/packages/docs/pages/docs/library/options.mdx
+++ b/packages/docs/pages/docs/library/options.mdx
@@ -106,7 +106,8 @@ All option types that may have a value share a set of attributes, which are desc
 #### Always required
 
 The `required` attribute indicates that the option is _always_ required, regardless of other
-options. Mutually exclusive with [default value](#default-value--callback).
+options. Mutually exclusive with [default value](#default-value--callback) and
+[conditional requirements](#conditional-requirements).
 
 #### Default value | callback
 
@@ -165,17 +166,20 @@ You can also specify a callback, which accepts the following parameter:
 
 - `values` - the parsed values
 
-It should return `true{:ts}` if the requirements were satisfied, or `false{:ts}` otherwise. The
-callback may be configured with a custom `toString` method, that will be used when rendering this
-attribute in error and help messages.
+Notes about this callback:
+
+- it should return `true{:ts}` if the requirements were satisfied, or `false{:ts}` otherwise
+- it cannot be asynchronous, since it must be evaluated within the parsing loop
+- it may be configured with a custom `toString` method to render it in error and help messages
 
 #### Conditional requirements
 
-The `requiredIf` attribute, if present, specifies conditional requirements. They work like the
+The `requiredIf` attribute, if present, specifies conditional requirements. They behave like the
 reverse of the previous attribute: they indicate requirements that must be satisfied for the
-affected option to be _considered_ required.
+affected option to be _considered_ required. Mutually exclusive with
+[always required](#always-required).
 
-An example might help elucidate this difference. Suppose we have:
+An example might help elucidate this distinction. Suppose we have these requirements:
 
 ```ts
 req.all(
@@ -185,13 +189,13 @@ req.all(
 );
 ```
 
-If these requirements were defined in the `requires` attribute, they would mean:
+If they were defined in the `requires` attribute, they would mean:
 
 > _If this option is specified (either on the command-line or in an environment variable), then the
 > following must hold true: `option1` must be present AND (`option2` must be absent OR `option3`
 > must have a value different than `[2]`) AND `option1` must have the same value as `option3`._
 
-If these requirements were defined in the `requiredIf` attribute, they would mean:
+If they were defined in the `requiredIf` attribute, they would mean:
 
 > _If `option1` is present AND (`option2` is absent OR `option3` has a value different than `[2]`)
 > AND `option1` has the same value as `option3`, then this option is considered required and must be

--- a/packages/docs/pages/docs/library/options.mdx
+++ b/packages/docs/pages/docs/library/options.mdx
@@ -144,8 +144,9 @@ The `requires` attribute, if present, specifies requirements that must be satisf
 is specified on the command-line. It can be either:
 
 - an option key;
-- an object that maps option keys to required values; or
-- a requirement expression
+- an object that maps option keys to required values;
+- a requirement expression; or
+- a requirement callback
 
 In the case of an option key, the referenced option must also be present on the command-line.
 In the case of an object, every referenced option must have the corresponding value.
@@ -159,6 +160,40 @@ In the case of an expression, it is evaluated as follows:
   When an object is specified, `undefined{:ts}` values can be used to signify required _presence_,
   and `null{:ts}` values to signify required _absence_.
 </Callout>
+
+You can also specify a callback, which accepts the following parameter:
+
+- `values` - the parsed values
+
+It should return `true{:ts}` if the requirements were satisfied, or `false{:ts}` otherwise.
+
+#### Conditional requirements
+
+The `requiredIf` attribute, if present, specifies conditional requirements. They work like the
+reverse of the previous attribute: they indicate requirements that must be satisfied for the
+affected option to be _considered_ required.
+
+An example might help elucidate this difference. Suppose we have:
+
+```ts
+req.all(
+  'option1',
+  req.one({ option2: null }, req.not({ option3: [2] })),
+  (values) => values['option1'] === values['option3'],
+);
+```
+
+If these requirements were defined in the `requires` attribute, they would mean:
+
+> _If this option is specified (either on the command-line or in an environment variable), then the
+> following must hold true: `option1` must be present AND (`option2` must be absent OR `option3`
+> must have a value different than `[2]`) AND `option1` must have the same value as `option3`._
+
+If these requirements were defined in the `requiredIf` attribute, they would mean:
+
+> _If `option1` is present AND (`option2` is absent OR `option3` has a value different than `[2]`)
+> AND `option1` has the same value as `option3`, then this option is considered required and must be
+> specified (either on the command-line or in an environment variable)._
 
 <Callout type="info">
   During requirement evaluation, values are compared _after_ being normalized.

--- a/packages/docs/pages/docs/library/options.mdx
+++ b/packages/docs/pages/docs/library/options.mdx
@@ -165,7 +165,9 @@ You can also specify a callback, which accepts the following parameter:
 
 - `values` - the parsed values
 
-It should return `true{:ts}` if the requirements were satisfied, or `false{:ts}` otherwise.
+It should return `true{:ts}` if the requirements were satisfied, or `false{:ts}` otherwise. The
+callback may be configured with a custom `toString` method, that will be used when rendering this
+attribute in error and help messages.
 
 #### Conditional requirements
 

--- a/packages/docs/pages/docs/library/parser.mdx
+++ b/packages/docs/pages/docs/library/parser.mdx
@@ -104,6 +104,7 @@ parsing the argument that overlaps this position in the string.
 To understand how the parser supports asynchronous operations, we need to review the kinds of
 callbacks that an option definition may declare:
 
+- [requirement callback](options.mdx#forward-requirements)
 - Parsing callbacks
   - [default callback](options.mdx#default-value--callback)
   - [parse callback](options.mdx#parse-callback)
@@ -114,7 +115,8 @@ callbacks that an option definition may declare:
   - [execute callback](options.mdx#execute-callback)
   - [command callback](options.mdx#command-callback)
 
-All of these callbacks can be asynchronous, and are discussed below.
+Except for the requirement callback, all other callbacks can be asynchronous, and are discussed
+below.
 
 ### Parsing callbacks
 

--- a/packages/docs/pages/docs/library/validator.mdx
+++ b/packages/docs/pages/docs/library/validator.mdx
@@ -169,8 +169,6 @@ optional properties:
 The `ErrorItem` enumeration is a type that is used in the property described next. It lists the
 kinds of error messages that may be raised by the library:
 
-- `deprecatedOption` - warning saved by the parser when a deprecated option is specified on the
-  command-line
 - `parseError` - raised by the parser when an option parameter fails to be parsed
 - `parseErrorWithSimilar` - raised by the parser when an option parameter fails to be parsed, and
   there are option name suggestions
@@ -216,12 +214,13 @@ kinds of error messages that may be raised by the library:
   number option's range constraint
 - `arrayOptionLimit` - raised by either the parser or validator when a value fails to satisfy an
   array option's limit constraint
+- `deprecatedOption` - warning saved by the parser when a deprecated option is specified on the
+  command-line
 
 ### Error phrases
 
 The `phrases` property specifies the phrases to be used for each kind of error message:
 
-- `deprecatedOption` - `'Option %o is deprecated and may be removed in future releases.'{:ts}`
 - `parseError` - `'%t\n\nDid you mean to specify an option name instead of %o?'{:ts}`
 - `parseErrorWithSimilar` - `'%t\n\nDid you mean to specify an option name instead of %o1? Similar names are %o2.'{:ts}`
 - `unknownOption` - `'Unknown option %o.'{:ts}`
@@ -237,8 +236,8 @@ The `phrases` property specifies the phrases to be used for each kind of error m
 - `invalidOptionName` - `'Invalid option name %o.'{:ts}`
 - `optionEmptyVersion` - `'Option %o contains empty version.'{:ts}`
 - `optionRequiresItself` - `'Option %o requires itself.'{:ts}`
-- `unknownRequiredOption` - `'Unknown required option %o.'{:ts}`
-- `niladicOptionRequiredValue` - `'Required option %o does not accept values.'{:ts}`
+- `unknownRequiredOption` - `'Unknown option %o in requirement.'{:ts}`
+- `niladicOptionRequiredValue` - `'Option %o does not accept values.'{:ts}`
 - `optionZeroEnum` - `'Option %o has zero enum values.'{:ts}`
 - `duplicateOptionName` - `'Duplicate option name %o.'{:ts}`
 - `duplicatePositionalOption` - `'Duplicate positional option %o.'{:ts}`
@@ -250,6 +249,7 @@ The `phrases` property specifies the phrases to be used for each kind of error m
 - `numberOptionEnums` - `'Invalid parameter to %o: %n1. Possible values are %n2.'{:ts}`
 - `numberOptionRange` - `'Invalid parameter to %o: %n1. Value must be in the range %n2.'{:ts}`
 - `arrayOptionLimit` - `'Option %o has too many values (%n1). Should have at most %n2.'{:ts}`
+- `deprecatedOption` - `'Option %o is deprecated and may be removed in future releases.'{:ts}`
 
 These phrases will be formatted according to [text formatting](styles.mdx#text-splitting) rules.
 
@@ -272,7 +272,6 @@ description of the corresponding value.
 
 | Error                      | Specifiers                                                                      |
 | -------------------------- | ------------------------------------------------------------------------------- |
-| deprecatedOption           | `%o` = the specified option name                                                |
 | parseError                 | `%t` = the previous error message; `%o` = the unknown option name               |
 | parseErrorWithSimilar      | same as above, except `%o` is `%o1` and `%o2` = similar option names            |
 | unknownOption              | `%o` = the unknown option name                                                  |
@@ -301,3 +300,4 @@ description of the corresponding value.
 | numberOptionEnums          | `%o` = the option key or name; `%n1` = the specified value; `%n2` = the enums   |
 | numberOptionRange          | `%o` = the option key or name; `%n1` = the specified value; `%n2` = the range   |
 | arrayOptionLimit           | `%o` = the option key or name; `%n1` = the value count; `%n2` = the count limit |
+| deprecatedOption           | `%o` = the specified option name                                                |

--- a/packages/docs/pages/docs/library/validator.mdx
+++ b/packages/docs/pages/docs/library/validator.mdx
@@ -102,16 +102,15 @@ the restrictions listed below.
 
 #### Option requiring itself
 
-An option must not declare a requirement that includes its _own_ option key.
+An option must not declare a requirement that references itself.
 
 #### Unknown required option
 
-An option must not declare a requirement that includes an _unknown_ option key.
+An option must not declare a requirement that references an _unknown_ option.
 
-#### Niladic option required with a value
+#### Invalid required option
 
-An option must not declare a requirement that includes an option key referencing a _niladic_ option,
-if it includes a required value that is neither `undefined{:ts}` nor `null{:ts}`.
+An option must not declare a requirement that references a _non-valued_ option.
 
 #### Incompatible required value data type
 
@@ -197,8 +196,7 @@ kinds of error messages that may be raised by the library:
 - `optionEmptyVersion` - raised by the validator when a version option has an empty version string
 - `optionRequiresItself` - raised by the validator when an option requires itself
 - `unknownRequiredOption` - raised by the validator when an option requires an unknown option
-- `niladicOptionRequiredValue` - raised by the validator when an option requires a niladic option
-  with a value
+- `invalidRequiredOption` - raised by the validator when an option requires a non-valued option
 - `optionZeroEnum` - raised by the validator when an option has a zero-length enumeration array
 - `duplicateOptionName` - raised by the validator when an option has a duplicate name
 - `duplicatePositionalOption` - raised by the validator when there are two or more positional
@@ -242,7 +240,7 @@ The `phrases` property specifies the phrases to be used for each kind of error m
 - `optionEmptyVersion` - `'Option %o contains empty version.'{:ts}`
 - `optionRequiresItself` - `'Option %o requires itself.'{:ts}`
 - `unknownRequiredOption` - `'Unknown option %o in requirement.'{:ts}`
-- `niladicOptionRequiredValue` - `'Option %o does not accept values.'{:ts}`
+- `invalidRequiredOption` - `'Non-valued option %o in requirement.'{:ts}`
 - `optionZeroEnum` - `'Option %o has zero enum values.'{:ts}`
 - `duplicateOptionName` - `'Duplicate option name %o.'{:ts}`
 - `duplicatePositionalOption` - `'Duplicate positional option %o.'{:ts}`
@@ -275,34 +273,34 @@ Specifiers may end with a single digit that represents a specific value in the e
 following table lists the available specifiers for each kind of error message, along with a
 description of the corresponding value.
 
-| Error                      | Specifiers                                                                      |
-| -------------------------- | ------------------------------------------------------------------------------- |
-| parseError                 | `%t` = the previous error message; `%o` = the unknown option name               |
-| parseErrorWithSimilar      | same as above, except `%o` is `%o1` and `%o2` = similar option names            |
-| unknownOption              | `%o` = the unknown option name                                                  |
-| unknownOptionWithSimilar   | same as above, except `%o` is `%o1` and `%o2` = similar option names            |
-| optionRequires             | `%o` = the specified option name; `%t` = the option requirements                |
-| missingRequiredOption      | `%o` = the option's preferred name                                              |
-| missingParameter           | `%o` = the specified option name                                                |
-| missingPackageJson         |                                                                                 |
-| positionalInlineValue      | `%o` = the positional marker                                                    |
-| optionInlineValue          | `%o` = the specified option name                                                |
-| emptyPositionalMarker      | `%o` = the option key                                                           |
-| optionWithNoName           | `%o` = the option key                                                           |
-| invalidOptionName          | `%o` = the option name                                                          |
-| optionEmptyVersion         | `%o` = the option key                                                           |
-| optionRequiresItself       | `%o` = the option key                                                           |
-| unknownRequiredOption      | `%o` = the required option key                                                  |
-| niladicOptionRequiredValue | `%o` = the required option key                                                  |
-| optionZeroEnum             | `%o` = the option key                                                           |
-| duplicateOptionName        | `%o` = the option name                                                          |
-| duplicatePositionalOption  | `%o` = the option key                                                           |
-| duplicateStringOptionEnum  | `%o` = the option key; `%s` = the duplicate enum value                          |
-| duplicateNumberOptionEnum  | `%o` = the option key; `%n` = the duplicate enum value                          |
-| optionValueIncompatible    | `%o` = the option key; `%p` = the incompatible value; `%s` = the expected type  |
-| stringOptionEnums          | `%o` = the option key or name; `%s1` = the specified value; `%s2` = the enums   |
-| stringOptionRegex          | `%o` = the option key or name; `%s` = the specified value; `%r` = the regex     |
-| numberOptionEnums          | `%o` = the option key or name; `%n1` = the specified value; `%n2` = the enums   |
-| numberOptionRange          | `%o` = the option key or name; `%n1` = the specified value; `%n2` = the range   |
-| arrayOptionLimit           | `%o` = the option key or name; `%n1` = the value count; `%n2` = the count limit |
-| deprecatedOption           | `%o` = the specified option name                                                |
+| Error                     | Specifiers                                                                      |
+| ------------------------- | ------------------------------------------------------------------------------- |
+| parseError                | `%t` = the previous error message; `%o` = the unknown option name               |
+| parseErrorWithSimilar     | same as above, except `%o` is `%o1` and `%o2` = similar option names            |
+| unknownOption             | `%o` = the unknown option name                                                  |
+| unknownOptionWithSimilar  | same as above, except `%o` is `%o1` and `%o2` = similar option names            |
+| optionRequires            | `%o` = the specified option name; `%t` = the option requirements                |
+| missingRequiredOption     | `%o` = the option's preferred name                                              |
+| missingParameter          | `%o` = the specified option name                                                |
+| missingPackageJson        |                                                                                 |
+| positionalInlineValue     | `%o` = the positional marker                                                    |
+| optionInlineValue         | `%o` = the specified option name                                                |
+| emptyPositionalMarker     | `%o` = the option key                                                           |
+| optionWithNoName          | `%o` = the option key                                                           |
+| invalidOptionName         | `%o` = the option name                                                          |
+| optionEmptyVersion        | `%o` = the option key                                                           |
+| optionRequiresItself      | `%o` = the option key                                                           |
+| unknownRequiredOption     | `%o` = the required option key                                                  |
+| invalidRequiredOption     | `%o` = the required option key                                                  |
+| optionZeroEnum            | `%o` = the option key                                                           |
+| duplicateOptionName       | `%o` = the option name                                                          |
+| duplicatePositionalOption | `%o` = the option key                                                           |
+| duplicateStringOptionEnum | `%o` = the option key; `%s` = the duplicate enum value                          |
+| duplicateNumberOptionEnum | `%o` = the option key; `%n` = the duplicate enum value                          |
+| optionValueIncompatible   | `%o` = the option key; `%p` = the incompatible value; `%s` = the expected type  |
+| stringOptionEnums         | `%o` = the option key or name; `%s1` = the specified value; `%s2` = the enums   |
+| stringOptionRegex         | `%o` = the option key or name; `%s` = the specified value; `%r` = the regex     |
+| numberOptionEnums         | `%o` = the option key or name; `%n1` = the specified value; `%n2` = the enums   |
+| numberOptionRange         | `%o` = the option key or name; `%n1` = the specified value; `%n2` = the range   |
+| arrayOptionLimit          | `%o` = the option key or name; `%n1` = the value count; `%n2` = the count limit |
+| deprecatedOption          | `%o` = the specified option name                                                |

--- a/packages/docs/pages/docs/library/validator.mdx
+++ b/packages/docs/pages/docs/library/validator.mdx
@@ -92,8 +92,13 @@ normalized.
 
 ### Requirements validation
 
-When an option declares that it requires other options, these requirements are subject to the
-restrictions listed below.
+When an option declares requirements referencing other options, these requirements are subject to
+the restrictions listed below.
+
+<Callout type="info">
+  This does not apply to [requirement callbacks](options.mdx#forward-requirements). They are ignored
+  during validation.
+</Callout>
 
 #### Option requiring itself
 

--- a/packages/tsargp/lib/enums.ts
+++ b/packages/tsargp/lib/enums.ts
@@ -82,9 +82,9 @@ export const enum ErrorItem {
    */
   unknownRequiredOption,
   /**
-   * Raised by the validator when an option requires a niladic option with a value.
+   * Raised by the validator when an option requires a non-valued option.
    */
-  niladicOptionRequiredValue,
+  invalidRequiredOption,
   /**
    * Raised by the validator when an option has a zero-length enumeration array.
    */

--- a/packages/tsargp/lib/enums.ts
+++ b/packages/tsargp/lib/enums.ts
@@ -138,6 +138,10 @@ export const enum ErrorItem {
    * Warning saved by the parser when a deprecated option is specified on the command-line.
    */
   deprecatedOption,
+  /**
+   * Raised by the parser when a conditional option requirement is not satisfied.
+   */
+  optionRequiredIf,
 }
 
 /**
@@ -224,6 +228,10 @@ export const enum HelpItem {
    * The option's environment variable, if any.
    */
   envVar,
+  /**
+   * The option's conditional requirements, if any.
+   */
+  requiredIf,
 }
 
 /**

--- a/packages/tsargp/lib/formatter.ts
+++ b/packages/tsargp/lib/formatter.ts
@@ -1076,7 +1076,7 @@ function formatRequirements(
     if (negate) {
       result.addWord('not');
     }
-    formatFunctions.p('fcn', styles, style, result);
+    formatFunctions.p(requires, styles, style, result);
   }
 }
 

--- a/packages/tsargp/lib/formatter.ts
+++ b/packages/tsargp/lib/formatter.ts
@@ -504,7 +504,6 @@ function getNameWidths(options: Options): Array<number> {
  * @param styles The set of styles
  * @param style The style to revert to
  * @param inDesc True if in the description
- * @returns Nothing
  */
 function formatValue(
   option: ValuedOption,
@@ -516,15 +515,18 @@ function formatValue(
 ) {
   switch (typeof value) {
     case 'boolean':
-      return formatFunctions.b(value, styles, style, result);
+      formatFunctions.b(value, styles, style, result);
+      break;
     case 'string':
-      return formatFunctions.s(value, styles, style, result);
+      formatFunctions.s(value, styles, style, result);
+      break;
     case 'number':
-      return formatFunctions.n(value, styles, style, result);
+      formatFunctions.n(value, styles, style, result);
+      break;
     default:
       if (isArray(option) && Array.isArray(value)) {
         const formatFn = option.type === 'strings' ? formatFunctions.s : formatFunctions.n;
-        return formatArray(option, value, result, styles, formatFn, style, inDesc);
+        formatArray(option, value, result, styles, formatFn, style, inDesc);
       } else if (value !== undefined) {
         formatFunctions.p(value, styles, style, result);
       }

--- a/packages/tsargp/lib/options.ts
+++ b/packages/tsargp/lib/options.ts
@@ -98,10 +98,18 @@ export type RequiresVal = { [key: string]: ParamOption['example'] | null };
  * An option requirement can be either:
  *
  * - an option key;
- * - an object that maps option keys to required values; or
- * - a requirement expression.
+ * - an object that maps option keys to required values;
+ * - a requirement expression; or
+ * - a requirement callback
  */
-export type Requires = string | RequiresVal | RequiresExp;
+export type Requires = string | RequiresVal | RequiresExp | RequiresCallback;
+
+/**
+ * A callback to check option requirements.
+ * @param values The option values
+ * @returns True if the requirements were satisfied
+ */
+export type RequiresCallback = (values: OptionValues) => boolean;
 
 /**
  * A callback to parse the value of option parameters. Any specified normalization or constraint
@@ -221,6 +229,10 @@ export type WithRequired = {
    * @deprecated mutually exclusive with {@link WithRequired.required}
    */
   readonly default?: never;
+  /**
+   * @deprecated mutually exclusive with {@link WithRequired.required}
+   */
+  readonly requiredIf?: never;
 };
 
 /**
@@ -236,10 +248,15 @@ export type WithDefault<T> = {
    * based on those values.
    */
   readonly default?: T | DefaultCallback<T>;
+  /**
+   * The conditional requirements.
+   */
+  readonly requiredIf?: Requires;
   // TODO: change link to WithDefault.default once this is resolved:
   // https://github.com/TypeStrong/typedoc/issues/2524
   /**
-   * @deprecated mutually exclusive with {@link WithDefault['default']}
+   * @deprecated mutually exclusive with {@link WithDefault['default']} and
+   * {@link WithDefault['requiredIf']}
    */
   readonly required?: never;
 };

--- a/packages/tsargp/lib/parser.ts
+++ b/packages/tsargp/lib/parser.ts
@@ -550,7 +550,7 @@ class ParserLoop {
         error.addWord('not');
       }
       const styles = this.validator.config.styles;
-      formatFunctions.p('fcn', styles, styles.text, error);
+      formatFunctions.p(requires, styles, styles.text, error);
       return false;
     }
     return true;

--- a/packages/tsargp/lib/parser.ts
+++ b/packages/tsargp/lib/parser.ts
@@ -488,9 +488,15 @@ class ParserLoop {
           this.specifiedKeys.add(key); // need this for checking requirements in the second loop
           continue;
         }
+        const name = option.preferredName ?? '';
         if ('required' in option && option.required) {
-          const name = option.preferredName ?? '';
           throw this.validator.error(ErrorItem.missingRequiredOption, { o: name });
+        }
+        if ('requiredIf' in option && option.requiredIf) {
+          const error = new TerminalString();
+          if (!this.checkRequires(option.requiredIf, error, true, true)) {
+            throw this.validator.error(ErrorItem.optionRequiredIf, { o: name, t: error });
+          }
         }
         if ('default' in option) {
           setDefaultValue(this.validator, this.values, key, option);
@@ -501,7 +507,7 @@ class ParserLoop {
       const option = this.validator.options[key];
       if ('requires' in option && option.requires) {
         const error = new TerminalString();
-        if (!this.checkRequires(option.requires, error)) {
+        if (!this.checkRequires(option.requires, error, false, false)) {
           const name = option.preferredName ?? '';
           throw this.validator.error(ErrorItem.optionRequires, { o: name, t: error });
         }
@@ -514,23 +520,40 @@ class ParserLoop {
    * @param requires The option requirements
    * @param error The terminal string error
    * @param negate True if the requirements should be negated
-   * @returns True if the requirement was satisfied
+   * @param invert True if the requirements should be inverted
+   * @returns True if the requirements were satisfied
    */
-  private checkRequires(requires: Requires, error: TerminalString, negate = false): boolean {
+  private checkRequires(
+    requires: Requires,
+    error: TerminalString,
+    negate: boolean,
+    invert: boolean,
+  ): boolean {
     if (typeof requires === 'string') {
-      return this.checkRequirement([requires, undefined], error, negate);
+      return this.checkRequirement([requires, undefined], error, negate, invert);
     }
     if (requires instanceof RequiresNot) {
-      return this.checkRequires(requires.item, error, !negate);
+      return this.checkRequires(requires.item, error, !negate, invert);
     }
     if (requires instanceof RequiresAll || requires instanceof RequiresOne) {
       const and = requires instanceof RequiresAll !== negate;
       const itemFn = this.checkRequires.bind(this);
-      return checkRequireItems(requires.items, itemFn, error, negate, and);
+      return checkRequireItems(requires.items, itemFn, error, negate, invert, and);
     }
-    const entries = Object.entries(requires);
-    const itemFn = this.checkRequirement.bind(this);
-    return checkRequireItems(entries, itemFn, error, negate, !negate);
+    if (typeof requires === 'object') {
+      const entries = Object.entries(requires);
+      const itemFn = this.checkRequirement.bind(this);
+      return checkRequireItems(entries, itemFn, error, negate, invert, !negate);
+    }
+    if (requires(this.values) == negate) {
+      if (negate != invert) {
+        error.addWord('not');
+      }
+      const styles = this.validator.config.styles;
+      formatFunctions.p('fcn', styles, styles.text, error);
+      return false;
+    }
+    return true;
   }
 
   /**
@@ -538,12 +561,14 @@ class ParserLoop {
    * @param kvp The required option key and value
    * @param error The terminal string error
    * @param negate True if the requirement should be negated
+   * @param invert True if the requirements should be inverted
    * @returns True if the requirement was satisfied
    */
   private checkRequirement(
     kvp: [key: string, value: RequiresVal[string]],
     error: TerminalString,
     negate: boolean,
+    invert: boolean,
   ): boolean {
     const [key, value] = kvp;
     const option = this.validator.options[key];
@@ -553,7 +578,7 @@ class ParserLoop {
       if ((specified == required) != negate) {
         return true;
       }
-      if (specified) {
+      if (specified != invert) {
         error.addWord('no');
       }
       const name = option.preferredName ?? '';
@@ -561,7 +586,16 @@ class ParserLoop {
       formatFunctions.o(name, styles, styles.text, error);
       return false;
     }
-    return checkRequiredValue(this.validator, this.values, option, negate, key, value, error);
+    return checkRequiredValue(
+      this.validator,
+      this.values,
+      option,
+      negate,
+      invert,
+      key,
+      value,
+      error,
+    );
   }
 }
 
@@ -831,14 +865,16 @@ function handleNameCompletion(validator: OptionValidator, prefix?: string): neve
  * @param itemFn The callback to execute on each item
  * @param error The terminal string error
  * @param negate True if the requirement should be negated
+ * @param invert True if the requirements should be inverted
  * @param and If true, return on the first error; else return on the first success
  * @returns True if the requirement was satisfied
  */
 function checkRequireItems<T>(
   items: Array<T>,
-  itemFn: (item: T, error: TerminalString, negate: boolean) => boolean,
+  itemFn: (item: T, error: TerminalString, negate: boolean, invert: boolean) => boolean,
   error: TerminalString,
   negate: boolean,
+  invert: boolean,
   and: boolean,
 ): boolean {
   if (!and && items.length > 1) {
@@ -849,9 +885,9 @@ function checkRequireItems<T>(
     if (and || first) {
       first = false;
     } else {
-      error.addWord('or');
+      error.addWord(invert ? 'and' : 'or');
     }
-    const success = itemFn(item, error, negate);
+    const success = itemFn(item, error, negate, invert);
     if (success !== and) {
       return success;
     }
@@ -1075,6 +1111,7 @@ function resetValue(values: OptionValues, key: string, option: ArrayOption) {
  * @param values The option values
  * @param option The option definition
  * @param negate True if the requirement should be negated
+ * @param invert True if the requirements should be inverted
  * @param key The required option key
  * @param value The required value
  * @param error The terminal string error
@@ -1086,6 +1123,7 @@ function checkSingle<T extends boolean | string | number>(
   values: OptionValues,
   option: SingleOption,
   negate: boolean,
+  invert: boolean,
   key: string,
   value: T,
   error: TerminalString,
@@ -1102,7 +1140,7 @@ function checkSingle<T extends boolean | string | number>(
   }
   const styles = validator.config.styles;
   formatFunctions.o(name, styles, styles.text, error);
-  error.addWord(negate ? '!=' : '=');
+  error.addWord(negate != invert ? '!=' : '=');
   formatFn(expected, styles, styles.text, error);
   return false;
 }
@@ -1114,6 +1152,7 @@ function checkSingle<T extends boolean | string | number>(
  * @param values The option values
  * @param option The option definition
  * @param negate True if the requirement should be negated
+ * @param invert True if the requirements should be inverted
  * @param key The required option key
  * @param value The required value
  * @param error The terminal string error
@@ -1125,6 +1164,7 @@ function checkArray<T extends string | number>(
   values: OptionValues,
   option: ArrayOption,
   negate: boolean,
+  invert: boolean,
   key: string,
   value: ReadonlyArray<T>,
   error: TerminalString,
@@ -1141,7 +1181,7 @@ function checkArray<T extends string | number>(
   }
   const styles = validator.config.styles;
   formatFunctions.o(name, styles, styles.text, error);
-  error.addWord(negate ? '!=' : '=').addOpening('[');
+  error.addWord(negate != invert ? '!=' : '=').addOpening('[');
   expected.forEach((val, i) => {
     formatFn(val, styles, styles.text, error);
     if (i < expected.length - 1) {
@@ -1158,6 +1198,7 @@ function checkArray<T extends string | number>(
  * @param values The option values
  * @param option The option definition
  * @param negate True if the requirement should be negated
+ * @param invert True if the requirements should be inverted
  * @param key The required option key (to get the specified value)
  * @param value The required value
  * @param error The terminal string error
@@ -1168,6 +1209,7 @@ function checkRequiredValue(
   values: OptionValues,
   option: ParamOption,
   negate: boolean,
+  invert: boolean,
   key: string,
   value: Exclude<RequiresVal[string], undefined | null>,
   error: TerminalString,
@@ -1180,7 +1222,7 @@ function checkRequiredValue(
         ? formatFunctions.s
         : formatFunctions.n;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  return (checkFn as any)(validator, values, option, negate, key, value, error, formatFn);
+  return (checkFn as any)(validator, values, option, negate, invert, key, value, error, formatFn);
 }
 
 /**

--- a/packages/tsargp/lib/validator.ts
+++ b/packages/tsargp/lib/validator.ts
@@ -96,8 +96,8 @@ export const defaultConfig: ConcreteError = {
     [ErrorItem.invalidOptionName]: 'Invalid option name %o.',
     [ErrorItem.optionEmptyVersion]: 'Option %o contains empty version.',
     [ErrorItem.optionRequiresItself]: 'Option %o requires itself.',
-    [ErrorItem.unknownRequiredOption]: 'Unknown required option %o.',
-    [ErrorItem.niladicOptionRequiredValue]: 'Required option %o does not accept values.',
+    [ErrorItem.unknownRequiredOption]: 'Unknown option %o in requirement.',
+    [ErrorItem.niladicOptionRequiredValue]: 'Option %o does not accept values.',
     [ErrorItem.optionZeroEnum]: 'Option %o has zero enum values.',
     [ErrorItem.duplicateOptionName]: 'Duplicate option name %o.',
     [ErrorItem.duplicatePositionalOption]: 'Duplicate positional option %o.',
@@ -111,6 +111,7 @@ export const defaultConfig: ConcreteError = {
     [ErrorItem.numberOptionRange]: 'Invalid parameter to %o: %n1. Value must be in the range %n2.',
     [ErrorItem.arrayOptionLimit]: 'Option %o has too many values (%n1). Should have at most %n2.',
     [ErrorItem.deprecatedOption]: 'Option %o is deprecated and may be removed in future releases.',
+    [ErrorItem.optionRequiredIf]: 'Option %o is required if %t.',
   },
 };
 
@@ -297,6 +298,9 @@ export class OptionValidator {
       if ('requires' in option && option.requires) {
         this.validateRequirements(key, option.requires);
       }
+      if ('requiredIf' in option && option.requiredIf) {
+        this.validateRequirements(key, option.requiredIf);
+      }
       if (option.type === 'version' && option.version === '') {
         throw this.error(ErrorItem.optionEmptyVersion, { o: key });
       }
@@ -318,7 +322,7 @@ export class OptionValidator {
       for (const item of requires.items) {
         this.validateRequirements(key, item);
       }
-    } else {
+    } else if (typeof requires === 'object') {
       for (const requiredKey in requires) {
         this.validateRequirement(key, requiredKey, requires[requiredKey]);
       }

--- a/packages/tsargp/test/formatter/formatter.default.spec.ts
+++ b/packages/tsargp/test/formatter/formatter.default.spec.ts
@@ -94,6 +94,20 @@ describe('HelpFormatter', () => {
       );
     });
 
+    it('should handle a flag option with a default callback with a toString method', () => {
+      const options = {
+        flag: {
+          type: 'flag',
+          names: ['-f', '--flag'],
+          desc: 'A flag option.',
+          default: () => true,
+        },
+      } as const satisfies Options;
+      options.flag.default.toString = () => 'fcn';
+      const message = new HelpFormatter(new OptionValidator(options)).formatHelp();
+      expect(message.wrap()).toEqual('  -f, --flag    A flag option. Defaults to <fcn>.\n');
+    });
+
     it('should handle a boolean option with a default value', () => {
       const options = {
         boolean: {

--- a/packages/tsargp/test/formatter/formatter.requirements.spec.ts
+++ b/packages/tsargp/test/formatter/formatter.requirements.spec.ts
@@ -4,7 +4,7 @@ import '../utils.spec'; // initialize globals
 
 describe('HelpFormatter', () => {
   describe('formatHelp', () => {
-    it('should handle an option that requires the presence of another', () => {
+    it('should handle an option that requires the presence of another (1)', () => {
       const options = {
         flag: {
           type: 'flag',
@@ -40,7 +40,7 @@ describe('HelpFormatter', () => {
       expect(message.wrap()).toEqual('  -f, --flag    A flag option. Requires -req.\n');
     });
 
-    it('should handle an option that requires the absence of another', () => {
+    it('should handle an option that requires the absence of another (1)', () => {
       const options = {
         flag: {
           type: 'flag',
@@ -94,7 +94,7 @@ describe('HelpFormatter', () => {
       expect(message.wrap()).toEqual(`  -f, --flag    A flag option. Requires -req = 'abc'.\n`);
     });
 
-    it('should handle an option with a requirement expression', () => {
+    it('should handle an option with a forward requirement expression', () => {
       const options = {
         flag: {
           type: 'flag',
@@ -124,7 +124,7 @@ describe('HelpFormatter', () => {
       );
     });
 
-    it('should handle an option with a requirement callback', () => {
+    it('should handle an option with a forward requirement callback', () => {
       const options = {
         flag: {
           type: 'flag',
@@ -138,7 +138,7 @@ describe('HelpFormatter', () => {
       expect(message.wrap()).toEqual(`  -f, --flag    A flag option. Requires <fcn>.\n`);
     });
 
-    it('should handle an option with a negated requirement callback', () => {
+    it('should handle an option with a negated forward requirement callback', () => {
       const options = {
         flag: {
           type: 'flag',
@@ -152,7 +152,7 @@ describe('HelpFormatter', () => {
       expect(message.wrap()).toEqual(`  -f, --flag    A flag option. Requires not <fcn>.\n`);
     });
 
-    it('should handle an option that is required if another is present', () => {
+    it('should handle an option that is required if another is present (1)', () => {
       const options = {
         flag: {
           type: 'flag',
@@ -188,7 +188,7 @@ describe('HelpFormatter', () => {
       expect(message.wrap()).toEqual('  -f, --flag    A flag option. Required if -req.\n');
     });
 
-    it('should handle an option that is required if another is absent', () => {
+    it('should handle an option that is required if another is absent (1)', () => {
       const options = {
         flag: {
           type: 'flag',

--- a/packages/tsargp/test/formatter/formatter.requires.spec.ts
+++ b/packages/tsargp/test/formatter/formatter.requires.spec.ts
@@ -123,7 +123,35 @@ describe('HelpFormatter', () => {
         `  -f, --flag    A flag option. Requires (-req1 and (-req2 = 1 or -req3 != '2')).\n`,
       );
     });
-    
+
+    it('should handle an option with a requirement callback', () => {
+      const options = {
+        flag: {
+          type: 'flag',
+          names: ['-f', '--flag'],
+          desc: 'A flag option.',
+          requires: () => true,
+        },
+      } as const satisfies Options;
+      options.flag.requires.toString = () => 'fcn';
+      const message = new HelpFormatter(new OptionValidator(options)).formatHelp();
+      expect(message.wrap()).toEqual(`  -f, --flag    A flag option. Requires <fcn>.\n`);
+    });
+
+    it('should handle an option with a negated requirement callback', () => {
+      const options = {
+        flag: {
+          type: 'flag',
+          names: ['-f', '--flag'],
+          desc: 'A flag option.',
+          requires: req.not(() => true),
+        },
+      } as const satisfies Options;
+      options.flag.requires.item.toString = () => 'fcn';
+      const message = new HelpFormatter(new OptionValidator(options)).formatHelp();
+      expect(message.wrap()).toEqual(`  -f, --flag    A flag option. Requires not <fcn>.\n`);
+    });
+
     it('should handle an option that is required if another is present', () => {
       const options = {
         flag: {
@@ -211,9 +239,7 @@ describe('HelpFormatter', () => {
         },
       } as const satisfies Options;
       const message = new HelpFormatter(new OptionValidator(options)).formatHelp();
-      expect(message.wrap()).toEqual(
-        `  -f, --flag    A flag option. Required if -req = 'abc'.\n`,
-      );
+      expect(message.wrap()).toEqual(`  -f, --flag    A flag option. Required if -req = 'abc'.\n`);
     });
 
     it('should handle an option with a conditional requirement expression', () => {
@@ -255,6 +281,7 @@ describe('HelpFormatter', () => {
           requiredIf: () => true,
         },
       } as const satisfies Options;
+      options.flag.requiredIf.toString = () => 'fcn';
       const message = new HelpFormatter(new OptionValidator(options)).formatHelp();
       expect(message.wrap()).toEqual(`  -f, --flag    A flag option. Required if <fcn>.\n`);
     });
@@ -268,6 +295,7 @@ describe('HelpFormatter', () => {
           requiredIf: req.not(() => true),
         },
       } as const satisfies Options;
+      options.flag.requiredIf.item.toString = () => 'fcn';
       const message = new HelpFormatter(new OptionValidator(options)).formatHelp();
       expect(message.wrap()).toEqual(`  -f, --flag    A flag option. Required if not <fcn>.\n`);
     });

--- a/packages/tsargp/test/parser/parser.requirements.spec.ts
+++ b/packages/tsargp/test/parser/parser.requirements.spec.ts
@@ -4,38 +4,6 @@ import '../utils.spec'; // initialize globals
 
 describe('ArgumentParser', () => {
   describe('parse', () => {
-    it('should throw an error on option with a value different than required', () => {
-      const options = {
-        requires: {
-          type: 'flag',
-          names: ['-f'],
-          requires: { required: false },
-        },
-        required: {
-          type: 'boolean',
-          names: ['-b'],
-        },
-      } as const satisfies Options;
-      const parser = new ArgumentParser(options);
-      expect(() => parser.parse(['-f', '-b', '1'])).toThrow(/Option -f requires -b = false\./);
-    });
-
-    it('should throw an error on option with a value equal to required when negated', () => {
-      const options = {
-        requires: {
-          type: 'flag',
-          names: ['-f'],
-          requires: req.not({ required: false }),
-        },
-        required: {
-          type: 'boolean',
-          names: ['-b'],
-        },
-      } as const satisfies Options;
-      const parser = new ArgumentParser(options);
-      expect(() => parser.parse(['-f', '-b', '0'])).toThrow(/Option -f requires -b != false\./);
-    });
-
     it('should ignore required value on option when using an async custom parse', () => {
       const options = {
         requires: {
@@ -51,38 +19,6 @@ describe('ArgumentParser', () => {
       } as const satisfies Options;
       const parser = new ArgumentParser(options);
       expect(() => parser.parse(['-f', '-b', '1'])).not.toThrow();
-    });
-
-    it('should throw an error on string option with a value different than required', () => {
-      const options = {
-        requires: {
-          type: 'flag',
-          names: ['-f'],
-          requires: { required: '0' },
-        },
-        required: {
-          type: 'string',
-          names: ['-s'],
-        },
-      } as const satisfies Options;
-      const parser = new ArgumentParser(options);
-      expect(() => parser.parse(['-f', '-s', '1'])).toThrow(/Option -f requires -s = '0'\./);
-    });
-
-    it('should throw an error on string option with a value equal to required when negated', () => {
-      const options = {
-        requires: {
-          type: 'flag',
-          names: ['-f'],
-          requires: req.not({ required: '0' }),
-        },
-        required: {
-          type: 'string',
-          names: ['-s'],
-        },
-      } as const satisfies Options;
-      const parser = new ArgumentParser(options);
-      expect(() => parser.parse(['-f', '-s', '0'])).toThrow(/Option -f requires -s != '0'\./);
     });
 
     it('should ignore required value on string option when using an async custom parse', () => {
@@ -102,38 +38,6 @@ describe('ArgumentParser', () => {
       expect(() => parser.parse(['-f', '-s', '1'])).not.toThrow();
     });
 
-    it('should throw an error on number option with a value different than required', () => {
-      const options = {
-        requires: {
-          type: 'flag',
-          names: ['-f'],
-          requires: { required: 0 },
-        },
-        required: {
-          type: 'number',
-          names: ['-n'],
-        },
-      } as const satisfies Options;
-      const parser = new ArgumentParser(options);
-      expect(() => parser.parse(['-f', '-n', '1'])).toThrow(/Option -f requires -n = 0\./);
-    });
-
-    it('should throw an error on number option with a value equal to required when negated', () => {
-      const options = {
-        requires: {
-          type: 'flag',
-          names: ['-f'],
-          requires: req.not({ required: 0 }),
-        },
-        required: {
-          type: 'number',
-          names: ['-n'],
-        },
-      } as const satisfies Options;
-      const parser = new ArgumentParser(options);
-      expect(() => parser.parse(['-f', '-n', '0'])).toThrow(/Option -f requires -n != 0\./);
-    });
-
     it('should ignore required value on number option when using an async custom parse', () => {
       const options = {
         requires: {
@@ -151,42 +55,6 @@ describe('ArgumentParser', () => {
       expect(() => parser.parse(['-f', '-n', '1'])).not.toThrow();
     });
 
-    it('should throw an error on strings option with a value different than required', () => {
-      const options = {
-        requires: {
-          type: 'flag',
-          names: ['-f'],
-          requires: { required: ['0', '1'] },
-        },
-        required: {
-          type: 'strings',
-          names: ['-ss'],
-        },
-      } as const satisfies Options;
-      const parser = new ArgumentParser(options);
-      expect(() => parser.parse(['-f', '-ss', '1'])).toThrow(
-        /Option -f requires -ss = \['0', '1'\]\./,
-      );
-    });
-
-    it('should throw an error on strings option with a value equal to required when negated', () => {
-      const options = {
-        requires: {
-          type: 'flag',
-          names: ['-f'],
-          requires: req.not({ required: ['0', '1'] }),
-        },
-        required: {
-          type: 'strings',
-          names: ['-ss'],
-        },
-      } as const satisfies Options;
-      const parser = new ArgumentParser(options);
-      expect(() => parser.parse(['-f', '-ss', '0', '1'])).toThrow(
-        /Option -f requires -ss != \['0', '1'\]\./,
-      );
-    });
-
     it('should ignore required value on strings option when using an async custom parse', () => {
       const options = {
         requires: {
@@ -202,40 +70,6 @@ describe('ArgumentParser', () => {
       } as const satisfies Options;
       const parser = new ArgumentParser(options);
       expect(() => parser.parse(['-f', '-ss', '1'])).not.toThrow();
-    });
-
-    it('should throw an error on numbers option with a value different than required', () => {
-      const options = {
-        requires: {
-          type: 'flag',
-          names: ['-f'],
-          requires: { required: [0, 1] },
-        },
-        required: {
-          type: 'numbers',
-          names: ['-ns'],
-        },
-      } as const satisfies Options;
-      const parser = new ArgumentParser(options);
-      expect(() => parser.parse(['-f', '-ns', '1'])).toThrow(/Option -f requires -ns = \[0, 1\]\./);
-    });
-
-    it('should throw an error on numbers option with a value equal to required when negated', () => {
-      const options = {
-        requires: {
-          type: 'flag',
-          names: ['-f'],
-          requires: req.not({ required: [0, 1] }),
-        },
-        required: {
-          type: 'numbers',
-          names: ['-ns'],
-        },
-      } as const satisfies Options;
-      const parser = new ArgumentParser(options);
-      expect(() => parser.parse(['-f', '-ns', '0', '1'])).toThrow(
-        /Option -f requires -ns != \[0, 1\]\./,
-      );
     });
 
     it('should ignore required value on numbers option when using an async custom parse', () => {
@@ -366,7 +200,7 @@ describe('ArgumentParser', () => {
       expect(options.required.exec).not.toHaveBeenCalled();
     });
 
-    it('should throw an error when on forward requirement not satisfied with req.not', () => {
+    it('should throw an error on forward requirement not satisfied with req.not', () => {
       const options = {
         string: {
           type: 'string',
@@ -386,7 +220,7 @@ describe('ArgumentParser', () => {
       expect(() => parser.parse(['-s', 'a', '1'])).toThrow(/Option -b requires -s != 'a'\./);
     });
 
-    it('should throw an error when on forward requirement not satisfied with req.all', () => {
+    it('should throw an error on forward requirement not satisfied with req.all', () => {
       const options = {
         flag1: {
           type: 'flag',
@@ -411,7 +245,7 @@ describe('ArgumentParser', () => {
       expect(() => parser.parse(['-f1', '-f2', '1'])).not.toThrow();
     });
 
-    it('should throw an error when on forward requirement not satisfied with req.one', () => {
+    it('should throw an error on forward requirement not satisfied with req.one', () => {
       const options = {
         flag1: {
           type: 'flag',
@@ -436,7 +270,7 @@ describe('ArgumentParser', () => {
       expect(() => parser.parse(['-f1', '-f2', '1'])).not.toThrow();
     });
 
-    it('should throw an error when on forward requirement not satisfied with an expression', () => {
+    it('should throw an error on forward requirement not satisfied with an expression', () => {
       const options = {
         requires: {
           type: 'flag',
@@ -491,7 +325,7 @@ describe('ArgumentParser', () => {
       ).not.toThrow();
     });
 
-    it('should throw an error when on forward requirement not satisfied with a negated expression', () => {
+    it('should throw an error on forward requirement not satisfied with a negated expression', () => {
       const options = {
         requires: {
           type: 'flag',
@@ -535,7 +369,7 @@ describe('ArgumentParser', () => {
     });
   });
 
-  it('should throw an error when on forward requirement not satisfied with a callback', () => {
+  it('should throw an error on forward requirement not satisfied with a callback', () => {
     const options = {
       flag1: {
         type: 'flag',
@@ -561,7 +395,7 @@ describe('ArgumentParser', () => {
     expect(() => parser.parse(['-f1', '-f2', '1'])).not.toThrow();
   });
 
-  it('should throw an error when on forward requirement not satisfied with a negated callback', () => {
+  it('should throw an error on forward requirement not satisfied with a negated callback', () => {
     const options = {
       flag1: {
         type: 'flag',
@@ -717,7 +551,7 @@ describe('ArgumentParser', () => {
     expect(() => parser.parse(['-s', 'a', '1'])).not.toThrow();
   });
 
-  it('should throw an error when on conditional requirement not satisfied with req.all', () => {
+  it('should throw an error on conditional requirement not satisfied with req.all', () => {
     const options = {
       flag1: {
         type: 'flag',
@@ -743,7 +577,7 @@ describe('ArgumentParser', () => {
     );
   });
 
-  it('should throw an error when on conditional requirement not satisfied with req.one', () => {
+  it('should throw an error on conditional requirement not satisfied with req.one', () => {
     const options = {
       flag1: {
         type: 'flag',
@@ -767,7 +601,7 @@ describe('ArgumentParser', () => {
     expect(() => parser.parse(['-f1', '-f2'])).toThrow(/Option -b is required if -f1\./);
   });
 
-  it('should throw an error when on conditional requirement not satisfied with an expression', () => {
+  it('should throw an error on conditional requirement not satisfied with an expression', () => {
     const options = {
       required: {
         type: 'flag',
@@ -809,7 +643,7 @@ describe('ArgumentParser', () => {
     );
   });
 
-  it('should throw an error when on conditional requirement not satisfied with a negated expression', () => {
+  it('should throw an error on conditional requirement not satisfied with a negated expression', () => {
     const options = {
       required: {
         type: 'flag',
@@ -863,7 +697,7 @@ describe('ArgumentParser', () => {
     ).not.toThrow();
   });
 
-  it('should throw an error when on conditional requirement not satisfied with a callback', () => {
+  it('should throw an error on conditional requirement not satisfied with a callback', () => {
     const options = {
       flag1: {
         type: 'flag',
@@ -888,7 +722,7 @@ describe('ArgumentParser', () => {
     expect(() => parser.parse(['-f1', '-f2'])).toThrow(/Option -b is required if <fcn>\./);
   });
 
-  it('should throw an error when on conditional requirement not satisfied with a negated callback', () => {
+  it('should throw an error on conditional requirement not satisfied with a negated callback', () => {
     const options = {
       flag1: {
         type: 'flag',

--- a/packages/tsargp/test/parser/parser.requires.spec.ts
+++ b/packages/tsargp/test/parser/parser.requires.spec.ts
@@ -366,7 +366,7 @@ describe('ArgumentParser', () => {
       expect(options.required.exec).not.toHaveBeenCalled();
     });
 
-    it('should throw an error when an option requirement is not satisfied with req.not', () => {
+    it('should throw an error when on forward requirement not satisfied with req.not', () => {
       const options = {
         string: {
           type: 'string',
@@ -386,7 +386,7 @@ describe('ArgumentParser', () => {
       expect(() => parser.parse(['-s', 'a', '1'])).toThrow(/Option -b requires -s != 'a'\./);
     });
 
-    it('should throw an error when an option requirement is not satisfied with req.all', () => {
+    it('should throw an error when on forward requirement not satisfied with req.all', () => {
       const options = {
         flag1: {
           type: 'flag',
@@ -411,7 +411,7 @@ describe('ArgumentParser', () => {
       expect(() => parser.parse(['-f1', '-f2', '1'])).not.toThrow();
     });
 
-    it('should throw an error when an option requirement is not satisfied with req.one', () => {
+    it('should throw an error when on forward requirement not satisfied with req.one', () => {
       const options = {
         flag1: {
           type: 'flag',
@@ -436,7 +436,7 @@ describe('ArgumentParser', () => {
       expect(() => parser.parse(['-f1', '-f2', '1'])).not.toThrow();
     });
 
-    it('should throw an error when an option requirement is not satisfied with an expression', () => {
+    it('should throw an error when on forward requirement not satisfied with an expression', () => {
       const options = {
         requires: {
           type: 'flag',
@@ -491,7 +491,7 @@ describe('ArgumentParser', () => {
       ).not.toThrow();
     });
 
-    it('should throw an error when an option requirement is not satisfied with a negated expression', () => {
+    it('should throw an error when on forward requirement not satisfied with a negated expression', () => {
       const options = {
         requires: {
           type: 'flag',
@@ -533,5 +533,381 @@ describe('ArgumentParser', () => {
         /Option -f requires \(-s != 'abc' or -n != 123 or -ss != \['a', 'b'\] or -ns != \[1, 2\]\)\./,
       );
     });
+  });
+  
+  it('should throw an error when on forward requirement not satisfied with a callback', () => {
+    const options = {
+      flag1: {
+        type: 'flag',
+        names: ['-f1'],
+      },
+      flag2: {
+        type: 'flag',
+        names: ['-f2'],
+      },
+      boolean: {
+        type: 'boolean',
+        names: ['-b'],
+        positional: true,
+        requires: (values) => values['flag1'] === values['flag2'],
+      },
+    } as const satisfies Options;
+    const parser = new ArgumentParser(options);
+    expect(() => parser.parse([])).not.toThrow();
+    expect(() => parser.parse(['1'])).not.toThrow();
+    expect(() => parser.parse(['-f1', '1'])).toThrow(/Option -b requires <fcn>\./);
+    expect(() => parser.parse(['-f2', '1'])).toThrow(/Option -b requires <fcn>\./);
+    expect(() => parser.parse(['-f1', '-f2', '1'])).not.toThrow();
+  });
+
+  it('should throw an error when on forward requirement not satisfied with a negated callback', () => {
+    const options = {
+      flag1: {
+        type: 'flag',
+        names: ['-f1'],
+      },
+      flag2: {
+        type: 'flag',
+        names: ['-f2'],
+      },
+      boolean: {
+        type: 'boolean',
+        names: ['-b'],
+        positional: true,
+        requires: req.not((values) => values['flag1'] === values['flag2']),
+      },
+    } as const satisfies Options;
+    const parser = new ArgumentParser(options);
+    expect(() => parser.parse([])).not.toThrow();
+    expect(() => parser.parse(['1'])).toThrow(/Option -b requires not <fcn>\./);
+    expect(() => parser.parse(['-f1', '1'])).not.toThrow();
+    expect(() => parser.parse(['-f2', '1'])).not.toThrow();
+    expect(() => parser.parse(['-f1', '-f2', '1'])).toThrow(/Option -b requires not <fcn>\./);
+  });
+
+  // ------
+  
+  it('should throw an error on option absent despite being required if another is present (1)', () => {
+    const options = {
+      required: {
+        type: 'flag',
+        names: ['-f1'],
+        requiredIf: 'other',
+      },
+      other: {
+        type: 'function',
+        names: ['-f2'],
+        break: true,
+        exec: vi.fn(),
+      },
+    } as const satisfies Options;
+    const parser = new ArgumentParser(options);
+    expect(() => parser.parse(['-f2'])).toThrow(/Option -f1 is required if -f2\./);
+    expect(options.other.exec).not.toHaveBeenCalled();
+  });
+
+  it('should throw an error on option absent despite being required if another is present (2)', () => {
+    const options = {
+      required: {
+        type: 'flag',
+        names: ['-f1'],
+        requiredIf: { other: undefined },
+      },
+      other: {
+        type: 'function',
+        names: ['-f2'],
+        break: true,
+        exec: vi.fn(),
+      },
+    } as const satisfies Options;
+    const parser = new ArgumentParser(options);
+    expect(() => parser.parse(['-f2'])).toThrow(/Option -f1 is required if -f2\./);
+    expect(options.other.exec).not.toHaveBeenCalled();
+  });
+
+  it('should throw an error on option absent despite being required if another is present (3)', () => {
+    const options = {
+      required: {
+        type: 'flag',
+        names: ['-f1'],
+        requiredIf: req.not({ other: null }),
+      },
+      other: {
+        type: 'function',
+        names: ['-f2'],
+        break: true,
+        exec: vi.fn(),
+      },
+    } as const satisfies Options;
+    const parser = new ArgumentParser(options);
+    expect(() => parser.parse(['-f2'])).toThrow(/Option -f1 is required if -f2\./);
+    expect(options.other.exec).not.toHaveBeenCalled();
+  });
+
+  it('should throw an error on option present despite being required if another is absent (1)', () => {
+    const options = {
+      required: {
+        type: 'flag',
+        names: ['-f1'],
+        requiredIf: req.not('other'),
+      },
+      other: {
+        type: 'function',
+        names: ['-f2'],
+        exec: vi.fn(),
+      },
+    } as const satisfies Options;
+    const parser = new ArgumentParser(options);
+    expect(() => parser.parse([])).toThrow(/Option -f1 is required if no -f2\./);
+    expect(options.other.exec).not.toHaveBeenCalled();
+  });
+
+  it('should throw an error on option present despite being required if another is absent (2)', () => {
+    const options = {
+      required: {
+        type: 'flag',
+        names: ['-f1'],
+        requiredIf: { other: null },
+      },
+      other: {
+        type: 'function',
+        names: ['-f2'],
+        exec: vi.fn(),
+      },
+    } as const satisfies Options;
+    const parser = new ArgumentParser(options);
+    expect(() => parser.parse([])).toThrow(/Option -f1 is required if no -f2\./);
+    expect(options.other.exec).not.toHaveBeenCalled();
+  });
+
+  it('should throw an error on option present despite being required if another is absent (3)', () => {
+    const options = {
+      required: {
+        type: 'flag',
+        names: ['-f1'],
+        requiredIf: req.not({ other: undefined }),
+      },
+      other: {
+        type: 'function',
+        names: ['-f2'],
+        exec: vi.fn(),
+      },
+    } as const satisfies Options;
+    const parser = new ArgumentParser(options);
+    expect(() => parser.parse([])).toThrow(/Option -f1 is required if no -f2\./);
+    expect(options.other.exec).not.toHaveBeenCalled();
+  });
+
+  it('should throw an error on conditional requirement not satisfied with req.not', () => {
+    const options = {
+      string: {
+        type: 'string',
+        names: ['-s'],
+      },
+      boolean: {
+        type: 'boolean',
+        names: ['-b'],
+        positional: true,
+        requiredIf: req.not({ string: 'a' }),
+      },
+    } as const satisfies Options;
+    const parser = new ArgumentParser(options);
+    expect(() => parser.parse([])).toThrow(/Option -b is required if no -s\./);
+    expect(() => parser.parse(['-s', 'b'])).toThrow(/Option -b is required if -s != 'a'\./);
+    expect(() => parser.parse(['-s', 'a', '1'])).not.toThrow();
+  });
+
+  it('should throw an error when on conditional requirement not satisfied with req.all', () => {
+    const options = {
+      flag1: {
+        type: 'flag',
+        names: ['-f1'],
+      },
+      flag2: {
+        type: 'flag',
+        names: ['-f2'],
+      },
+      boolean: {
+        type: 'boolean',
+        names: ['-b'],
+        positional: true,
+        requiredIf: req.all('flag1', 'flag2'),
+      },
+    } as const satisfies Options;
+    const parser = new ArgumentParser(options);
+    expect(() => parser.parse([])).not.toThrow();
+    expect(() => parser.parse(['-f1'])).not.toThrow();
+    expect(() => parser.parse(['-f2'])).not.toThrow();
+    expect(() => parser.parse(['-f1', '-f2'])).toThrow(
+      /Option -b is required if \(-f1 and -f2\)\./,
+    );
+  });
+
+  it('should throw an error when on conditional requirement not satisfied with req.one', () => {
+    const options = {
+      flag1: {
+        type: 'flag',
+        names: ['-f1'],
+      },
+      flag2: {
+        type: 'flag',
+        names: ['-f2'],
+      },
+      boolean: {
+        type: 'boolean',
+        names: ['-b'],
+        positional: true,
+        requiredIf: req.one('flag1', 'flag2'),
+      },
+    } as const satisfies Options;
+    const parser = new ArgumentParser(options);
+    expect(() => parser.parse([])).not.toThrow();
+    expect(() => parser.parse(['-f1'])).toThrow(/Option -b is required if -f1\./);
+    expect(() => parser.parse(['-f2'])).toThrow(/Option -b is required if -f2\./);
+    expect(() => parser.parse(['-f1', '-f2'])).toThrow(/Option -b is required if -f1\./);
+  });
+
+  it('should throw an error when on conditional requirement not satisfied with an expression', () => {
+    const options = {
+      required: {
+        type: 'flag',
+        names: ['-f'],
+        requiredIf: {
+          string: 'abc',
+          number: 123,
+          strings: ['a', 'b'],
+          numbers: [1, 2],
+        },
+      },
+      string: {
+        type: 'string',
+        names: ['-s'],
+      },
+      number: {
+        type: 'number',
+        names: ['-n'],
+      },
+      strings: {
+        type: 'strings',
+        names: ['-ss'],
+      },
+      numbers: {
+        type: 'numbers',
+        names: ['-ns'],
+      },
+    } as const satisfies Options;
+    const parser = new ArgumentParser(options);
+    expect(() => parser.parse([])).not.toThrow();
+    expect(() => parser.parse(['-s', 'a'])).not.toThrow();
+    expect(() => parser.parse(['-s', 'abc'])).not.toThrow();
+    expect(() => parser.parse(['-s', 'abc', '-n', '123'])).not.toThrow();
+    expect(() => parser.parse(['-s', 'abc', '-n', '123', '-ss', 'a', 'b'])).not.toThrow();
+    expect(() =>
+      parser.parse(['-s', 'abc', '-n', '123', '-ss', 'a', 'b', '-ns', '1', '2']),
+    ).toThrow(
+      /Option -f is required if \(-s = 'abc' and -n = 123 and -ss = \['a', 'b'\] and -ns = \[1, 2\]\)\./,
+    );
+  });
+
+  it('should throw an error when on conditional requirement not satisfied with a negated expression', () => {
+    const options = {
+      required: {
+        type: 'flag',
+        names: ['-f'],
+        requiredIf: req.not({
+          string: 'abc',
+          number: 123,
+          strings: ['a', 'b'],
+          numbers: [1, 2],
+        }),
+      },
+      string: {
+        type: 'string',
+        names: ['-s'],
+      },
+      number: {
+        type: 'number',
+        names: ['-n'],
+      },
+      strings: {
+        type: 'strings',
+        names: ['-ss'],
+      },
+      numbers: {
+        type: 'numbers',
+        names: ['-ns'],
+      },
+    } as const satisfies Options;
+    const parser = new ArgumentParser(options);
+    expect(() => parser.parse([])).toThrow(/Option -f is required if no -s\./);
+    expect(() => parser.parse(['-s', 'a'])).toThrow(/Option -f is required if -s != 'abc'\./);
+    expect(() => parser.parse(['-s', 'abc'])).toThrow(/Option -f is required if no -n\./);
+    expect(() => parser.parse(['-s', 'abc', '-n', '1'])).toThrow(
+      /Option -f is required if -n != 123\./,
+    );
+    expect(() => parser.parse(['-n', '123'])).toThrow(/Option -f is required if no -s\./);
+    expect(() => parser.parse(['-s', 'abc', '-n', '123'])).toThrow(
+      /Option -f is required if no -ss\./,
+    );
+    expect(() => parser.parse(['-s', 'abc', '-n', '123', '-ss', 'a'])).toThrow(
+      /Option -f is required if -ss != \['a', 'b'\]\./,
+    );
+    expect(() => parser.parse(['-s', 'abc', '-n', '123', '-ss', 'a', 'b'])).toThrow(
+      /Option -f is required if no -ns\./,
+    );
+    expect(() => parser.parse(['-s', 'abc', '-n', '123', '-ss', 'a', 'b', '-ns', '1'])).toThrow(
+      /Option -f is required if -ns != \[1, 2\]\./,
+    );
+    expect(() =>
+      parser.parse(['-s', 'abc', '-n', '123', '-ss', 'a', 'b', '-ns', '1', '2']),
+    ).not.toThrow();
+  });
+
+  it('should throw an error when on conditional requirement not satisfied with a callback', () => {
+    const options = {
+      flag1: {
+        type: 'flag',
+        names: ['-f1'],
+      },
+      flag2: {
+        type: 'flag',
+        names: ['-f2'],
+      },
+      boolean: {
+        type: 'boolean',
+        names: ['-b'],
+        positional: true,
+        requiredIf: (values) => values['flag1'] === values['flag2'],
+      },
+    } as const satisfies Options;
+    const parser = new ArgumentParser(options);
+    expect(() => parser.parse([])).toThrow(/Option -b is required if <fcn>\./);
+    expect(() => parser.parse(['-f1'])).not.toThrow();
+    expect(() => parser.parse(['-f2'])).not.toThrow();
+    expect(() => parser.parse(['-f1', '-f2'])).toThrow(/Option -b is required if <fcn>\./);
+  });
+
+  it('should throw an error when on conditional requirement not satisfied with a negated callback', () => {
+    const options = {
+      flag1: {
+        type: 'flag',
+        names: ['-f1'],
+      },
+      flag2: {
+        type: 'flag',
+        names: ['-f2'],
+      },
+      boolean: {
+        type: 'boolean',
+        names: ['-b'],
+        positional: true,
+        requiredIf: req.not((values) => values['flag1'] === values['flag2']),
+      },
+    } as const satisfies Options;
+    const parser = new ArgumentParser(options);
+    expect(() => parser.parse([])).not.toThrow();
+    expect(() => parser.parse(['-f1'])).toThrow(/Option -b is required if not <fcn>\./);
+    expect(() => parser.parse(['-f2'])).toThrow(/Option -b is required if not <fcn>\./);
+    expect(() => parser.parse(['-f1', '-f2'])).not.toThrow();
   });
 });

--- a/packages/tsargp/test/parser/parser.requires.spec.ts
+++ b/packages/tsargp/test/parser/parser.requires.spec.ts
@@ -534,7 +534,7 @@ describe('ArgumentParser', () => {
       );
     });
   });
-  
+
   it('should throw an error when on forward requirement not satisfied with a callback', () => {
     const options = {
       flag1: {
@@ -552,6 +552,7 @@ describe('ArgumentParser', () => {
         requires: (values) => values['flag1'] === values['flag2'],
       },
     } as const satisfies Options;
+    options.boolean.requires.toString = () => 'fcn';
     const parser = new ArgumentParser(options);
     expect(() => parser.parse([])).not.toThrow();
     expect(() => parser.parse(['1'])).not.toThrow();
@@ -577,6 +578,7 @@ describe('ArgumentParser', () => {
         requires: req.not((values) => values['flag1'] === values['flag2']),
       },
     } as const satisfies Options;
+    options.boolean.requires.item.toString = () => 'fcn';
     const parser = new ArgumentParser(options);
     expect(() => parser.parse([])).not.toThrow();
     expect(() => parser.parse(['1'])).toThrow(/Option -b requires not <fcn>\./);
@@ -585,8 +587,6 @@ describe('ArgumentParser', () => {
     expect(() => parser.parse(['-f1', '-f2', '1'])).toThrow(/Option -b requires not <fcn>\./);
   });
 
-  // ------
-  
   it('should throw an error on option absent despite being required if another is present (1)', () => {
     const options = {
       required: {
@@ -880,6 +880,7 @@ describe('ArgumentParser', () => {
         requiredIf: (values) => values['flag1'] === values['flag2'],
       },
     } as const satisfies Options;
+    options.boolean.requiredIf.toString = () => 'fcn';
     const parser = new ArgumentParser(options);
     expect(() => parser.parse([])).toThrow(/Option -b is required if <fcn>\./);
     expect(() => parser.parse(['-f1'])).not.toThrow();
@@ -904,6 +905,7 @@ describe('ArgumentParser', () => {
         requiredIf: req.not((values) => values['flag1'] === values['flag2']),
       },
     } as const satisfies Options;
+    options.boolean.requiredIf.item.toString = () => 'fcn';
     const parser = new ArgumentParser(options);
     expect(() => parser.parse([])).not.toThrow();
     expect(() => parser.parse(['-f1'])).toThrow(/Option -b is required if not <fcn>\./);

--- a/packages/tsargp/test/validator/validator.requirements.spec.ts
+++ b/packages/tsargp/test/validator/validator.requirements.spec.ts
@@ -36,7 +36,40 @@ describe('OptionValidator', () => {
       expect(() => validator.validate()).toThrow(/Unknown option unknown in requirement\./);
     });
 
-    it('should allow an option required to be present', () => {
+    it('should throw an error on required help option', () => {
+      const options = {
+        requires: {
+          type: 'flag',
+          names: ['-f'],
+          requires: { required: true },
+        },
+        required: {
+          type: 'help',
+          names: ['-h'],
+        },
+      } as const satisfies Options;
+      const validator = new OptionValidator(options);
+      expect(() => validator.validate()).toThrow(/Non-valued option required in requirement\./);
+    });
+
+    it('should throw an error on required version option', () => {
+      const options = {
+        requires: {
+          type: 'flag',
+          names: ['-f'],
+          requires: { required: true },
+        },
+        required: {
+          type: 'version',
+          names: ['-v'],
+          version: '',
+        },
+      } as const satisfies Options;
+      const validator = new OptionValidator(options);
+      expect(() => validator.validate()).toThrow(/Non-valued option required in requirement\./);
+    });
+
+    it('should allow a flag option required to be present', () => {
       const options = {
         requires: {
           type: 'flag',
@@ -52,7 +85,7 @@ describe('OptionValidator', () => {
       expect(() => validator.validate()).not.toThrow();
     });
 
-    it('should allow an option required to be absent', () => {
+    it('should allow a flag option required to be absent', () => {
       const options = {
         requires: {
           type: 'flag',
@@ -68,7 +101,7 @@ describe('OptionValidator', () => {
       expect(() => validator.validate()).not.toThrow();
     });
 
-    it('should throw an error on option required with a specific value', () => {
+    it('should allow a flag option required with a value', () => {
       const options = {
         requires: {
           type: 'flag',
@@ -81,12 +114,10 @@ describe('OptionValidator', () => {
         },
       } as const satisfies Options;
       const validator = new OptionValidator(options);
-      expect(() => validator.validate()).toThrow(
-        /Option required does not accept values\./,
-      );
+      expect(() => validator.validate()).not.toThrow();
     });
 
-    it('should throw an error on function option required with a value', () => {
+    it('should allow a function option required with a value', () => {
       const options = {
         requires: {
           type: 'flag',
@@ -100,8 +131,42 @@ describe('OptionValidator', () => {
         },
       } as const satisfies Options;
       const validator = new OptionValidator(options);
+      expect(() => validator.validate()).not.toThrow();
+    });
+
+    it('should allow a command option required with a value', () => {
+      const options = {
+        requires: {
+          type: 'flag',
+          names: ['-f1'],
+          requires: { required: true },
+        },
+        required: {
+          type: 'command',
+          names: ['-c'],
+          options: {},
+          cmd: () => {},
+        },
+      } as const satisfies Options;
+      const validator = new OptionValidator(options);
+      expect(() => validator.validate()).not.toThrow();
+    });
+
+    it('should throw an error on flag option required with an incompatible value', () => {
+      const options = {
+        requires: {
+          type: 'flag',
+          names: ['-f1'],
+          requires: { required: 'abc' },
+        },
+        required: {
+          type: 'flag',
+          names: ['-f2'],
+        },
+      } as const satisfies Options;
+      const validator = new OptionValidator(options);
       expect(() => validator.validate()).toThrow(
-        /Option required does not accept values\./,
+        /Option required has incompatible value <abc>\. Should be of type 'boolean'\./,
       );
     });
 
@@ -231,7 +296,7 @@ describe('OptionValidator', () => {
       );
     });
 
-    it('should throw an error on option required if itself', () => {
+    it('should throw an error on option required by its own presence', () => {
       const options = {
         requires: {
           type: 'flag',
@@ -247,7 +312,7 @@ describe('OptionValidator', () => {
       expect(() => validator.validate()).toThrow(/Option requires requires itself\./);
     });
 
-    it('should throw an error on option required if unknown option', () => {
+    it('should throw an error on option required if an unknown option is present', () => {
       const options = {
         requires: {
           type: 'flag',
@@ -263,7 +328,7 @@ describe('OptionValidator', () => {
       expect(() => validator.validate()).toThrow(/Unknown option unknown in requirement\./);
     });
 
-    it('should allow an option required if another is present', () => {
+    it('should allow an option required if a flag option is present', () => {
       const options = {
         requires: {
           type: 'flag',
@@ -279,7 +344,7 @@ describe('OptionValidator', () => {
       expect(() => validator.validate()).not.toThrow();
     });
 
-    it('should allow an option required if another is absent', () => {
+    it('should allow an option required if a flag option is absent', () => {
       const options = {
         requires: {
           type: 'flag',
@@ -295,7 +360,7 @@ describe('OptionValidator', () => {
       expect(() => validator.validate()).not.toThrow();
     });
 
-    it('should throw an error on option required if another has a specific value', () => {
+    it('should allow an option required if a flag option has a value', () => {
       const options = {
         requires: {
           type: 'flag',
@@ -308,12 +373,10 @@ describe('OptionValidator', () => {
         },
       } as const satisfies Options;
       const validator = new OptionValidator(options);
-      expect(() => validator.validate()).toThrow(
-        /Option other does not accept values\./,
-      );
+      expect(() => validator.validate()).not.toThrow();
     });
 
-    it('should throw an error on option required if a function option has a value', () => {
+    it('should allow an option required if a function option has a value', () => {
       const options = {
         requires: {
           type: 'flag',
@@ -327,8 +390,42 @@ describe('OptionValidator', () => {
         },
       } as const satisfies Options;
       const validator = new OptionValidator(options);
+      expect(() => validator.validate()).not.toThrow();
+    });
+
+    it('should allow an option required if a command option has a value', () => {
+      const options = {
+        requires: {
+          type: 'flag',
+          names: ['-f1'],
+          requiredIf: { other: true },
+        },
+        other: {
+          type: 'command',
+          names: ['-c'],
+          options: {},
+          cmd: () => {},
+        },
+      } as const satisfies Options;
+      const validator = new OptionValidator(options);
+      expect(() => validator.validate()).not.toThrow();
+    });
+
+    it('should throw an error on option required if a flag option has an incompatible value', () => {
+      const options = {
+        requires: {
+          type: 'flag',
+          names: ['-f1'],
+          requiredIf: { other: 'abc' },
+        },
+        other: {
+          type: 'flag',
+          names: ['-f2'],
+        },
+      } as const satisfies Options;
+      const validator = new OptionValidator(options);
       expect(() => validator.validate()).toThrow(
-        /Option other does not accept values\./,
+        /Option other has incompatible value <abc>\. Should be of type 'boolean'\./,
       );
     });
 

--- a/packages/tsargp/test/validator/validator.requires.spec.ts
+++ b/packages/tsargp/test/validator/validator.requires.spec.ts
@@ -33,7 +33,7 @@ describe('OptionValidator', () => {
         },
       } as const satisfies Options;
       const validator = new OptionValidator(options);
-      expect(() => validator.validate()).toThrow(/Unknown required option unknown\./);
+      expect(() => validator.validate()).toThrow(/Unknown option unknown in requirement\./);
     });
 
     it('should allow an option required to be present', () => {
@@ -68,7 +68,7 @@ describe('OptionValidator', () => {
       expect(() => validator.validate()).not.toThrow();
     });
 
-    it('should throw an error on flag option required with a value', () => {
+    it('should throw an error on option required with a specific value', () => {
       const options = {
         requires: {
           type: 'flag',
@@ -82,7 +82,7 @@ describe('OptionValidator', () => {
       } as const satisfies Options;
       const validator = new OptionValidator(options);
       expect(() => validator.validate()).toThrow(
-        /Required option required does not accept values\./,
+        /Option required does not accept values\./,
       );
     });
 
@@ -101,7 +101,7 @@ describe('OptionValidator', () => {
       } as const satisfies Options;
       const validator = new OptionValidator(options);
       expect(() => validator.validate()).toThrow(
-        /Required option required does not accept values\./,
+        /Option required does not accept values\./,
       );
     });
 
@@ -228,6 +228,233 @@ describe('OptionValidator', () => {
       const validator = new OptionValidator(options);
       expect(() => validator.validate()).toThrow(
         /Option required has incompatible value <1>\. Should be of type 'number'\./,
+      );
+    });
+
+    it('should throw an error on option required if itself', () => {
+      const options = {
+        requires: {
+          type: 'flag',
+          names: ['-f1'],
+          requiredIf: req.all('other', req.one({ requires: 'o' })),
+        },
+        other: {
+          type: 'flag',
+          names: ['-f2'],
+        },
+      } as const satisfies Options;
+      const validator = new OptionValidator(options);
+      expect(() => validator.validate()).toThrow(/Option requires requires itself\./);
+    });
+
+    it('should throw an error on option required if unknown option', () => {
+      const options = {
+        requires: {
+          type: 'flag',
+          names: ['-f1'],
+          requiredIf: req.all('other', req.one({ unknown: 'o' })),
+        },
+        other: {
+          type: 'flag',
+          names: ['-f2'],
+        },
+      } as const satisfies Options;
+      const validator = new OptionValidator(options);
+      expect(() => validator.validate()).toThrow(/Unknown option unknown in requirement\./);
+    });
+
+    it('should allow an option required if another is present', () => {
+      const options = {
+        requires: {
+          type: 'flag',
+          names: ['-f1'],
+          requiredIf: { other: undefined },
+        },
+        other: {
+          type: 'flag',
+          names: ['-f2'],
+        },
+      } as const satisfies Options;
+      const validator = new OptionValidator(options);
+      expect(() => validator.validate()).not.toThrow();
+    });
+
+    it('should allow an option required if another is absent', () => {
+      const options = {
+        requires: {
+          type: 'flag',
+          names: ['-f1'],
+          requiredIf: { other: null },
+        },
+        other: {
+          type: 'flag',
+          names: ['-f2'],
+        },
+      } as const satisfies Options;
+      const validator = new OptionValidator(options);
+      expect(() => validator.validate()).not.toThrow();
+    });
+
+    it('should throw an error on option required if another has a specific value', () => {
+      const options = {
+        requires: {
+          type: 'flag',
+          names: ['-f1'],
+          requiredIf: { other: true },
+        },
+        other: {
+          type: 'flag',
+          names: ['-f2'],
+        },
+      } as const satisfies Options;
+      const validator = new OptionValidator(options);
+      expect(() => validator.validate()).toThrow(
+        /Option other does not accept values\./,
+      );
+    });
+
+    it('should throw an error on option required if a function option has a value', () => {
+      const options = {
+        requires: {
+          type: 'flag',
+          names: ['-f1'],
+          requiredIf: { other: true },
+        },
+        other: {
+          type: 'function',
+          names: ['-f2'],
+          exec: () => {},
+        },
+      } as const satisfies Options;
+      const validator = new OptionValidator(options);
+      expect(() => validator.validate()).toThrow(
+        /Option other does not accept values\./,
+      );
+    });
+
+    it('should throw an error on option required if a boolean option has an incompatible value', () => {
+      const options = {
+        requires: {
+          type: 'flag',
+          names: ['-f'],
+          requiredIf: { other: 1 },
+        },
+        other: {
+          type: 'boolean',
+          names: ['-b'],
+        },
+      } as const satisfies Options;
+      const validator = new OptionValidator(options);
+      expect(() => validator.validate()).toThrow(
+        /Option other has incompatible value <1>\. Should be of type 'boolean'\./,
+      );
+    });
+
+    it('should throw an error on option required if a string option has an incompatible value', () => {
+      const options = {
+        requires: {
+          type: 'flag',
+          names: ['-f'],
+          requiredIf: { other: 1 },
+        },
+        other: {
+          type: 'string',
+          names: ['-s'],
+        },
+      } as const satisfies Options;
+      const validator = new OptionValidator(options);
+      expect(() => validator.validate()).toThrow(
+        /Option other has incompatible value <1>\. Should be of type 'string'\./,
+      );
+    });
+
+    it('should throw an error on option required if a number option has an incompatible value', () => {
+      const options = {
+        requires: {
+          type: 'flag',
+          names: ['-f'],
+          requiredIf: { other: '1' },
+        },
+        other: {
+          type: 'number',
+          names: ['-n'],
+        },
+      } as const satisfies Options;
+      const validator = new OptionValidator(options);
+      expect(() => validator.validate()).toThrow(
+        /Option other has incompatible value <1>\. Should be of type 'number'\./,
+      );
+    });
+
+    it('should throw an error on option required if a strings option has an incompatible value', () => {
+      const options = {
+        requires: {
+          type: 'flag',
+          names: ['-f'],
+          requiredIf: { other: 1 },
+        },
+        other: {
+          type: 'strings',
+          names: ['-ss'],
+        },
+      } as const satisfies Options;
+      const validator = new OptionValidator(options);
+      expect(() => validator.validate()).toThrow(
+        /Option other has incompatible value <1>\. Should be of type 'object'\./,
+      );
+    });
+
+    it('should throw an error on option required if a strings option has an incompatible array element', () => {
+      const options = {
+        requires: {
+          type: 'flag',
+          names: ['-f'],
+          requiredIf: { other: [1] },
+        },
+        other: {
+          type: 'strings',
+          names: ['-ss'],
+        },
+      } as const satisfies Options;
+      const validator = new OptionValidator(options);
+      expect(() => validator.validate()).toThrow(
+        /Option other has incompatible value <1>\. Should be of type 'string'\./,
+      );
+    });
+
+    it('should throw an error on option required if a numbers option has an incompatible value', () => {
+      const options = {
+        requires: {
+          type: 'flag',
+          names: ['-f'],
+          requiredIf: { other: 1 },
+        },
+        other: {
+          type: 'numbers',
+          names: ['-ns'],
+        },
+      } as const satisfies Options;
+      const validator = new OptionValidator(options);
+      expect(() => validator.validate()).toThrow(
+        /Option other has incompatible value <1>\. Should be of type 'object'\./,
+      );
+    });
+
+    it('should throw an error on option required if a numbers option has an incompatible array element', () => {
+      const options = {
+        requires: {
+          type: 'flag',
+          names: ['-f'],
+          requiredIf: { other: ['1'] },
+        },
+        other: {
+          type: 'numbers',
+          names: ['-ns'],
+        },
+      } as const satisfies Options;
+      const validator = new OptionValidator(options);
+      expect(() => validator.validate()).toThrow(
+        /Option other has incompatible value <1>\. Should be of type 'number'\./,
       );
     });
   });


### PR DESCRIPTION
A new attribute,`requiredIf`, was added to valued options, to indicate the option's conditional requirements. An equally named enumerator was added to `HelpItem`, in order to print this attribute in the help message. 

> [!NOTE]
> The same was done with the previously added `envVar` attribute, which had been forgotten. 

Both the parser and the formatter were updated to handle this attribute, and many test cases were refactored in order to cover the new functionality.

The Options page was updated to document the new attribute, with an example that illustrates the difference between it and the traditional `requires`.

Closes #10 
