### PR TITLE
Issues/19

### DIFF
--- a/.changeset/orange-carpets-laugh.md
+++ b/.changeset/orange-carpets-laugh.md
@@ -2,4 +2,4 @@
 'tsargp': minor
 ---
 
-Added the `formatFull` method to the help formatter, that includes additional sections to the help message.
+Added the `formatFull` method to the help formatter, that implements sections in the help message. Added the following properties to `HelpConfig`: `sections`, `styles` amd `misc`. Removed some attributes from the help option which are not needed anymore. (We will not go through a deprecation process, since the library is under active development and not currently used by other packages.)

--- a/.changeset/orange-carpets-laugh.md
+++ b/.changeset/orange-carpets-laugh.md
@@ -2,4 +2,4 @@
 'tsargp': minor
 ---
 
-Added the `formatFull` method to the help formatter, that implements sections in the help message. Added the following properties to `HelpConfig`: `sections`, `styles` amd `misc`. Removed some attributes from the help option which are not needed anymore. (We will not go through a deprecation process, since the library is under active development and not currently used by other packages.)
+Added the `formatFull` method to the help formatter, that implements sections in the help message. Added the following properties to `HelpConfig`: `sections`, `styles` amd `misc`. Removed some attributes from the help option which are not needed anymore. (We will _not_ go through a deprecation process, since the library is under active development and not currently used by other packages.)

--- a/.changeset/orange-carpets-laugh.md
+++ b/.changeset/orange-carpets-laugh.md
@@ -1,0 +1,5 @@
+---
+'tsargp': minor
+---
+
+Added the `formatFull` method to the help formatter, that includes additional sections to the help message.

--- a/.changeset/shaggy-cobras-wait.md
+++ b/.changeset/shaggy-cobras-wait.md
@@ -1,0 +1,5 @@
+---
+'@trulysimple/tsargp-docs': minor
+---
+
+Updated the Formatter page to document the new `formatFull` method.

--- a/.changeset/shaggy-cobras-wait.md
+++ b/.changeset/shaggy-cobras-wait.md
@@ -2,4 +2,4 @@
 '@trulysimple/tsargp-docs': minor
 ---
 
-Updated the Formatter page to document the new `formatFull` method.
+Updated the Formatter page to document the new `formatFull` method, as well as the new configuration properties: `sections`, `styles` amd `misc`. Updated the help option section in the Options page, to reflect the changes to this option's attributes.

--- a/cspell.json
+++ b/cspell.json
@@ -3,6 +3,7 @@
   "version": "0.2",
   "language": "en",
   "dictionaries": ["cpp", "typescript"],
+  "words": ["uncategorized"],
   "ignoreWords": [
     "Sogari",
     "lockb",

--- a/packages/docs/pages/docs/index.mdx
+++ b/packages/docs/pages/docs/index.mdx
@@ -18,7 +18,7 @@ title: Introduction - Docs
 | ESM-native             | Asynchronous callbacks  | Custom phrases           |
 | Online documentation   | Recursive commands      | Option grouping/hiding   |
 
-[^1]: less than 30KB minified
+[^1]: ~32KB minified
 
 ## Motivation
 

--- a/packages/docs/pages/docs/library/formatter.mdx
+++ b/packages/docs/pages/docs/library/formatter.mdx
@@ -123,7 +123,7 @@ It has the following set of optional properties:
 - `usageHeading` - the text of the usage section heading (defaults to `'Usage'{:ts}`)
 - `groupHeading` - the text of the default option group heading (defaults to `'Options'{:ts}`)
 
-<Callout type="default">
+<Callout type="info">
   All of these properties can include inline styles and will be formatted according to [text
   formatting](styles.mdx#text-splitting) rules, unless `misc.noWrap` is set.
 </Callout>

--- a/packages/docs/pages/docs/library/formatter.mdx
+++ b/packages/docs/pages/docs/library/formatter.mdx
@@ -30,13 +30,13 @@ parameter.
 
 ### Full help
 
-The `formatFull` method returns a help message that includes more information, as will be explained
-later in this page. It accepts two optional parameters:
+The `formatFull` method returns a help message that includes [help sections](#help-sections), as
+will be explained later in this page. It accepts two optional parameters:
 
-- `progName` - the name of the program to use in the default usage message
 - `hide` - an object to configure sections that should not be rendered
+- `progName` - the name of the program to use in the default usage message
 
-The `hide` parameter is of type `HideSections`, which contains the following set of optional flags:
+The `hide` parameter, of type `HideSections`, contains the following set of optional flags:
 
 - `intro` - true to omit the introduction section from the full help
 - `usage` - true to omit the usage section from the full help
@@ -78,11 +78,36 @@ This column contains either:
 The last column contains the option description and is composed of [help items](#help-items), which
 are explained later in this page.
 
+## Default usage
+
+The default usage text is a concise representation of a program's command-line. Here is an example:
+
+{/* cSpell:disable */}
+
+```ansi
+demo.js [[95mhelp[0m] [([95m-h[0m|[95m--help[0m)] [([95m-v[0m|[95m--version[0m)]
+        [([95m-f[0m|[95m--flag[0m|[95m--no-flag[0m)] [[95mhello[0m]
+        [([95m-b[0m|[95m--boolean[0m) [90m<boolean>[0m]
+        [([95m-s[0m|[95m--stringRegex[0m) [90m<my string>[0m]
+        [([95m-n[0m|[95m--numberRange[0m) [90m<my number>[0m]
+        [([95m-se[0m|[95m--stringEnum[0m) [32m'one'[0m]
+        [([95m-ne[0m|[95m--numberEnum[0m) [33m1[0m]
+        [([95m-ss[0m|[95m--strings[0m) [90m<strings>[0m]
+        [([95m-ns[0m|[95m--numbers[0m) [90m<numbers>[0m]
+        [[([95m--stringsEnum[0m|[95m--[0m)] [32m'one'[0m [32m'two'[0m]
+        [[95m--numbersEnum[0m [32m'1,2'[0m]
+```
+
+{/* cSpell:enable */}
+
+You can use the default text, or provide your own in the help format configuration, as is described
+in the next section.
+
 ## Help format
 
 In addition to the validator instance, the formatter constructor accepts a `HelpConfig` object that
 can be used to customize the message format. This configuration will apply to both help sections and
-help entries. It contains a set of optional properties, as described below.
+help entries. It contains a collection of optional properties, as described below.
 
 ### Help sections
 
@@ -90,15 +115,15 @@ The `sections` property specifies texts to be used in the various sections of th
 It has the following set of optional properties:
 
 - `intro` - the introduction of the help message. This is the initial section and has no heading.
-- `usage` - your CLI usage instructions. It can be either a text or `true{:ts}`, in which case a
-  default usage text will be rendered instead. This section has a heading that can be configured
-  with the `usageTitle` property.
+- `usage` - your CLI usage instructions. It can be either a text or `true{:ts}`, in which case the
+  [default usage](#default-usage) text will be rendered instead. This section has a heading that can
+  be configured with the `usageHeading` property.
 - `footer` - an afterword, copyright notice or external reference. This is the final section and has
   no heading.
-- `usageTitle` - the title of the usage section (defaults to `'Usage'{:ts}`)
-- `optionsTitle` - the title of the default option group (defaults to `'Options'{:ts}`)
+- `usageHeading` - the text of the usage section heading (defaults to `'Usage'{:ts}`)
+- `groupHeading` - the text of the default option group heading (defaults to `'Options'{:ts}`)
 
-<Callout type="warning">
+<Callout type="default">
   All of these properties can include inline styles and will be formatted according to [text
   formatting](styles.mdx#text-splitting) rules, unless `misc.noWrap` is set.
 </Callout>
@@ -111,14 +136,17 @@ sections and of entry columns. It has the following set of optional properties:
 - `intro` - level of indentation for the introduction section (non-negative, defaults to `0{:ts}`)
 - `usage` - level of indentation for the usage section text (non-negative, defaults to `2{:ts}`)
 - `footer` - level of indentation for the footer section (non-negative, defaults to `0{:ts}`)
-- `headings` - level of indentation for all headings (non-negative, defaults to `0{:ts}`)
 - `names` - level of indentation for the option names (non-negative, defaults to `2{:ts}`)
 - `param` - level of indentation for the option parameter (non-negative if `paramAbsolute` is
   `true{:ts}`, defaults to `2{:ts}`)
 - `descr` - level of indentation for the option description (non-negative if `descrAbsolute` is
   `true{:ts}`, defaults to `2{:ts}`)
-- `usageOptions` - level of indentation for the usage options (non-negative if `usageOptionsAbsolute`
-  is `true{:ts}`, defaults to `1{:ts}`)
+- `usageOptions` - level of indentation for the options in the [default usage](#default-usage)
+  (non-negative if `usageOptionsAbsolute` is `true{:ts}`, defaults to `1{:ts}`)
+- `usageHeading` - level of indentation for the usage section heading (non-negative, defaults to
+  `0{:ts}`)
+- `groupHeading` - level of indentation for every option group heading (non-negative, defaults to
+  `0{:ts}`)
 - `paramAbsolute` whether the indentation level for the option parameter should be relative to the
   beginning of the line instead of the end of the option names (defaults to `false{:ts}`)
 - `descrAbsolute` whether the indentation level for the option description should be relative to the
@@ -138,9 +166,10 @@ columns. It has the following set of optional properties:
 - `names` - line breaks to insert before the option names (defaults to `0{:ts}`)
 - `param` - line breaks to insert before the option parameter (defaults to `0{:ts}`)
 - `descr` - line breaks to insert before the option description (defaults to `0{:ts}`)
-- `usageTitle` - line breaks to insert before the usage section heading (defaults to `2{:ts}`)
-- `usageOptions` - line breaks to insert before the usage options (defaults to `0{:ts}`)
-- `groupTitle` - line breaks to insert before each option group heading (defaults to `2{:ts}`)
+- `usageOptions` - line breaks to insert before the options in the [default usage](#default-usage)
+  (defaults to `0{:ts}`)
+- `usageHeading` - line breaks to insert before the usage section heading (defaults to `2{:ts}`)
+- `groupHeading` - line breaks to insert before every option group heading (defaults to `2{:ts}`)
 
 ### Hidden columns
 
@@ -150,6 +179,10 @@ following set of optional properties:
 - `names` - whether option names should be omitted (defaults to `false{:ts}`)
 - `param` - whether option parameters should be omitted (defaults to `false{:ts}`)
 - `descr` - whether option descriptions should be omitted (defaults to `false{:ts}`)
+
+<Callout type="info">
+  These settings do not apply to the [default usage](#default-usage) text.
+</Callout>
 
 ### Help items
 
@@ -217,14 +250,23 @@ These phrases will be formatted according to [text formatting](styles.mdx#text-s
   ``` `Requires ${style(tf.bold)}%s`{:ts} ```.
 </Callout>
 
+### Section styles
+
+The `styles` property specifies the [styles](styles.mdx#styling-attributes) of the help sections. It
+has the following set of optional properties:
+
+- `intro` - the style of the introduction section (defaults to `tf.clear{:ts}`)
+- `usage` - the style of the usage section (defaults to `tf.clear{:ts}`)
+- `footer` - the style of the footer section (defaults to `tf.clear{:ts}`)
+- `usageHeading` - the style of the usage section heading (defaults to `tf.bold{:ts}`)
+- `groupHeading` - the style of every option group heading (defaults to `tf.bold{:ts}`)
+
 ### Miscellaneous
 
 The `misc` property specifies additional, uncategorized settings. It has the following set of
 optional properties:
 
-- `headingStyle` - a [style](styles.mdx#styling-attributes) to be applied to all headings (defaults
-  to `tf.bold{:ts}`)
-- `headingPhrase` - the phrase to use for all headings (defaults to `'%s:'{:ts}`)
+- `headingPhrase` - a custom phrase to use for all headings (defaults to `'%s:'{:ts}`)
 - `noWrap` - whether provided section texts should _not_ be split into words. This allows you to
   format texts however you like, at the expense of not wrapping them (defaults to `false{:ts}`)
 

--- a/packages/docs/pages/docs/library/formatter.mdx
+++ b/packages/docs/pages/docs/library/formatter.mdx
@@ -28,6 +28,21 @@ The `formatGroups` method, on the other hand, returns a `Map{:ts}` that maps gro
 messages, including the default group with an empty name. Neither of these methods accept any
 parameter.
 
+### Full help
+
+The `formatFull` method returns a help message that includes more information, as will be explained
+later in this page. It accepts two optional parameters:
+
+- `progName` - the name of the program to use in the default usage message
+- `hide` - an object to configure sections that should not be rendered
+
+The `hide` parameter is of type `HideSections`, which contains the following set of optional flags:
+
+- `intro` - true to omit the introduction section from the full help
+- `usage` - true to omit the usage section from the full help
+- `groups` - true if no option group should be displayed in the full help
+- `footer` - true to omit the footer section from the full help
+
 ## Help entries
 
 Each option definition results in a help entry being included under its respective group in the help
@@ -66,32 +81,66 @@ are explained later in this page.
 ## Help format
 
 In addition to the validator instance, the formatter constructor accepts a `HelpConfig` object that
-can be used to customize the message format. This configuration will apply to all help entries. It
-contains a set of optional properties, as described below.
+can be used to customize the message format. This configuration will apply to both help sections and
+help entries. It contains a set of optional properties, as described below.
+
+### Help sections
+
+The `sections` property specifies texts to be used in the various sections of the full help message.
+It has the following set of optional properties:
+
+- `intro` - the introduction of the help message. This is the initial section and has no heading.
+- `usage` - your CLI usage instructions. It can be either a text or `true{:ts}`, in which case a
+  default usage text will be rendered instead. This section has a heading that can be configured
+  with the `usageTitle` property.
+- `footer` - an afterword, copyright notice or external reference. This is the final section and has
+  no heading.
+- `usageTitle` - the title of the usage section (defaults to `'Usage'{:ts}`)
+- `optionsTitle` - the title of the default option group (defaults to `'Options'{:ts}`)
+
+<Callout type="warning">
+  All of these properties can include inline styles and will be formatted according to [text
+  formatting](styles.mdx#text-splitting) rules, unless `misc.noWrap` is set.
+</Callout>
 
 ### Indentation level
 
-The `indent` property specifies the indentation levels (in number of terminal columns) of help entry
-columns. It has the following set of optional properties:
+The `indent` property specifies the indentation levels (in number of terminal columns) of help
+sections and of entry columns. It has the following set of optional properties:
 
+- `intro` - level of indentation for the introduction section (non-negative, defaults to `0{:ts}`)
+- `usage` - level of indentation for the usage section text (non-negative, defaults to `2{:ts}`)
+- `footer` - level of indentation for the footer section (non-negative, defaults to `0{:ts}`)
+- `headings` - level of indentation for all headings (non-negative, defaults to `0{:ts}`)
 - `names` - level of indentation for the option names (non-negative, defaults to `2{:ts}`)
 - `param` - level of indentation for the option parameter (non-negative if `paramAbsolute` is
   `true{:ts}`, defaults to `2{:ts}`)
 - `descr` - level of indentation for the option description (non-negative if `descrAbsolute` is
   `true{:ts}`, defaults to `2{:ts}`)
+- `usageOptions` - level of indentation for the usage options (non-negative if `usageOptionsAbsolute`
+  is `true{:ts}`, defaults to `1{:ts}`)
 - `paramAbsolute` whether the indentation level for the option parameter should be relative to the
   beginning of the line instead of the end of the option names (defaults to `false{:ts}`)
 - `descrAbsolute` whether the indentation level for the option description should be relative to the
   beginning of the line instead of the end of the option parameter (defaults to `false{:ts}`)
+- `usageOptionsAbsolute` whether the indentation level for the usage options should be relative to
+  the beginning of the line instead of the end of the program name (defaults to `false{:ts}`)
 
 ### Line breaks
 
-The `breaks` property specifies the number of line breaks to insert before help entry columns. It
-has the following set of optional properties:
+The `breaks` property specifies the number of line breaks to insert before help sections or entry
+columns. It has the following set of optional properties:
 
+- `intro` - line breaks to insert before the introduction section (defaults to `0{:ts}`)
+- `usage` - line breaks to insert before the usage section text (defaults to `2{:ts}`)
+- `groups` - line breaks to insert before each option group content (defaults to `2{:ts}`)
+- `footer` - line breaks to insert before the footer section (defaults to `2{:ts}`)
 - `names` - line breaks to insert before the option names (defaults to `0{:ts}`)
 - `param` - line breaks to insert before the option parameter (defaults to `0{:ts}`)
 - `descr` - line breaks to insert before the option description (defaults to `0{:ts}`)
+- `usageTitle` - line breaks to insert before the usage section heading (defaults to `2{:ts}`)
+- `usageOptions` - line breaks to insert before the usage options (defaults to `0{:ts}`)
+- `groupTitle` - line breaks to insert before each option group heading (defaults to `2{:ts}`)
 
 ### Hidden columns
 
@@ -167,6 +216,17 @@ These phrases will be formatted according to [text formatting](styles.mdx#text-s
   will mess up the text wrapping. For example, the following phrase is not valid:
   ``` `Requires ${style(tf.bold)}%s`{:ts} ```.
 </Callout>
+
+### Miscellaneous
+
+The `misc` property specifies additional, uncategorized settings. It has the following set of
+optional properties:
+
+- `headingStyle` - a [style](styles.mdx#styling-attributes) to be applied to all headings (defaults
+  to `tf.bold{:ts}`)
+- `headingPhrase` - the phrase to use for all headings (defaults to `'%s:'{:ts}`)
+- `noWrap` - whether provided section texts should _not_ be split into words. This allows you to
+  format texts however you like, at the expense of not wrapping them (defaults to `false{:ts}`)
 
 ## Help styles
 

--- a/packages/docs/pages/docs/library/options.mdx
+++ b/packages/docs/pages/docs/library/options.mdx
@@ -398,25 +398,14 @@ handles the formatting of help messages. Internally, it performs the following a
 The application should catch the message and print it in a terminal. This option has the following
 optional attributes.
 
-#### Usage & footer
+#### Format
 
-The `usage` attribute describes your CLI usage instructions. It goes before everything else in the
-help message. The `footer` attribute is an afterword that can be used to insert a copyright notice
-or reference to other media. Both attributes can include inline styles and will be formatted
-according to [text formatting](styles.mdx#text-splitting) rules, unless the `noSplit` attribute is
-set.
+The `format` attribute specifies a custom [help format](formatter.mdx#help-format) configuration.
 
-#### Format & heading style
+#### Hide sections
 
-The `format` attribute, if present, specifies the [help format](formatter.mdx#help-format)
-configuration. The `headingStyle` attribute, if present, specifies a
-[style](styles.mdx#styling-attributes) to be applied to group headings.
-
-#### No text splitting
-
-The `noSplit` attribute, if present, indicates that the usage, footer and heading texts should _not_
-be split into words. This allows them to have custom indentation and prevents a colon from being
-appended to group headings, but at the expense of losing the text wrapping feature.
+The `hideSections` attribute specifies [help sections](formatter.mdx#help-sections) that should be
+omitted from the help message.
 
 ### Version option
 

--- a/packages/tsargp/examples/calc.options.ts
+++ b/packages/tsargp/examples/calc.options.ts
@@ -120,6 +120,11 @@ const mainOpts = {
     type: 'help',
     names: ['help'],
     desc: 'Prints this help message.',
+    format: {
+      sections: {
+        usage: true,
+      },
+    },
   },
   ...addOpts,
   ...subOpts,

--- a/packages/tsargp/examples/demo.options.ts
+++ b/packages/tsargp/examples/demo.options.ts
@@ -75,20 +75,19 @@ export default {
     type: 'help',
     names: ['-h', '--help'],
     desc: 'A help option. Prints this help message.',
-    usage: `
-    ${style(tf.clear, tf.bold)}Argument parser for TypeScript.
+    format: {
+      sections: {
+        intro: `${style(tf.clear, tf.bold)}Argument parser for TypeScript.`,
+        usage: true,
+        footer: `MIT License.
+Copyright (c) 2024 ${style(tf.bold, tf.italic)}TrulySimple${style(tf.clear)}
 
-    ${style(tf.clear, fg.yellow)}tsargp
-    ${style(fg.default)}--help
-    ${style(fg.green)}# print help
-    ${style(fg.default)}`,
-    footer: `
-    MIT License.
-    Copyright (c) 2024
-    ${style(tf.bold, tf.italic)}TrulySimple${style(tf.clear)}
-
-    Report a bug:
-    ${style(tf.faint)}https://github.com/trulysimple/tsargp/issues`,
+Report a bug: ${style(tf.faint)}https://github.com/trulysimple/tsargp/issues`,
+      },
+      misc: {
+        noWrap: true,
+      },
+    },
   },
   /**
    * A version option that throws the package version.

--- a/packages/tsargp/lib/formatter.ts
+++ b/packages/tsargp/lib/formatter.ts
@@ -548,12 +548,12 @@ export class HelpFormatter {
     }
     const descrStyle = option.styles?.descr ?? this.styles.text;
     const result = new TerminalString(0, this.config.breaks.descr).addSequence(descrStyle);
-    const len = result.strings.length;
+    const count = result.count;
     for (const item of this.config.items) {
       const phrase = this.config.phrases[item];
       this.format[item](option, phrase, this.styles, descrStyle, result);
     }
-    if (result.strings.length > len) {
+    if (result.count > count) {
       return result.addSequence(style(tf.clear)).addBreaks(1); // add ending breaks after styles
     }
     return new TerminalString(0, 1);
@@ -675,7 +675,7 @@ export class HelpFormatter {
           ? [formatSection(progName, indent.usage, breaks.usage, styles.usage, true)]
           : []),
         defaultUsage
-          ? formatUsage(this.options, this.styles, optionsIndent, usageOptionsBreaks)
+          ? formatUsage(this.options, this.styles, styles.usage, optionsIndent, usageOptionsBreaks)
           : formatSection(sections.usage, indent.usage, breaks.usage, styles.usage, misc.noWrap),
       );
     }
@@ -904,6 +904,7 @@ function formatSection(
  * Options are rendered in the same order as declared in the option definitions.
  * @param options The option definitions
  * @param styles The set of styles
+ * @param style The default style
  * @param indent The indentation level (negative values are replaced by zero)
  * @param breaks The number of line breaks (non-positive values are ignored)
  * @returns The terminal string
@@ -911,15 +912,20 @@ function formatSection(
 function formatUsage(
   options: Options,
   styles: ConcreteStyles,
+  style: Style,
   indent: number,
   breaks: number,
 ): TerminalString {
-  const result = new TerminalString(indent, breaks);
+  const result = new TerminalString(indent, breaks).addSequence(style);
+  const count = result.count;
   for (const key in options) {
     const option = options[key];
     if (!option.hide) {
-      formatUsageOption(option, styles, styles.text, result);
+      formatUsageOption(option, styles, style, result);
     }
+  }
+  if (result.count == count) {
+    return new TerminalString(); // this string does not contain any word
   }
   return result;
 }

--- a/packages/tsargp/lib/options.ts
+++ b/packages/tsargp/lib/options.ts
@@ -1,9 +1,9 @@
 //--------------------------------------------------------------------------------------------------
 // Imports
 //--------------------------------------------------------------------------------------------------
-import type { HelpConfig } from './formatter';
 import type { Style } from './styles';
 import type { Resolve, Writable, URL } from './utils';
+import { HelpConfig, HideSections } from './formatter';
 
 //--------------------------------------------------------------------------------------------------
 // Constants
@@ -201,8 +201,9 @@ export type WithType<T extends string> = {
   readonly group?: string;
   /**
    * True if the option should be hidden from the help message.
+   * Use the string 'usage' to hide it only from the default usage message.
    */
-  readonly hide?: true;
+  readonly hide?: true | 'usage';
   /**
    * The option display styles.
    */
@@ -612,27 +613,13 @@ export type CommandOption = WithType<'command'> &
  */
 export type HelpOption = WithType<'help'> & {
   /**
-   * The usage message. This goes before everything else.
-   */
-  readonly usage?: string;
-  /**
-   * The footer message. This goes after everything else.
-   */
-  readonly footer?: string;
-  /**
    * The help format configuration.
    */
   readonly format?: HelpConfig;
   /**
-   * The style of option group headings.
+   * The help sections that should be omitted.
    */
-  readonly headingStyle?: Style;
-  /**
-   * Indicates that the usage, footer and heading texts should not be split into words. This allows
-   * them to have custom indentation and prevents a colon from being appended to group headings, but
-   * at the expense of losing the text wrapping feature.
-   */
-  readonly noSplit?: true;
+  readonly hideSections?: HideSections;
 };
 
 /**

--- a/packages/tsargp/lib/options.ts
+++ b/packages/tsargp/lib/options.ts
@@ -1,9 +1,9 @@
 //--------------------------------------------------------------------------------------------------
 // Imports
 //--------------------------------------------------------------------------------------------------
+import type { HelpConfig, HideSections } from './formatter';
 import type { Style } from './styles';
 import type { Resolve, Writable, URL } from './utils';
-import { HelpConfig, HideSections } from './formatter';
 
 //--------------------------------------------------------------------------------------------------
 // Constants

--- a/packages/tsargp/test/formatter/formatter.sections.spec.ts
+++ b/packages/tsargp/test/formatter/formatter.sections.spec.ts
@@ -35,6 +35,15 @@ describe('HelpFormatter', () => {
       expect(message.wrap()).toEqual('\n\nintro');
     });
 
+    it('should stylize the introduction section', () => {
+      const config: HelpConfig = {
+        sections: { intro: 'intro' },
+        styles: { intro: style(tf.italic) },
+      };
+      const message = new HelpFormatter(new OptionValidator({}), config).formatFull();
+      expect(message.wrap(0, true)).toMatch(/\x9b3mintro/); // cspell:disable-line
+    });
+
     it('should render the usage section', () => {
       const config: HelpConfig = { sections: { usage: 'usage' } };
       const message = new HelpFormatter(new OptionValidator({}), config).formatFull();
@@ -42,7 +51,7 @@ describe('HelpFormatter', () => {
     });
 
     it('should render the usage section with a custom heading', () => {
-      const config: HelpConfig = { sections: { usage: 'usage', usageTitle: 'title' } };
+      const config: HelpConfig = { sections: { usage: 'usage', usageHeading: 'title' } };
       const message = new HelpFormatter(new OptionValidator({}), config).formatFull();
       expect(message.wrap()).toEqual('title:\n\n  usage');
     });
@@ -60,19 +69,43 @@ describe('HelpFormatter', () => {
       expect(message.wrap()).toEqual('Usage:\n\nusage');
     });
 
+    it('should indent the usage section heading', () => {
+      const config: HelpConfig = { sections: { usage: 'usage' }, indent: { usageHeading: 2 } };
+      const message = new HelpFormatter(new OptionValidator({}), config).formatFull();
+      expect(message.wrap()).toEqual('  Usage:\n\n  usage');
+    });
+
     it('should break the usage section', () => {
       const config: HelpConfig = { sections: { usage: 'usage' }, breaks: { usage: 1 } };
       const message = new HelpFormatter(new OptionValidator({}), config).formatFull();
       expect(message.wrap()).toEqual('Usage:\n  usage');
     });
 
-    it('should break the usage section title', () => {
+    it('should break the usage section heading', () => {
       const config: HelpConfig = {
         sections: { intro: 'intro', usage: 'usage' },
-        breaks: { usageTitle: 1 },
+        breaks: { usageHeading: 1 },
       };
       const message = new HelpFormatter(new OptionValidator({}), config).formatFull();
       expect(message.wrap()).toEqual('intro\nUsage:\n\n  usage');
+    });
+
+    it('should stylize the usage section', () => {
+      const config: HelpConfig = {
+        sections: { usage: 'usage' },
+        styles: { usage: style(tf.italic) },
+      };
+      const message = new HelpFormatter(new OptionValidator({}), config).formatFull();
+      expect(message.wrap(0, true)).toMatch(/\x9b3musage/); // cspell:disable-line
+    });
+
+    it('should stylize the usage section heading', () => {
+      const config: HelpConfig = {
+        sections: { usage: 'usage' },
+        styles: { usageHeading: style(tf.italic) },
+      };
+      const message = new HelpFormatter(new OptionValidator({}), config).formatFull();
+      expect(message.wrap(0, true)).toMatch(/\x9b3mUsage:/); // cspell:disable-line
     });
 
     it('should render the footer section', () => {
@@ -103,7 +136,16 @@ describe('HelpFormatter', () => {
       expect(message.wrap()).toEqual('intro\nfooter');
     });
 
-    it('should render the option groups', () => {
+    it('should stylize the footer section', () => {
+      const config: HelpConfig = {
+        sections: { footer: 'footer' },
+        styles: { footer: style(tf.italic) },
+      };
+      const message = new HelpFormatter(new OptionValidator({}), config).formatFull();
+      expect(message.wrap(0, true)).toMatch(/\x9b3mfooter/); // cspell:disable-line
+    });
+
+    it('should render the default option group', () => {
       const options = {
         flag: {
           type: 'flag',
@@ -115,7 +157,7 @@ describe('HelpFormatter', () => {
       expect(message.wrap()).toEqual('Options:\n\n  -f, --flag    A flag option.');
     });
 
-    it('should render the default option group with a custom name', () => {
+    it('should render the default option group with a custom heading', () => {
       const options = {
         flag: {
           type: 'flag',
@@ -123,7 +165,7 @@ describe('HelpFormatter', () => {
           desc: 'A flag option.',
         },
       } as const satisfies Options;
-      const config: HelpConfig = { sections: { optionsTitle: 'title' } };
+      const config: HelpConfig = { sections: { groupHeading: 'title' } };
       const message = new HelpFormatter(new OptionValidator(options), config).formatFull();
       expect(message.wrap()).toEqual('title:\n\n  -f, --flag    A flag option.');
     });
@@ -162,9 +204,35 @@ describe('HelpFormatter', () => {
           desc: 'A flag option.',
         },
       } as const satisfies Options;
-      const config: HelpConfig = { sections: { intro: 'intro' }, breaks: { groupTitle: 1 } };
+      const config: HelpConfig = { sections: { intro: 'intro' }, breaks: { groupHeading: 1 } };
       const message = new HelpFormatter(new OptionValidator(options), config).formatFull();
       expect(message.wrap()).toEqual('intro\nOptions:\n\n  -f, --flag    A flag option.');
+    });
+
+    it('should indent the option group headings', () => {
+      const options = {
+        flag: {
+          type: 'flag',
+          names: ['-f', '--flag'],
+          desc: 'A flag option.',
+        },
+      } as const satisfies Options;
+      const config: HelpConfig = { indent: { groupHeading: 2 } };
+      const message = new HelpFormatter(new OptionValidator(options), config).formatFull();
+      expect(message.wrap()).toEqual('  Options:\n\n  -f, --flag    A flag option.');
+    });
+
+    it('should stylize the option group headings', () => {
+      const options = {
+        flag: {
+          type: 'flag',
+          names: ['-f', '--flag'],
+          desc: 'A flag option.',
+        },
+      } as const satisfies Options;
+      const config: HelpConfig = { styles: { groupHeading: style(tf.italic) } };
+      const message = new HelpFormatter(new OptionValidator(options), config).formatFull();
+      expect(message.wrap(0, true)).toMatch(/\x9b3mOptions:/); // cspell:disable-line
     });
 
     it('should render the default usage text', () => {
@@ -250,37 +318,6 @@ describe('HelpFormatter', () => {
       );
     });
 
-    it('should indent all headings', () => {
-      const options = {
-        flag: {
-          type: 'flag',
-          names: ['-f', '--flag'],
-          desc: 'A flag option.',
-        },
-      } as const satisfies Options;
-      const config: HelpConfig = { sections: { usage: 'usage' }, indent: { headings: 2 } };
-      const message = new HelpFormatter(new OptionValidator(options), config).formatFull();
-      expect(message.wrap()).toEqual(
-        '  Usage:\n\n  usage\n\n  Options:\n\n  -f, --flag    A flag option.',
-      );
-    });
-
-    it('should stylize all headings', () => {
-      const options = {
-        flag: {
-          type: 'flag',
-          names: ['-f', '--flag'],
-          desc: 'A flag option.',
-        },
-      } as const satisfies Options;
-      const config: HelpConfig = {
-        sections: { usage: 'usage' },
-        misc: { headingStyle: style(tf.clear) },
-      };
-      const message = new HelpFormatter(new OptionValidator(options), config).formatFull();
-      expect(message.wrap(0, true)).toMatch(/\x9b0mUsage:.+\x9b0mOptions:/s);
-    });
-
     it('should use custom phrase for all headings', () => {
       const options = {
         flag: {
@@ -309,14 +346,31 @@ describe('HelpFormatter', () => {
           intro: '  intro',
           usage: 'usage  text',
           footer: '  footer',
-          usageTitle: 'usage  title',
-          optionsTitle: 'options  title',
+          usageHeading: 'usage  title',
+          groupHeading: 'options  title',
         },
         misc: { noWrap: true },
       };
       const message = new HelpFormatter(new OptionValidator(options), config).formatFull();
       expect(message.wrap()).toEqual(
         '  intro\n\nusage  title:\n\n  usage  text\n\noptions  title:\n\n  -f, --flag    A flag option.\n\n  footer',
+      );
+    });
+
+    it('should hide an option from the default usage text', () => {
+      const options = {
+        flag: {
+          type: 'flag',
+          names: ['-f', '--flag'],
+          desc: 'A flag option.',
+          hide: 'usage',
+        },
+      } as const satisfies Options;
+      const validator = new OptionValidator(options);
+      const config: HelpConfig = { sections: { usage: true } };
+      const message = new HelpFormatter(validator, config).formatFull({}, 'prog');
+      expect(message.wrap()).toEqual(
+        'Usage:\n\n  prog\n\nOptions:\n\n  -f, --flag    A flag option.',
       );
     });
   });

--- a/packages/tsargp/test/formatter/formatter.sections.spec.ts
+++ b/packages/tsargp/test/formatter/formatter.sections.spec.ts
@@ -1,0 +1,323 @@
+import { describe, expect, it } from 'vitest';
+import type { Options, HelpConfig, HideSections } from '../../lib';
+import { HelpFormatter, OptionValidator, style, tf } from '../../lib';
+import '../utils.spec'; // initialize globals
+
+describe('HelpFormatter', () => {
+  describe('formatFull', () => {
+    it('should handle no options', () => {
+      const message = new HelpFormatter(new OptionValidator({})).formatFull();
+      expect(message.wrap()).toEqual('');
+    });
+
+    it('should render the introduction section', () => {
+      const config: HelpConfig = { sections: { intro: 'intro' } };
+      const message = new HelpFormatter(new OptionValidator({}), config).formatFull();
+      expect(message.wrap()).toEqual('intro');
+    });
+
+    it('should omit the introduction section', () => {
+      const config: HelpConfig = { sections: { intro: 'intro' } };
+      const hide: HideSections = { intro: true };
+      const message = new HelpFormatter(new OptionValidator({}), config).formatFull(hide);
+      expect(message.wrap()).toEqual('');
+    });
+
+    it('should indent the introduction section', () => {
+      const config: HelpConfig = { sections: { intro: 'intro' }, indent: { intro: 2 } };
+      const message = new HelpFormatter(new OptionValidator({}), config).formatFull();
+      expect(message.wrap()).toEqual('  intro');
+    });
+
+    it('should break the introduction section', () => {
+      const config: HelpConfig = { sections: { intro: 'intro' }, breaks: { intro: 2 } };
+      const message = new HelpFormatter(new OptionValidator({}), config).formatFull();
+      expect(message.wrap()).toEqual('\n\nintro');
+    });
+
+    it('should render the usage section', () => {
+      const config: HelpConfig = { sections: { usage: 'usage' } };
+      const message = new HelpFormatter(new OptionValidator({}), config).formatFull();
+      expect(message.wrap()).toEqual('Usage:\n\n  usage');
+    });
+
+    it('should render the usage section with a custom heading', () => {
+      const config: HelpConfig = { sections: { usage: 'usage', usageTitle: 'title' } };
+      const message = new HelpFormatter(new OptionValidator({}), config).formatFull();
+      expect(message.wrap()).toEqual('title:\n\n  usage');
+    });
+
+    it('should omit the usage section', () => {
+      const config: HelpConfig = { sections: { usage: 'usage' } };
+      const hide: HideSections = { usage: true };
+      const message = new HelpFormatter(new OptionValidator({}), config).formatFull(hide);
+      expect(message.wrap()).toEqual('');
+    });
+
+    it('should indent the usage section', () => {
+      const config: HelpConfig = { sections: { usage: 'usage' }, indent: { usage: 0 } };
+      const message = new HelpFormatter(new OptionValidator({}), config).formatFull();
+      expect(message.wrap()).toEqual('Usage:\n\nusage');
+    });
+
+    it('should break the usage section', () => {
+      const config: HelpConfig = { sections: { usage: 'usage' }, breaks: { usage: 1 } };
+      const message = new HelpFormatter(new OptionValidator({}), config).formatFull();
+      expect(message.wrap()).toEqual('Usage:\n  usage');
+    });
+
+    it('should break the usage section title', () => {
+      const config: HelpConfig = {
+        sections: { intro: 'intro', usage: 'usage' },
+        breaks: { usageTitle: 1 },
+      };
+      const message = new HelpFormatter(new OptionValidator({}), config).formatFull();
+      expect(message.wrap()).toEqual('intro\nUsage:\n\n  usage');
+    });
+
+    it('should render the footer section', () => {
+      const config: HelpConfig = { sections: { footer: 'footer' } };
+      const message = new HelpFormatter(new OptionValidator({}), config).formatFull();
+      expect(message.wrap()).toEqual('footer');
+    });
+
+    it('should omit the footer section', () => {
+      const config: HelpConfig = { sections: { footer: 'footer' } };
+      const hide: HideSections = { footer: true };
+      const message = new HelpFormatter(new OptionValidator({}), config).formatFull(hide);
+      expect(message.wrap()).toEqual('');
+    });
+
+    it('should indent the footer section', () => {
+      const config: HelpConfig = { sections: { footer: 'footer' }, indent: { footer: 2 } };
+      const message = new HelpFormatter(new OptionValidator({}), config).formatFull();
+      expect(message.wrap()).toEqual('  footer');
+    });
+
+    it('should break the footer section', () => {
+      const config: HelpConfig = {
+        sections: { intro: 'intro', footer: 'footer' },
+        breaks: { footer: 1 },
+      };
+      const message = new HelpFormatter(new OptionValidator({}), config).formatFull();
+      expect(message.wrap()).toEqual('intro\nfooter');
+    });
+
+    it('should render the option groups', () => {
+      const options = {
+        flag: {
+          type: 'flag',
+          names: ['-f', '--flag'],
+          desc: 'A flag option.',
+        },
+      } as const satisfies Options;
+      const message = new HelpFormatter(new OptionValidator(options)).formatFull();
+      expect(message.wrap()).toEqual('Options:\n\n  -f, --flag    A flag option.');
+    });
+
+    it('should render the default option group with a custom name', () => {
+      const options = {
+        flag: {
+          type: 'flag',
+          names: ['-f', '--flag'],
+          desc: 'A flag option.',
+        },
+      } as const satisfies Options;
+      const config: HelpConfig = { sections: { optionsTitle: 'title' } };
+      const message = new HelpFormatter(new OptionValidator(options), config).formatFull();
+      expect(message.wrap()).toEqual('title:\n\n  -f, --flag    A flag option.');
+    });
+
+    it('should omit the option groups', () => {
+      const options = {
+        flag: {
+          type: 'flag',
+          names: ['-f', '--flag'],
+          desc: 'A flag option.',
+        },
+      } as const satisfies Options;
+      const hide: HideSections = { groups: true };
+      const message = new HelpFormatter(new OptionValidator(options)).formatFull(hide);
+      expect(message.wrap()).toEqual('');
+    });
+
+    it('should break the option groups', () => {
+      const options = {
+        flag: {
+          type: 'flag',
+          names: ['-f', '--flag'],
+          desc: 'A flag option.',
+        },
+      } as const satisfies Options;
+      const config: HelpConfig = { breaks: { groups: 1 } };
+      const message = new HelpFormatter(new OptionValidator(options), config).formatFull();
+      expect(message.wrap()).toEqual('Options:\n  -f, --flag    A flag option.');
+    });
+
+    it('should break the option group headings', () => {
+      const options = {
+        flag: {
+          type: 'flag',
+          names: ['-f', '--flag'],
+          desc: 'A flag option.',
+        },
+      } as const satisfies Options;
+      const config: HelpConfig = { sections: { intro: 'intro' }, breaks: { groupTitle: 1 } };
+      const message = new HelpFormatter(new OptionValidator(options), config).formatFull();
+      expect(message.wrap()).toEqual('intro\nOptions:\n\n  -f, --flag    A flag option.');
+    });
+
+    it('should render the default usage text', () => {
+      const options = {
+        flag: {
+          type: 'flag',
+          names: ['-f', '--flag'],
+          desc: 'A flag option.',
+        },
+      } as const satisfies Options;
+      const config: HelpConfig = { sections: { usage: true } };
+      const message = new HelpFormatter(new OptionValidator(options), config).formatFull();
+      expect(message.wrap()).toEqual(
+        'Usage:\n\n  [(-f|--flag)]\n\nOptions:\n\n  -f, --flag    A flag option.',
+      );
+    });
+
+    it('should render the default usage text with a program title', () => {
+      const options = {
+        flag: {
+          type: 'flag',
+          names: ['-f', '--flag'],
+          desc: 'A flag option.',
+        },
+      } as const satisfies Options;
+      const validator = new OptionValidator(options);
+      const config: HelpConfig = { sections: { usage: true } };
+      const message = new HelpFormatter(validator, config).formatFull({}, 'prog');
+      expect(message.wrap()).toEqual(
+        'Usage:\n\n  prog [(-f|--flag)]\n\nOptions:\n\n  -f, --flag    A flag option.',
+      );
+    });
+
+    it('should indent the usage options in the default usage text with a program title', () => {
+      const options = {
+        flag: {
+          type: 'flag',
+          names: ['-f', '--flag'],
+          desc: 'A flag option.',
+        },
+      } as const satisfies Options;
+      const validator = new OptionValidator(options);
+      const config: HelpConfig = { sections: { usage: true }, indent: { usageOptions: 2 } };
+      const message = new HelpFormatter(validator, config).formatFull({}, 'prog');
+      expect(message.wrap()).toEqual(
+        'Usage:\n\n  prog  [(-f|--flag)]\n\nOptions:\n\n  -f, --flag    A flag option.',
+      );
+    });
+
+    it('should break the usage options in the default usage text with a program title', () => {
+      const options = {
+        flag: {
+          type: 'flag',
+          names: ['-f', '--flag'],
+          desc: 'A flag option.',
+        },
+      } as const satisfies Options;
+      const validator = new OptionValidator(options);
+      const config: HelpConfig = { sections: { usage: true }, breaks: { usageOptions: 1 } };
+      const message = new HelpFormatter(validator, config).formatFull({}, 'prog');
+      expect(message.wrap()).toEqual(
+        'Usage:\n\n  prog\n       [(-f|--flag)]\n\nOptions:\n\n  -f, --flag    A flag option.',
+      );
+    });
+
+    it('should indent the usage options in the default usage text with a program title, relative to the beginning of the line', () => {
+      const options = {
+        flag: {
+          type: 'flag',
+          names: ['-f', '--flag'],
+          desc: 'A flag option.',
+        },
+      } as const satisfies Options;
+      const validator = new OptionValidator(options);
+      const config: HelpConfig = {
+        sections: { usage: true },
+        indent: { usageOptionsAbsolute: true },
+        breaks: { usageOptions: 1 },
+      };
+      const message = new HelpFormatter(validator, config).formatFull({}, 'prog');
+      expect(message.wrap()).toEqual(
+        'Usage:\n\n  prog\n [(-f|--flag)]\n\nOptions:\n\n  -f, --flag    A flag option.',
+      );
+    });
+
+    it('should indent all headings', () => {
+      const options = {
+        flag: {
+          type: 'flag',
+          names: ['-f', '--flag'],
+          desc: 'A flag option.',
+        },
+      } as const satisfies Options;
+      const config: HelpConfig = { sections: { usage: 'usage' }, indent: { headings: 2 } };
+      const message = new HelpFormatter(new OptionValidator(options), config).formatFull();
+      expect(message.wrap()).toEqual(
+        '  Usage:\n\n  usage\n\n  Options:\n\n  -f, --flag    A flag option.',
+      );
+    });
+
+    it('should stylize all headings', () => {
+      const options = {
+        flag: {
+          type: 'flag',
+          names: ['-f', '--flag'],
+          desc: 'A flag option.',
+        },
+      } as const satisfies Options;
+      const config: HelpConfig = {
+        sections: { usage: 'usage' },
+        misc: { headingStyle: style(tf.clear) },
+      };
+      const message = new HelpFormatter(new OptionValidator(options), config).formatFull();
+      expect(message.wrap(0, true)).toMatch(/\x9b0mUsage:.+\x9b0mOptions:/s);
+    });
+
+    it('should use custom phrase for all headings', () => {
+      const options = {
+        flag: {
+          type: 'flag',
+          names: ['-f', '--flag'],
+          desc: 'A flag option.',
+        },
+      } as const satisfies Options;
+      const config: HelpConfig = { sections: { usage: 'usage' }, misc: { headingPhrase: '[%s]' } };
+      const message = new HelpFormatter(new OptionValidator(options), config).formatFull();
+      expect(message.wrap()).toEqual(
+        '[Usage]\n\n  usage\n\n[Options]\n\n  -f, --flag    A flag option.',
+      );
+    });
+
+    it('should not wrap section texts', () => {
+      const options = {
+        flag: {
+          type: 'flag',
+          names: ['-f', '--flag'],
+          desc: 'A flag option.',
+        },
+      } as const satisfies Options;
+      const config: HelpConfig = {
+        sections: {
+          intro: '  intro',
+          usage: 'usage  text',
+          footer: '  footer',
+          usageTitle: 'usage  title',
+          optionsTitle: 'options  title',
+        },
+        misc: { noWrap: true },
+      };
+      const message = new HelpFormatter(new OptionValidator(options), config).formatFull();
+      expect(message.wrap()).toEqual(
+        '  intro\n\nusage  title:\n\n  usage  text\n\noptions  title:\n\n  -f, --flag    A flag option.\n\n  footer',
+      );
+    });
+  });
+});

--- a/packages/tsargp/test/formatter/formatter.sections.spec.ts
+++ b/packages/tsargp/test/formatter/formatter.sections.spec.ts
@@ -250,6 +250,24 @@ describe('HelpFormatter', () => {
       );
     });
 
+    it('should stylize the default usage text', () => {
+      const options = {
+        flag: {
+          type: 'flag',
+          names: ['-f', '--flag'],
+          desc: 'A flag option.',
+        },
+      } as const satisfies Options;
+      const validator = new OptionValidator(options);
+      const config: HelpConfig = {
+        sections: { usage: true },
+        styles: { usage: style(tf.italic) },
+      };
+      const message = new HelpFormatter(validator, config).formatFull();
+      // cspell:disable-next-line
+      expect(message.wrap(0, true)).toMatch(/\x9b3m\[\(.+-f\x9b3m\|.+--flag\x9b3m\)\]/);
+    });
+
     it('should render the default usage text with a program title', () => {
       const options = {
         flag: {
@@ -318,6 +336,23 @@ describe('HelpFormatter', () => {
       );
     });
 
+    it('should stylize the default usage text with a program title', () => {
+      const options = {
+        flag: {
+          type: 'flag',
+          names: ['-f', '--flag'],
+          desc: 'A flag option.',
+        },
+      } as const satisfies Options;
+      const validator = new OptionValidator(options);
+      const config: HelpConfig = {
+        sections: { usage: true },
+        styles: { usage: style(tf.italic) },
+      };
+      const message = new HelpFormatter(validator, config).formatFull({}, 'prog');
+      expect(message.wrap(0, true)).toMatch(/\x9b3mprog/); // cspell:disable-line
+    });
+
     it('should use custom phrase for all headings', () => {
       const options = {
         flag: {
@@ -367,7 +402,7 @@ describe('HelpFormatter', () => {
         },
       } as const satisfies Options;
       const validator = new OptionValidator(options);
-      const config: HelpConfig = { sections: { usage: true } };
+      const config: HelpConfig = { sections: { usage: true }, breaks: { usageOptions: 1 } };
       const message = new HelpFormatter(validator, config).formatFull({}, 'prog');
       expect(message.wrap()).toEqual(
         'Usage:\n\n  prog\n\nOptions:\n\n  -f, --flag    A flag option.',

--- a/packages/tsargp/test/parser/parser.spec.ts
+++ b/packages/tsargp/test/parser/parser.spec.ts
@@ -64,7 +64,7 @@ describe('ArgumentParser', () => {
         try {
           parser.parse(['-h']);
         } catch (err) {
-          expect((err as HelpMessage).wrap(0)).toMatch(/^Args:\n\n {2}-f\n\nOptions:\n\n {2}-h\n/);
+          expect((err as HelpMessage).wrap(0)).toMatch(/^Args:\n\n {2}-f\n\nOptions:\n\n {2}-h/);
         }
       });
 
@@ -73,10 +73,14 @@ describe('ArgumentParser', () => {
           help: {
             type: 'help',
             names: ['-h'],
-            usage: 'example  usage',
-            footer: 'example  footer',
             group: 'example  heading',
-            format: { indent: { names: 0 } },
+            format: {
+              sections: {
+                usage: 'example  usage',
+                footer: 'example  footer',
+              },
+              indent: { usage: 0, names: 0 },
+            },
           },
         } as const satisfies Options;
         const parser = new ArgumentParser(options);
@@ -85,20 +89,24 @@ describe('ArgumentParser', () => {
           parser.parse(['-h']);
         } catch (err) {
           expect((err as HelpMessage).wrap(0)).toMatch(
-            /^example usage\n\nexample heading:\n\n-h\n\nexample footer\n/,
+            /^Usage:\n\nexample usage\n\nexample heading:\n\n-h\n\nexample footer/,
           );
         }
       });
 
-      it('should throw a help message that does not split texts into words', () => {
+      it('should throw a help message that does not wrap texts', () => {
         const options = {
           help: {
             type: 'help',
             names: ['-h'],
-            usage: '  example  usage',
-            footer: '  example  footer',
             group: '  example  heading',
-            noSplit: true,
+            format: {
+              sections: {
+                usage: '  example  usage',
+                footer: '  example  footer',
+              },
+              misc: { noWrap: true, headingPhrase: '%s' },
+            },
           },
         } as const satisfies Options;
         const parser = new ArgumentParser(options);
@@ -106,7 +114,7 @@ describe('ArgumentParser', () => {
           parser.parse(['-h']);
         } catch (err) {
           expect((err as HelpMessage).wrap(0)).toMatch(
-            /^ {2}example {2}usage\n\n {2}example {2}heading\n\n {2}-h\n\n {2}example {2}footer\n/,
+            /^Usage\n\n {4}example {2}usage\n\n {2}example {2}heading\n\n {2}-h\n\n {2}example {2}footer/,
           );
         }
       });


### PR DESCRIPTION
Added the `formatFull` method to the help formatter, that implements sections in the help message. The full help can be configured with the new `HelpConfig` properties: `sections`, `styles` amd `misc`.

Some attributes were temoved from the help option, as they are not needed anymore.

The Formatter page was updated to document the new `formatFull` method.

> [!NOTE]
> We will _not_ go through a deprecation process, since the library is under active development and not currently used by other packages.

Closes #19 
