### PR TITLE
Issues/13

### DIFF
--- a/.changeset/clever-years-smoke.md
+++ b/.changeset/clever-years-smoke.md
@@ -1,0 +1,5 @@
+---
+'tsargp': minor
+---
+
+Added text alignment settings for option parameter and description in the help message. Added a `rightAlign` property to terminal strings, that makes the wrapping procedure align text to the terminal's width.

--- a/.changeset/clever-years-smoke.md
+++ b/.changeset/clever-years-smoke.md
@@ -2,4 +2,4 @@
 'tsargp': minor
 ---
 
-Added text alignment settings for option parameter and description in the help message. Added a `rightAlign` property to terminal strings, that makes the wrapping procedure align text to the terminal's width.
+Added text alignment settings for option parameter and description in the help message. Added a `rightAlign` property to terminal strings, that makes the wrapping procedure align text to the terminal's right boundary.

--- a/.changeset/rotten-fishes-cross.md
+++ b/.changeset/rotten-fishes-cross.md
@@ -1,0 +1,5 @@
+---
+'@trulysimple/tsargp-docs': minor
+---
+
+Updated the Formatter page to document the new alignment settings for option parameters and description in the help message. Added a section in the Styles page for the new right-alignment feature of the wrapping procedure.

--- a/packages/docs/pages/docs/library/formatter.mdx
+++ b/packages/docs/pages/docs/library/formatter.mdx
@@ -71,7 +71,8 @@ This column contains either:
 ### Description column
 
 The last column contains the option description and is composed of [help items](#help-items), which
-are explained later in this page.
+are explained later in this page. This column may be configured to be
+[right-aligned](#text-alignment).
 
 ## Help sections
 
@@ -172,6 +173,10 @@ optional properties:
 
 - `names` - alignment for the option names (can be one of `'left'{:ts}`, `'right'{:ts}` or
   `'justified'{:ts}`, defaults to `'justified'{:ts}`)
+- `param` - alignment for the option parameter (can be one of `'left'{:ts}` or `'right'{:ts}`,
+  defaults to `'left'{:ts}`)
+- `descr` - alignment for the option description (can be one of `'left'{:ts}` or `'right'{:ts}`,
+  defaults to `'left'{:ts}`)
 
 <Callout type="info">
   In the case of `names`, justified means that each name receives a "slot" in the names column, and

--- a/packages/docs/pages/docs/library/styles.mdx
+++ b/packages/docs/pages/docs/library/styles.mdx
@@ -188,7 +188,7 @@ instead wrapped relative to the beginning of each line.
 #### Text alignment
 
 A terminal string optionally has a flag that indicates whether it should be aligned to the
-terminal's right boundary when being wrapped. This feature is used by the formatter in the option
+terminal's right boundary when being wrapped. This feature is used by the formatter in the help's
 [description column](formatter.mdx#description-column).
 
 ## Terminal messages

--- a/packages/docs/pages/docs/library/styles.mdx
+++ b/packages/docs/pages/docs/library/styles.mdx
@@ -185,6 +185,12 @@ terminal column. When wrapping text to a desired width, it tries to respect this
 the desired width does not accommodate the text while respecting its indentation level, the text is
 instead wrapped relative to the beginning of each line.
 
+#### Text alignment
+
+A terminal string optionally has a flag that indicates whether it should be aligned to the
+terminal's right boundary when being wrapped. This feature is used by the formatter in the option
+[description column](formatter.mdx#description-column).
+
 ## Terminal messages
 
 The `TerminalMessage` is a base class that wraps a list of terminal strings. It provides a `wrap`

--- a/packages/tsargp/test/formatter/formatter.formatting.spec.ts
+++ b/packages/tsargp/test/formatter/formatter.formatting.spec.ts
@@ -231,5 +231,23 @@ describe('HelpFormatter', () => {
       const message = new HelpFormatter(new OptionValidator(options), config).formatHelp();
       expect(message.wrap()).toEqual('  -f, --flag\n     --flag2\n');
     });
+
+    it('should align option parameters to the right boundary', () => {
+      const options = {
+        numbers1: {
+          type: 'numbers',
+          names: ['-ns1'],
+          example: [1, 2],
+        },
+        numbers2: {
+          type: 'numbers',
+          names: ['-ns2'],
+          example: [1],
+        },
+      } as const satisfies Options;
+      const config: HelpConfig = { align: { param: 'right' }, items: [] };
+      const message = new HelpFormatter(new OptionValidator(options), config).formatHelp();
+      expect(message.wrap()).toEqual('  -ns1  1 2\n  -ns2    1\n');
+    });
   });
 });

--- a/packages/tsargp/test/styles/styles.wrapping.spec.ts
+++ b/packages/tsargp/test/styles/styles.wrapping.spec.ts
@@ -86,19 +86,19 @@ describe('TerminalString', () => {
       it('should wrap relative to the beginning when the largest word does not fit the width (1)', () => {
         const result = new Array<string>();
         new TerminalString(1).splitText('abc largest').wrapToWidth(result, 0, 5, false);
-        expect(result).toEqual(['abc', '\nlargest']);
+        expect(result).toEqual(['abc', '\n', 'largest']);
       });
 
       it('should wrap relative to the beginning when the largest word does not fit the width (2)', () => {
         const result = new Array<string>();
         new TerminalString(1).splitText('abc largest').wrapToWidth(result, 1, 5, false);
-        expect(result).toEqual(['\n', 'abc', '\nlargest']);
+        expect(result).toEqual(['\n', 'abc', '\n', 'largest']);
       });
 
       it('should wrap relative to the beginning when the largest word does not fit the width (3)', () => {
         const result = new Array<string>();
         new TerminalString(1).addBreak().splitText('abc largest').wrapToWidth(result, 1, 5, false);
-        expect(result).toEqual(['\n', 'abc', '\nlargest']);
+        expect(result).toEqual(['\n', 'abc', '\n', 'largest']);
       });
 
       it('should wrap with a move sequence when the largest word fits the width (1)', () => {
@@ -122,7 +122,7 @@ describe('TerminalString', () => {
       it('should wrap with a move sequence when the largest word fits the width (4)', () => {
         const result = new Array<string>();
         new TerminalString(1).splitText('abc largest').wrapToWidth(result, 1, 10, false);
-        expect(result).toEqual(['abc', `\n${seq(cs.cha, 2)}largest`]);
+        expect(result).toEqual(['abc', `\n${seq(cs.cha, 2)}`, 'largest']);
       });
 
       it('should wrap with a move sequence when the largest word fits the width (5)', () => {
@@ -175,6 +175,20 @@ describe('TerminalString', () => {
         const result = new Array<string>();
         new TerminalString().splitText('⚠️ abc').wrapToWidth(result, 0, 10, false);
         expect(result).toEqual(['⚠️', ' abc']);
+      });
+    });
+
+    describe('when right-aligned', () => {
+      it('should align when breaking the line', () => {
+        const result = new Array<string>();
+        new TerminalString(0, 0, true).addWord('abc').addBreak().wrapToWidth(result, 0, 10, false);
+        expect(result).toEqual([seq(cs.cuf, 7), 'abc', '\n']);
+      });
+
+      it('should align when wrapping the line', () => {
+        const result = new Array<string>();
+        new TerminalString(0, 0, true).splitText('type script').wrapToWidth(result, 0, 10, false);
+        expect(result).toEqual([seq(cs.cuf, 6), 'type', '\n', seq(cs.cuf, 4), 'script']);
       });
     });
   });


### PR DESCRIPTION
New properties, `param` and `descr`, were added to the text alignment settings of `HelpConfig`. A new property, `rightAlign`, was added to the `TerminalString` class, that makes the `wrapToWidth` method align text to the terminal's right boundary.

The Formatter page was updated to document the new alignment settings. A new section was added to the Styles page, to document the new right-alignment feature of the wrapping procedure.

Closes #13 
