### PR TITLE
Issues/47

### DIFF
--- a/.changeset/gorgeous-singers-hope.md
+++ b/.changeset/gorgeous-singers-hope.md
@@ -2,4 +2,4 @@
 'tsargp': minor
 ---
 
-Added a help format configuration named `compactNames`, that can be used to remove the extra spacing between option names in the help message.
+Added a help format configuration named `align`, that can be used to select the alignment of option names in the help message.

--- a/.changeset/gorgeous-singers-hope.md
+++ b/.changeset/gorgeous-singers-hope.md
@@ -1,0 +1,5 @@
+---
+'tsargp': minor
+---
+
+Added a help format configuration named `compactNames`, that can be used to remove the extra spacing between option names in the help message.

--- a/packages/docs/pages/docs/library/formatter.mdx
+++ b/packages/docs/pages/docs/library/formatter.mdx
@@ -44,11 +44,11 @@ containing a piece of information, as described below.
 
 ### Names column
 
-This column contains the option's names separated by commas. The names are listed in the same order
+This column contains the options' names separated by commas. The names are listed in the same order
 specified in the [names](options.mdx#names--preferred-name) attribute.
 
 Depending on the [alignment](#text-alignment) configuration, each option name may reserve a "slot"
-in the corresponding index in this column, and the length of a name slot will be the length of the
+in the respective index in this column, and the length of a name slot will be the length of the
 largest name in that slot, among all options.
 
 For example, if an option's names are `'-f'{:ts}`, `'-ff'{:ts}`, `''{:ts}` and `'--flag'{:ts}`, the

--- a/packages/docs/pages/docs/library/formatter.mdx
+++ b/packages/docs/pages/docs/library/formatter.mdx
@@ -45,9 +45,11 @@ containing a piece of information, as described below.
 ### Names column
 
 This column contains the option's names separated by commas. The names are listed in the same order
-specified in the [names](options.mdx#names--preferred-name) attribute. Each option name reserves a
-"slot" in the corresponding index in this column, and the length of a name slot will be the length
-of the largest name in that slot, among all options.
+specified in the [names](options.mdx#names--preferred-name) attribute.
+
+Depending on the [alignment](#text-alignment) configuration, each option name may reserve a "slot"
+in the corresponding index in this column, and the length of a name slot will be the length of the
+largest name in that slot, among all options.
 
 For example, if an option's names are `'-f'{:ts}`, `'-ff'{:ts}`, `''{:ts}` and `'--flag'{:ts}`, the
 resulting entry might be formatted as:
@@ -158,10 +160,24 @@ columns. It has the following set of optional properties:
   `true{:ts}`, defaults to `2{:ts}`)
 - `descr` - level of indentation for the option description (non-negative if `descrAbsolute` is
   `true{:ts}`, defaults to `2{:ts}`)
-- `paramAbsolute` whether the indentation level for the option parameter should be relative to the
+- `paramAbsolute` - whether the indentation level for the option parameter should be relative to the
   beginning of the line instead of the end of the option names (defaults to `false{:ts}`)
-- `descrAbsolute` whether the indentation level for the option description should be relative to the
+- `descrAbsolute` - whether the indentation level for the option description should be relative to the
   beginning of the line instead of the end of the option parameter (defaults to `false{:ts}`)
+
+### Text alignment
+
+The `align` property specifies the `Alignment` of help entry columns. It has the following set of
+optional properties:
+
+- `names` - alignment for the names column (defaults to `'justified'{:ts}`)
+
+Possible values for each of these settings are `'left'{:ts}`, `'right'{:ts}` or `'justified'{:ts}`.
+
+<Callout type="info">
+  In the case of `names`, justified means that each name receives a "slot" in the names column, and
+  the name is left-aligned within that slot. See [names column](#names-column) for more information.
+</Callout>
 
 ### Line breaks
 

--- a/packages/docs/pages/docs/library/options.mdx
+++ b/packages/docs/pages/docs/library/options.mdx
@@ -388,15 +388,11 @@ Niladic options do not expect any parameter on the command-line. With the notabl
 ### Help option
 
 The **help** option is a convenient specialization of the [function option](#function-option) that
-handles the formatting of help messages. Internally, it performs the following actions:
+handles the formatting of help messages. Internally, it instantiates a [formatter](formatter.mdx)
+class with the provided configuration, obtains a formatted message and throws it. The application
+is responsible for catching this message and printing it in a terminal.
 
-1. instantiate a [formatter](formatter.mdx) class with the provided (or default) configuration
-2. get the formatted messages, one for each option group
-3. assemble them into a single message interspersed with group headings
-4. throw the resulting message
-
-The application should catch the message and print it in a terminal. This option has the following
-optional attributes.
+This option has the following optional attributes.
 
 #### Help format
 

--- a/packages/tsargp/lib/formatter.ts
+++ b/packages/tsargp/lib/formatter.ts
@@ -606,13 +606,13 @@ function getMaxNamesWidth(options: Options): number {
   for (const key in options) {
     const option = options[key];
     if (!option.hide && option.names) {
-      let sum = 0;
+      let len = 0;
       for (const name of option.names) {
         if (name) {
-          sum += (sum ? 2 : 0) + name.length;
+          len += (len ? 2 : 0) + name.length;
         }
       }
-      result = Math.max(result, sum);
+      result = Math.max(result, len);
     }
   }
   return result;
@@ -695,10 +695,9 @@ function formatNameSlots(
       if (str) {
         str.addClosing(',');
       }
-      str = new TerminalString(indent, breaks);
-      breaks = 0; // break only on the first name
-      str.addAndRevert(namesStyle, name, defStyle);
+      str = new TerminalString(indent, breaks).addAndRevert(namesStyle, name, defStyle);
       result.push(str);
+      breaks = 0; // break only on the first name
     } else {
       str = undefined;
     }

--- a/packages/tsargp/lib/formatter.ts
+++ b/packages/tsargp/lib/formatter.ts
@@ -24,6 +24,11 @@ import { assert, splitPhrase } from './utils';
 // Types
 //--------------------------------------------------------------------------------------------------
 /**
+ * A text alignment setting.
+ */
+export type Alignment = 'left' | 'right' | 'justified';
+
+/**
  * The help format configuration.
  */
 export type HelpConfig = {
@@ -53,10 +58,19 @@ export type HelpConfig = {
      * of the line instead of the end of the parameter column. (Defaults to false)
      */
     readonly descrAbsolute?: boolean;
+  };
+
+  /**
+   * The alignment settings for each help entry column.
+   */
+  readonly align?: {
     /**
-     * True if name slots should not have extra spacing. (Defaults to false)
+     * The alignment of the names column. (Defaults to 'justified')
+     *
+     * Justified here means that each name receives a "slot" in the names column, and the name is
+     * left-aligned within that slot.
      */
-    readonly compactNames?: boolean;
+    readonly names?: Alignment;
   };
 
   /**
@@ -243,7 +257,9 @@ const defaultConfig: ConcreteFormat = {
     descr: 2,
     paramAbsolute: false,
     descrAbsolute: false,
-    compactNames: false,
+  },
+  align: {
+    names: 'justified',
   },
   breaks: {
     names: 0,
@@ -354,7 +370,7 @@ export class HelpFormatter {
     this.config = mergeConfig(config);
     this.nameWidths = this.config.hidden.names
       ? 0
-      : this.config.indent.compactNames
+      : this.config.align.names === 'left'
         ? getMaxNamesWidth(this.options)
         : getNameWidths(this.options);
     let paramWidth = 0;
@@ -545,6 +561,7 @@ export class HelpFormatter {
 function mergeConfig(config: HelpConfig): ConcreteFormat {
   return {
     indent: { ...defaultConfig.indent, ...config.indent },
+    align: { ...defaultConfig.align, ...config.align },
     breaks: { ...defaultConfig.breaks, ...config.breaks },
     hidden: { ...defaultConfig.hidden, ...config.hidden },
     items: config.items ?? defaultConfig.items,

--- a/packages/tsargp/test/formatter/formatter.formatting.spec.ts
+++ b/packages/tsargp/test/formatter/formatter.formatting.spec.ts
@@ -200,7 +200,7 @@ describe('HelpFormatter', () => {
       expect(message.wrap()).toEqual('  -b, --boolean  <boolean>\n');
     });
 
-    it('should indent name slots in compact mode', () => {
+    it('should align option names to the left boundary', () => {
       const options = {
         flag: {
           type: 'flag',
@@ -208,7 +208,7 @@ describe('HelpFormatter', () => {
           desc: 'A flag option',
         },
       } as const satisfies Options;
-      const config: HelpConfig = { indent: { compactNames: true } };
+      const config: HelpConfig = { align: { names: 'left' } };
       const message = new HelpFormatter(new OptionValidator(options), config).formatHelp();
       expect(message.wrap()).toEqual('  -f, --flag    A flag option\n');
     });

--- a/packages/tsargp/test/formatter/formatter.formatting.spec.ts
+++ b/packages/tsargp/test/formatter/formatter.formatting.spec.ts
@@ -202,15 +202,42 @@ describe('HelpFormatter', () => {
 
     it('should align option names to the left boundary', () => {
       const options = {
-        flag: {
+        flag1: {
           type: 'flag',
           names: ['-f', null, '--flag'],
+          desc: 'A flag option',
+        },
+        flag2: {
+          type: 'flag',
+          names: [null, '--flag2', null],
           desc: 'A flag option',
         },
       } as const satisfies Options;
       const config: HelpConfig = { align: { names: 'left' } };
       const message = new HelpFormatter(new OptionValidator(options), config).formatHelp();
-      expect(message.wrap()).toEqual('  -f, --flag    A flag option\n');
+      expect(message.wrap()).toEqual(
+        '  -f, --flag    A flag option\n  --flag2       A flag option\n',
+      );
+    });
+
+    it('should align option names to the right boundary', () => {
+      const options = {
+        flag1: {
+          type: 'flag',
+          names: ['-f', null, '--flag'],
+          desc: 'A flag option',
+        },
+        flag2: {
+          type: 'flag',
+          names: [null, '--flag2', null],
+          desc: 'A flag option',
+        },
+      } as const satisfies Options;
+      const config: HelpConfig = { align: { names: 'right' } };
+      const message = new HelpFormatter(new OptionValidator(options), config).formatHelp();
+      expect(message.wrap()).toEqual(
+        '  -f, --flag    A flag option\n     --flag2    A flag option\n',
+      );
     });
   });
 });

--- a/packages/tsargp/test/formatter/formatter.formatting.spec.ts
+++ b/packages/tsargp/test/formatter/formatter.formatting.spec.ts
@@ -101,7 +101,7 @@ describe('HelpFormatter', () => {
 
     it('should not break columns in the help message when configured with negative values', () => {
       const options = {
-        flag: {
+        boolean: {
           type: 'boolean',
           names: ['-b', '--boolean'],
           desc: 'A boolean option',
@@ -114,7 +114,7 @@ describe('HelpFormatter', () => {
 
     it('should break columns in the help message when configured with positive indentation', () => {
       const options = {
-        flag: {
+        boolean: {
           type: 'boolean',
           names: ['-b', '--boolean'],
           desc: 'A boolean option',
@@ -129,7 +129,7 @@ describe('HelpFormatter', () => {
 
     it('should break columns in the help message when configured with absolute indentation', () => {
       const options = {
-        flag: {
+        boolean: {
           type: 'boolean',
           names: ['-b', '--boolean'],
           desc: 'A boolean option',
@@ -147,7 +147,7 @@ describe('HelpFormatter', () => {
 
     it('should break columns in the help message when configured with negative indentation', () => {
       const options = {
-        flag: {
+        boolean: {
           type: 'boolean',
           names: ['-b', '--boolean'],
           desc: 'A boolean option',
@@ -163,7 +163,7 @@ describe('HelpFormatter', () => {
 
     it('should hide the option names from the help message when configured to do so', () => {
       const options = {
-        flag: {
+        boolean: {
           type: 'boolean',
           names: ['-b', '--boolean'],
           desc: 'A boolean option',
@@ -176,7 +176,7 @@ describe('HelpFormatter', () => {
 
     it('should hide the option param from the help message when configured to do so', () => {
       const options = {
-        flag: {
+        boolean: {
           type: 'boolean',
           names: ['-b', '--boolean'],
           desc: 'A boolean option',
@@ -189,7 +189,7 @@ describe('HelpFormatter', () => {
 
     it('should hide the option description from the help message when configured to do so', () => {
       const options = {
-        flag: {
+        boolean: {
           type: 'boolean',
           names: ['-b', '--boolean'],
           desc: 'A boolean option',
@@ -198,6 +198,19 @@ describe('HelpFormatter', () => {
       const config: HelpConfig = { hidden: { descr: true } };
       const message = new HelpFormatter(new OptionValidator(options), config).formatHelp();
       expect(message.wrap()).toEqual('  -b, --boolean  <boolean>\n');
+    });
+
+    it('should indent name slots in compact mode', () => {
+      const options = {
+        flag: {
+          type: 'flag',
+          names: ['-f', null, '--flag'],
+          desc: 'A flag option',
+        },
+      } as const satisfies Options;
+      const config: HelpConfig = { indent: { compactNames: true } };
+      const message = new HelpFormatter(new OptionValidator(options), config).formatHelp();
+      expect(message.wrap()).toEqual('  -f, --flag    A flag option\n');
     });
   });
 });


### PR DESCRIPTION
Added a help format configuration named `align`, that can be used to select the alignment of option names in the help message.

Closes #47 
