### PR TITLE
Issues/12

### DIFF
--- a/.changeset/red-panthers-cough.md
+++ b/.changeset/red-panthers-cough.md
@@ -1,0 +1,5 @@
+---
+'tsargp': minor
+---
+
+Added the `clusterLetters` attribute to valued options, to support the so called "short-options" style. Added the `shortStyle` configuration property to the parser configuration, to indicate that the first command-line argument is expected to be an option cluster. These two must be used in conjunction.

--- a/.changeset/sweet-pianos-rule.md
+++ b/.changeset/sweet-pianos-rule.md
@@ -1,0 +1,5 @@
+---
+'@trulysimple/tsargp-docs': minor
+---
+
+The Parser page was updated to document the new `shortStyle` configuration property. A new section called `Miscellaneous attributes` was added to the Options page, under which the `clusterLetters` attribute was documented. The `envVar` attribute was moved to this section.

--- a/packages/docs/pages/docs/index.mdx
+++ b/packages/docs/pages/docs/index.mdx
@@ -18,7 +18,7 @@ title: Introduction - Docs
 | ESM-native             | Asynchronous callbacks  | Custom phrases           |
 | Online documentation   | Recursive commands      | Option grouping/hiding   |
 
-[^1]: ~32KB minified
+[^1]: ~33KB minified
 
 ## Motivation
 

--- a/packages/docs/pages/docs/library/options.mdx
+++ b/packages/docs/pages/docs/library/options.mdx
@@ -210,17 +210,6 @@ If they were defined in the `requiredIf` attribute, they would mean:
   During requirement evaluation, values are compared _after_ being normalized.
 </Callout>
 
-#### Environment variable
-
-The `envVar` attribute, if present, specifies the name of an environment variable from which the
-option value will be read, in case the option is not specified on the command-line. Explicitly _not_
-available for [function options](#function-option) and [command options](#command-option).
-
-<Callout type="info">
-  If the environemnt variable for an option is found, the option is counted as if it were specified
-  on the command-line, which has implications for the evaluation of other option's requirements.
-</Callout>
-
 ### Parameter attributes
 
 All non-niladic option types share a set of attributes, which are described below.
@@ -377,6 +366,52 @@ The `limit` attribute, if present, indicates the maximum allowed number of array
 parameter that causes the option value to _exceed_ the given limit (after normalization) will cause
 an error to be thrown.
 
+### Miscellaneous attributes
+
+Some attributes are shared by all valued option types except [function options](#function-option)
+and [command options](#command-option). They are described below.
+
+#### Environment variable
+
+The `envVar` attribute, if present, specifies the name of an environment variable from which the
+option value will be read, in case the option is not specified on the command-line.
+
+<Callout type="info">
+  If the environemnt variable for an option is found, the option is counted as if it were specified
+  on the command-line, which has implications for the evaluation of other option's requirements.
+</Callout>
+
+#### Cluster letters
+
+The `clusterLetters` attribute, if present, specifies letters (or Unicode characters) that can be
+used to cluster options in the first command-line argument. This is also known as _short-option_
+style. This feature can enabled via the parser's [short-option style](parser.mdx#short-option-style)
+configuration property.
+
+Here is an example that illustrates how it works. Suppose we have the following options:
+
+- flag option, with name `'--flag'{:ts}` and letters `'fF'{:ts}`
+- string option, with name `'--str'{:ts}` and letters `'sS'{:ts}`
+- number option, with name `'--num'{:ts}` and letters `'nN'{:ts}`
+
+Given these options, the following invocations would be equivalent:
+
+```sh
+my_cli fsn 'my string' 123
+my_cli -fsn 'my string' 123
+my_cli fSN 'my string' 123
+my_cli -Fsn 'my string' 123
+```
+
+They would all be transformed to their "canonical" form:
+
+```sh
+my_cli --flag --str 'my string' --num 123
+```
+
+The order of the options in the cluster are preserved when converting to the canonical form.
+Variadic array options are supported, but must be the last option in a cluster.
+
 ## Niladic options
 
 Niladic options do not expect any parameter on the command-line. With the notable exception of the
@@ -442,8 +477,7 @@ value. You can use it to perform many kinds of useful things, such as:
   - e.g., if `--verbose` is set, add more help items to the [help format](#help-format) (or replace
     it altogether)
 
-In addition to the set of [value attributes](#value-attributes) (minus the environemnt variable),
-it has the following attributes.
+In addition to the set of [value attributes](#value-attributes), it has the following attributes.
 
 #### Execute callback
 
@@ -488,12 +522,12 @@ attributes and parses the remaining arguments.
   _recursive_ ones. This is explained in detail in the [commands guide](../guides/commands.mdx).
 </Callout>
 
-In addition to the set of [value attributes](#value-attributes) (minus the environemnt variable),
-it has the following required attributes.
+In addition to the set of [value attributes](#value-attributes), it has the following attributes.
 
 #### Command callback
 
-The `cmd` attribute is the callback function that should be executed. It accepts two parameters:
+The `cmd` attribute is the callback function that should be executed. It is required and accepts two
+parameters:
 
 - `values` - the values parsed for the parent command
 - `cmdValues` - the values parsed for the command
@@ -512,15 +546,21 @@ Notes about this callback:
 
 #### Command options | callback
 
-The `options` attribute is the set of option definitions for the command. You may also specify a
-(non-asynchronous) callback that returns the option definitions (this allows the implementation of
-[recursive commands](../guides/commands.mdx)).
+The `options` attribute is the set of option definitions for the command, or a (non-asynchronous)
+callback that returns the option definitions (this allows the implementation of
+[recursive commands](../guides/commands.mdx)). This attribute is required.
 
 <Callout type="warning">
   All incoming arguments will be parsed using the option definitions from this attribute, not those
   in which the option was declared. Hence, you should make it clear in the help message that all
   arguments pertaining to the command must be specified _after_ it.
 </Callout>
+
+#### Short-option style
+
+The `shortStyle` property indicates whether the first command argument is expected to be an option
+cluster. This must be used in conjunction with the [cluster letters](options.mdx#cluster-letters)
+of its options.
 
 ### Flag option
 
@@ -535,8 +575,8 @@ parameter.
   `-f` or a positional argument?).
 </Callout>
 
-In addition to the set of [value attributes](#value-attributes), it has the following optional
-attribute.
+In addition to the set of [value attributes](#value-attributes) and
+[miscellaneous attributes](#miscellaneous-attributes), it has the following optional attribute.
 
 #### Negation names
 
@@ -548,29 +588,46 @@ flag that has been previously specified must be reset by a supplementary list of
 
 ### Boolean option
 
-The **boolean** option has the set of [parameter attributes](#parameter-attributes) for a
-`boolean{:ts}` data type, as well as the set of [value attributes](#value-attributes).
+The **boolean** option has these sets of attributes:
+
+- [parameter attributes](#parameter-attributes) for a `boolean{:ts}` data type
+- [value attributes](#value-attributes)
+- [miscellaneous attributes](#miscellaneous-attributes)
 
 ### String option
 
-The **string** option has the set of [parameter attributes](#parameter-attributes) for a
-`string{:ts}` data type, as well as the sets of [value attributes](#value-attributes) and
-[string attributes](#string-attributes).
+The **string** option has these sets of attributes:
+
+- [parameter attributes](#parameter-attributes) for a `string{:ts}` data type
+- [value attributes](#value-attributes)
+- [string attributes](#string-attributes)
+- [miscellaneous attributes](#miscellaneous-attributes)
 
 ### Number option
 
-The **number** option has the set of [parameter attributes](#parameter-attributes) for a
-`number{:ts}` data type, as well as the sets of [value attributes](#value-attributes) and
-[number attributes](#number-attributes).
+The **number** option has these sets of attributes:
+
+- [parameter attributes](#parameter-attributes) for a `number{:ts}` data type
+- [value attributes](#value-attributes)
+- [number attributes](#number-attributes)
+- [miscellaneous attributes](#miscellaneous-attributes)
 
 ### Strings option
 
-The **strings** option has the set of [parameter attributes](#parameter-attributes) for a
-`string[]{:ts}` data type, as well as the sets of [value attributes](#value-attributes),
-[string attributes](#string-attributes) and [array attributes](#array-attributes).
+The **strings** option has these sets of attributes:
+
+- [parameter attributes](#parameter-attributes) for a `string[]{:ts}` data type
+- [value attributes](#value-attributes)
+- [string attributes](#string-attributes)
+- [array attributes](#array-attributes)
+- [miscellaneous attributes](#miscellaneous-attributes)
 
 ### Numbers option
 
-The **numbers** option has the set of [parameter attributes](#parameter-attributes) for a
-`number[]{:ts}` data type, as well as the sets of [value attributes](#value-attributes),
-[number attributes](#number-attributes) and [array attributes](#array-attributes).
+The **numbers** option has these sets of attributes:
+
+- [parameter attributes](#parameter-attributes) for a `number[]{:ts}` data type
+- [value attributes](#value-attributes)
+- [number attributes](#number-attributes)
+- [array attributes](#array-attributes)
+- [miscellaneous attributes](#miscellaneous-attributes)

--- a/packages/docs/pages/docs/library/options.mdx
+++ b/packages/docs/pages/docs/library/options.mdx
@@ -414,8 +414,8 @@ my_cli --flag --str 'my string' --num 123
 Notes about this feature:
 
 - the order of the options in the cluster are preserved when converting to the canonical form
-- variadic array options are supported, but must be the last option in a cluster
-- if a single dash is specified as the first character in a cluster, it is ignored
+- variadic array options are supported, but must be the last option in a cluster argument
+- if a single dash is specified as the first character in a cluster argument, it is ignored
 - if `Tab`-completion is performed in a cluster argument, the default completion is thrown
 - positional options with no names are skipped in a cluster argument
 

--- a/packages/docs/pages/docs/library/options.mdx
+++ b/packages/docs/pages/docs/library/options.mdx
@@ -384,9 +384,11 @@ option value will be read, in case the option is not specified on the command-li
 #### Cluster letters
 
 The `clusterLetters` attribute, if present, specifies letters (or Unicode characters) that can be
-used to cluster options in the first command-line argument. This is also known as _short-option_
-style. This feature can enabled via the parser's [short-option style](parser.mdx#short-option-style)
+used to cluster options in the first command-line argument. This is also known as [_short-option_
+style]. This feature can be enabled via the parser's [`shortStyle`](parser.mdx#short-option-style)
 configuration property.
+
+[_short-option_ style]: https://www.linuxtopia.org/online_books/linux_tool_guides/tar_user_guide/Short-Options.html
 
 Here is an example that illustrates how it works. Suppose we have the following options:
 
@@ -403,14 +405,19 @@ my_cli fSN 'my string' 123
 my_cli -Fsn 'my string' 123
 ```
 
-They would all be transformed to their "canonical" form:
+They would all be transformed to their "canonical" form, i.e.:
 
 ```sh
 my_cli --flag --str 'my string' --num 123
 ```
 
-The order of the options in the cluster are preserved when converting to the canonical form.
-Variadic array options are supported, but must be the last option in a cluster.
+Notes about this feature:
+
+- the order of the options in the cluster are preserved when converting to the canonical form
+- variadic array options are supported, but must be the last option in a cluster
+- if a single dash is specified as the first character in a cluster, it is ignored
+- if `Tab`-completion is performed in a cluster argument, the default completion is thrown
+- positional options with no names are skipped in a cluster argument
 
 ## Niladic options
 

--- a/packages/docs/pages/docs/library/parser.mdx
+++ b/packages/docs/pages/docs/library/parser.mdx
@@ -99,6 +99,11 @@ The `compIndex` property is the completion index of a raw command line. When sup
 methods with a command-line string, this value instructs the parser to perform bash completion when
 parsing the argument that overlaps this position in the string.
 
+### Short-option style
+
+The `shortStyle` property indicates whether the first argument is expected to be an option cluster.
+This must be used in conjunction with the [cluster letters](options.mdx#cluster-letters) attribute.
+
 ## Asynchronous parsing
 
 To understand how the parser supports asynchronous operations, we need to review the kinds of

--- a/packages/docs/pages/docs/library/validator.mdx
+++ b/packages/docs/pages/docs/library/validator.mdx
@@ -224,6 +224,10 @@ kinds of error messages that may be raised by the library:
   array option's limit constraint
 - `deprecatedOption` - warning saved by the parser when a deprecated option is specified on the
   command-line
+- `optionRequiredIf` - raised by the parser when a conditional option requirement is not satisfied
+- `duplicateOptionLetter` - raised by the validator when an option has a duplicate cluster letter
+- `variadicOptionInCluster` - raised by the parser when a variadic array option is specified in the
+  middle of an option cluster
 
 ### Error phrases
 
@@ -258,6 +262,9 @@ The `phrases` property specifies the phrases to be used for each kind of error m
 - `numberOptionRange` - `'Invalid parameter to %o: %n1. Value must be in the range %n2.'{:ts}`
 - `arrayOptionLimit` - `'Option %o has too many values (%n1). Should have at most %n2.'{:ts}`
 - `deprecatedOption` - `'Option %o is deprecated and may be removed in future releases.'{:ts}`
+- `optionRequiredIf` - `'Option %o is required if %t.'{:ts}`
+- `duplicateOptionLetter` - `'Duplicate option letter %o.'{:ts}`
+- `variadicOptionInCluster` - `'Variadic array option %o must be the last in a cluster.'{:ts}`
 
 These phrases will be formatted according to [text formatting](styles.mdx#text-splitting) rules.
 
@@ -284,7 +291,7 @@ description of the corresponding value.
 | parseErrorWithSimilar     | same as above, except `%o` is `%o1` and `%o2` = similar option names            |
 | unknownOption             | `%o` = the unknown option name                                                  |
 | unknownOptionWithSimilar  | same as above, except `%o` is `%o1` and `%o2` = similar option names            |
-| optionRequires            | `%o` = the specified option name; `%t` = the option requirements                |
+| optionRequires            | `%o` = the specified option name; `%t` = the option's requirements              |
 | missingRequiredOption     | `%o` = the option's preferred name                                              |
 | missingParameter          | `%o` = the specified option name                                                |
 | missingPackageJson        |                                                                                 |
@@ -309,3 +316,6 @@ description of the corresponding value.
 | numberOptionRange         | `%o` = the option key or name; `%n1` = the specified value; `%n2` = the range   |
 | arrayOptionLimit          | `%o` = the option key or name; `%n1` = the value count; `%n2` = the count limit |
 | deprecatedOption          | `%o` = the specified option name                                                |
+| optionRequiredIf          | `%o` = the specified option name; `%t` = the option's requirements              |
+| duplicateOptionLetter     | `%o` = the option letter                                                        |
+| variadicOptionInCluster   | `%o` = the specified option letter                                              |

--- a/packages/docs/pages/docs/library/validator.mdx
+++ b/packages/docs/pages/docs/library/validator.mdx
@@ -227,7 +227,7 @@ kinds of error messages that may be raised by the library:
 - `optionRequiredIf` - raised by the parser when a conditional option requirement is not satisfied
 - `duplicateOptionLetter` - raised by the validator when an option has a duplicate cluster letter
 - `variadicOptionInCluster` - raised by the parser when a variadic array option is specified in the
-  middle of an option cluster
+  middle of a cluster argument
 
 ### Error phrases
 

--- a/packages/tsargp/lib/enums.ts
+++ b/packages/tsargp/lib/enums.ts
@@ -142,6 +142,14 @@ export const enum ErrorItem {
    * Raised by the parser when a conditional option requirement is not satisfied.
    */
   optionRequiredIf,
+  /**
+   * Raised by the validator when an option has a duplicate letter.
+   */
+  duplicateOptionLetter,
+  /**
+   * Raised by the parser when a variadic array option is specified in the middle of an option cluster.
+   */
+  variadicOptionInCluster,
 }
 
 /**

--- a/packages/tsargp/lib/enums.ts
+++ b/packages/tsargp/lib/enums.ts
@@ -147,7 +147,8 @@ export const enum ErrorItem {
    */
   duplicateOptionLetter,
   /**
-   * Raised by the parser when a variadic array option is specified in the middle of an option cluster.
+   * Raised by the parser when a variadic array option is specified in the middle of a cluster
+   * argument.
    */
   variadicOptionInCluster,
 }

--- a/packages/tsargp/lib/enums.ts
+++ b/packages/tsargp/lib/enums.ts
@@ -143,7 +143,7 @@ export const enum ErrorItem {
    */
   optionRequiredIf,
   /**
-   * Raised by the validator when an option has a duplicate letter.
+   * Raised by the validator when an option has a duplicate cluster letter.
    */
   duplicateOptionLetter,
   /**

--- a/packages/tsargp/lib/formatter.ts
+++ b/packages/tsargp/lib/formatter.ts
@@ -1037,8 +1037,8 @@ function formatParam(
     'paramName' in option && option.paramName
       ? option.paramName.includes('<')
         ? option.paramName
-        : `<${option.paramName}>` + ellipsis
-      : `<${option.type}>` + ellipsis;
+        : `<${option.paramName}>${ellipsis}`
+      : `<${option.type}>${ellipsis}`;
   result.addAndRevert(paramStyle, param, style);
   return param.length;
 }

--- a/packages/tsargp/lib/options.ts
+++ b/packages/tsargp/lib/options.ts
@@ -351,17 +351,17 @@ export type WithParseDelimited<T> = {
 /**
  * Defines attributes for an option that accepts delimited-value parameters.
  */
-export type WithDelimited = {
+export type WithSeparator = {
   /**
    * The parameter value separator. If specified, the option accepts a single parameter.
    */
   readonly separator?: string | RegExp;
   /**
-   * @deprecated mutually exclusive with {@link WithDelimited.separator}
+   * @deprecated mutually exclusive with {@link WithSeparator.separator}
    */
   readonly parse?: never;
   /**
-   * @deprecated mutually exclusive with {@link WithDelimited.separator}
+   * @deprecated mutually exclusive with {@link WithSeparator.separator}
    */
   readonly parseDelimited?: never;
 };
@@ -497,14 +497,18 @@ export type WithValue<T> = (WithDefault<T> | WithRequired) & {
 };
 
 /**
- * Defines attributes common to all options that accept environment variables.
+ * Defines attributes common to all valued options except function and command options.
  */
-export type WithEnvVar = {
+export type WithMisc = {
   /**
    * The name of an environment variable to read from, if the option is not specified in the
    * command-line.
    */
   readonly envVar?: string;
+  /**
+   * The letters used for clustering in short-option style (e.g., 'fF').
+   */
+  readonly clusterLetters?: string;
 };
 
 /**
@@ -512,7 +516,7 @@ export type WithEnvVar = {
  */
 export type BooleanOption = WithType<'boolean'> &
   WithParam &
-  WithEnvVar &
+  WithMisc &
   WithValue<boolean> &
   (WithExample<boolean> | WithParamName) &
   WithParse<boolean>;
@@ -522,7 +526,7 @@ export type BooleanOption = WithType<'boolean'> &
  */
 export type StringOption = WithType<'string'> &
   WithParam &
-  WithEnvVar &
+  WithMisc &
   WithValue<string> &
   (WithExample<string> | WithParamName) &
   WithString &
@@ -533,7 +537,7 @@ export type StringOption = WithType<'string'> &
  */
 export type NumberOption = WithType<'number'> &
   WithParam &
-  WithEnvVar &
+  WithMisc &
   WithValue<number> &
   (WithExample<number> | WithParamName) &
   WithNumber &
@@ -544,30 +548,30 @@ export type NumberOption = WithType<'number'> &
  */
 export type StringsOption = WithType<'strings'> &
   WithParam &
-  WithEnvVar &
+  WithMisc &
   WithValue<ReadonlyArray<string>> &
   (WithExample<ReadonlyArray<string>> | WithParamName) &
   WithString &
   WithArray &
-  (WithParse<string> | WithParseDelimited<string> | WithDelimited);
+  (WithParse<string> | WithParseDelimited<string> | WithSeparator);
 
 /**
  * An option that has a number array value (may accept single or multiple parameters).
  */
 export type NumbersOption = WithType<'numbers'> &
   WithParam &
-  WithEnvVar &
+  WithMisc &
   WithValue<ReadonlyArray<number>> &
   (WithExample<ReadonlyArray<number>> | WithParamName) &
   WithNumber &
   WithArray &
-  (WithParse<number> | WithParseDelimited<number> | WithDelimited);
+  (WithParse<number> | WithParseDelimited<number> | WithSeparator);
 
 /**
  * An option that has a boolean value and is enabled if specified (or disabled if negated).
  */
 export type FlagOption = WithType<'flag'> &
-  WithEnvVar &
+  WithMisc &
   WithValue<boolean> & {
     /**
      * The names used for negation (e.g., '--no-flag').
@@ -605,6 +609,10 @@ export type CommandOption = WithType<'command'> &
      * The command options or a callback that returns the options (for use with recursive commands).
      */
     readonly options: Options | (() => Options);
+    /**
+     * True if the first argument is expected to be an option cluster (i.e., short-option style).
+     */
+    readonly shortStyle?: true;
   };
 
 /**

--- a/packages/tsargp/lib/validator.ts
+++ b/packages/tsargp/lib/validator.ts
@@ -113,6 +113,8 @@ export const defaultConfig: ConcreteError = {
     [ErrorItem.arrayOptionLimit]: 'Option %o has too many values (%n1). Should have at most %n2.',
     [ErrorItem.deprecatedOption]: 'Option %o is deprecated and may be removed in future releases.',
     [ErrorItem.optionRequiredIf]: 'Option %o is required if %t.',
+    [ErrorItem.duplicateOptionLetter]: 'Duplicate option letter %o.',
+    [ErrorItem.variadicOptionInCluster]: 'Variadic array option %o must be the last in a cluster.',
   },
 };
 
@@ -213,6 +215,7 @@ export type ConcreteStyles = ConcreteError['styles'];
  */
 export class OptionValidator {
   readonly names = new Map<string, string>();
+  readonly letters = new Map<string, string>();
   readonly positional: Positional | undefined;
 
   /**
@@ -272,6 +275,14 @@ export class OptionValidator {
     if (!option.preferredName) {
       option.preferredName = names.find((name): name is string => !!name);
     }
+    if ('clusterLetters' in option && option.clusterLetters) {
+      for (const letter of option.clusterLetters) {
+        if (validate && this.letters.has(letter)) {
+          throw this.error(ErrorItem.duplicateOptionLetter, { o: prefix + letter });
+        }
+        this.letters.set(letter, key);
+      }
+    }
   }
 
   /**
@@ -284,6 +295,7 @@ export class OptionValidator {
   validate(prefix = '', visited = new Set<Options>()) {
     let positional = false; // to check for duplicate positional options
     this.names.clear(); // to check for duplicate option names
+    this.letters.clear(); // to check for duplicate option letters
     for (const key in this.options) {
       const option = this.options[key];
       this.registerNames(key, option, true, prefix);

--- a/packages/tsargp/lib/validator.ts
+++ b/packages/tsargp/lib/validator.ts
@@ -243,7 +243,8 @@ export class OptionValidator {
    * @param option The option definition
    * @param validate True if performing validation
    * @param prefix The command prefix, if any
-   * @throws On empty positional marker, option with no name, invalid option name or duplicate name
+   * @throws On empty positional marker, option with no name, invalid option name, duplicate name or
+   * duplicate cluster letter
    */
   private registerNames(key: string, option: Option, validate = false, prefix = '') {
     const names = option.names ? option.names.slice() : [];

--- a/packages/tsargp/test/parser/parser.cluster.spec.ts
+++ b/packages/tsargp/test/parser/parser.cluster.spec.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it } from 'vitest';
+import { type Options, ArgumentParser } from '../../lib';
+import '../utils.spec'; // initialize globals
+
+describe('ArgumentParser', () => {
+  describe('parse', () => {
+    it('should accept no arguments when expecting a cluster argument', () => {
+      const options = {
+        flag: {
+          type: 'flag',
+          names: ['-f'],
+          clusterLetters: 'f',
+        },
+      } as const satisfies Options;
+      const parser = new ArgumentParser(options);
+      expect(() => parser.parse([], { shortStyle: true })).not.toThrow();
+    });
+
+    it('should skip the first dash in a cluster argument', () => {
+      const options = {
+        flag: {
+          type: 'flag',
+          names: ['-f'],
+          clusterLetters: 'f',
+        },
+      } as const satisfies Options;
+      const parser = new ArgumentParser(options);
+      expect(() => parser.parse(['-f'], { shortStyle: true })).not.toThrow();
+    });
+
+    it('should throw an error on unknown option letter', () => {
+      const options = {
+        flag: {
+          type: 'flag',
+          names: ['-f'],
+          clusterLetters: 'f',
+        },
+      } as const satisfies Options;
+      const parser = new ArgumentParser(options);
+      expect(() => parser.parse(['f-'], { shortStyle: true })).toThrow('Unknown option -.');
+    });
+
+    it('should skip options with no names in a cluster argument', () => {
+      const options = {
+        boolean: {
+          type: 'boolean',
+          positional: true,
+          clusterLetters: 'b',
+        },
+      } as const satisfies Options;
+      const parser = new ArgumentParser(options);
+      expect(() => parser.parse(['b'], { shortStyle: true })).not.toThrow();
+    });
+
+    it('should parse a flag option in a cluster argument', () => {
+      const options = {
+        flag: {
+          type: 'flag',
+          names: ['-f'],
+          clusterLetters: 'f',
+        },
+      } as const satisfies Options;
+      const parser = new ArgumentParser(options);
+      expect(parser.parse(['f'], { shortStyle: true })).toEqual({ flag: true });
+    });
+
+    it('should parse a boolean option in a cluster argument', () => {
+      const options = {
+        boolean: {
+          type: 'boolean',
+          names: ['-b'],
+          clusterLetters: 'b',
+        },
+      } as const satisfies Options;
+      const parser = new ArgumentParser(options);
+      expect(parser.parse(['b', '1'], { shortStyle: true })).toEqual({ boolean: true });
+    });
+
+    it('should parse a string option in a cluster argument', () => {
+      const options = {
+        string: {
+          type: 'string',
+          names: ['-s'],
+          clusterLetters: 's',
+        },
+      } as const satisfies Options;
+      const parser = new ArgumentParser(options);
+      expect(parser.parse(['s', '1'], { shortStyle: true })).toEqual({ string: '1' });
+    });
+
+    it('should parse a number option in a cluster argument', () => {
+      const options = {
+        number: {
+          type: 'number',
+          names: ['-n'],
+          clusterLetters: 'n',
+        },
+      } as const satisfies Options;
+      const parser = new ArgumentParser(options);
+      expect(parser.parse(['n', '1'], { shortStyle: true })).toEqual({ number: 1 });
+    });
+
+    it('should parse a strings option in a cluster argument', () => {
+      const options = {
+        strings: {
+          type: 'strings',
+          names: ['-ss'],
+          clusterLetters: 's',
+        },
+      } as const satisfies Options;
+      const parser = new ArgumentParser(options);
+      expect(parser.parse(['s', '1', '2'], { shortStyle: true })).toEqual({ strings: ['1', '2'] });
+    });
+
+    it('should parse a numbers option in a cluster argument', () => {
+      const options = {
+        numbers: {
+          type: 'numbers',
+          names: ['-ns'],
+          clusterLetters: 'n',
+        },
+      } as const satisfies Options;
+      const parser = new ArgumentParser(options);
+      expect(parser.parse(['n', '1', '2'], { shortStyle: true })).toEqual({ numbers: [1, 2] });
+    });
+
+    it('should throw an error on variadic strings option in the middle of a cluster argument', () => {
+      const options = {
+        flag: {
+          type: 'flag',
+          names: ['-f'],
+          clusterLetters: 'f',
+        },
+        strings: {
+          type: 'strings',
+          names: ['-ss'],
+          clusterLetters: 's',
+        },
+      } as const satisfies Options;
+      const parser = new ArgumentParser(options);
+      expect(() => parser.parse(['sf'], { shortStyle: true })).toThrow(
+        'Variadic array option s must be the last in a cluster.',
+      );
+    });
+
+    it('should throw an error on variadic numbers option in the middle of a cluster argument', () => {
+      const options = {
+        flag: {
+          type: 'flag',
+          names: ['-f'],
+          clusterLetters: 'f',
+        },
+        numbers: {
+          type: 'numbers',
+          names: ['-ns'],
+          clusterLetters: 'n',
+        },
+      } as const satisfies Options;
+      const parser = new ArgumentParser(options);
+      expect(() => parser.parse(['nf'], { shortStyle: true })).toThrow(
+        'Variadic array option n must be the last in a cluster.',
+      );
+    });
+  });
+});

--- a/packages/tsargp/test/parser/parser.cluster.spec.ts
+++ b/packages/tsargp/test/parser/parser.cluster.spec.ts
@@ -13,7 +13,7 @@ describe('ArgumentParser', () => {
         },
       } as const satisfies Options;
       const parser = new ArgumentParser(options);
-      expect(() => parser.parse([], { shortStyle: true })).not.toThrow();
+      expect(parser.parse([], { shortStyle: true })).toEqual({ flag: undefined });
     });
 
     it('should skip the first dash in a cluster argument', () => {
@@ -25,7 +25,7 @@ describe('ArgumentParser', () => {
         },
       } as const satisfies Options;
       const parser = new ArgumentParser(options);
-      expect(() => parser.parse(['-f'], { shortStyle: true })).not.toThrow();
+      expect(parser.parse(['-f'], { shortStyle: true })).toEqual({ flag: true });
     });
 
     it('should throw an error on unknown option letter', () => {
@@ -49,19 +49,7 @@ describe('ArgumentParser', () => {
         },
       } as const satisfies Options;
       const parser = new ArgumentParser(options);
-      expect(() => parser.parse(['b'], { shortStyle: true })).not.toThrow();
-    });
-
-    it('should parse a flag option in a cluster argument', () => {
-      const options = {
-        flag: {
-          type: 'flag',
-          names: ['-f'],
-          clusterLetters: 'f',
-        },
-      } as const satisfies Options;
-      const parser = new ArgumentParser(options);
-      expect(parser.parse(['f'], { shortStyle: true })).toEqual({ flag: true });
+      expect(parser.parse(['b'], { shortStyle: true })).toEqual({ boolean: undefined });
     });
 
     it('should parse a boolean option in a cluster argument', () => {

--- a/packages/tsargp/test/parser/parser.completion.spec.ts
+++ b/packages/tsargp/test/parser/parser.completion.spec.ts
@@ -470,6 +470,19 @@ describe('ArgumentParser', () => {
       expect(() => parser.parse('cmd -ns ', { compIndex: 8 })).toThrow(/^-ns$/);
       expect(() => parser.parse('cmd -ns=', { compIndex: 8 })).toThrow(/^$/);
     });
+
+    it('should throw the default completion when completing a cluster argument', () => {
+      const options = {
+        flag: {
+          type: 'flag',
+          names: ['-f'],
+          clusterLetters: 'f',
+        },
+      } as const satisfies Options;
+      const parser = new ArgumentParser(options);
+      expect(() => parser.parse('cmd --', { shortStyle: true, compIndex: 5 })).toThrow(/^$/);
+      expect(() => parser.parse('cmd ff', { shortStyle: true, compIndex: 5 })).toThrow(/^$/);
+    });
   });
 
   describe('parseAsync', () => {

--- a/packages/tsargp/test/validator/validator.duplicates.spec.ts
+++ b/packages/tsargp/test/validator/validator.duplicates.spec.ts
@@ -122,5 +122,17 @@ describe('OptionValidator', () => {
       const validator = new OptionValidator(options);
       expect(() => validator.validate()).toThrow(/Option numbers has duplicate enum 1\./);
     });
+
+    it('should throw an error on flag option with duplicate letters', () => {
+      const options = {
+        flag: {
+          type: 'flag',
+          names: ['-f'],
+          clusterLetters: 'aba',
+        },
+      } as const satisfies Options;
+      const validator = new OptionValidator(options);
+      expect(() => validator.validate()).toThrow(/Duplicate option letter a\./);
+    });
   });
 });

--- a/packages/tsargp/test/validator/validator.duplicates.spec.ts
+++ b/packages/tsargp/test/validator/validator.duplicates.spec.ts
@@ -123,7 +123,7 @@ describe('OptionValidator', () => {
       expect(() => validator.validate()).toThrow(/Option numbers has duplicate enum 1\./);
     });
 
-    it('should throw an error on flag option with duplicate letters', () => {
+    it('should throw an error on duplicate cluster letter in the same option', () => {
       const options = {
         flag: {
           type: 'flag',
@@ -133,6 +133,23 @@ describe('OptionValidator', () => {
       } as const satisfies Options;
       const validator = new OptionValidator(options);
       expect(() => validator.validate()).toThrow(/Duplicate option letter a\./);
+    });
+
+    it('should throw an error on duplicate cluster letter across different options', () => {
+      const options = {
+        flag1: {
+          type: 'flag',
+          names: ['-f1'],
+          clusterLetters: 'f',
+        },
+        flag2: {
+          type: 'flag',
+          names: ['-f2'],
+          clusterLetters: 'f',
+        },
+      } as const satisfies Options;
+      const validator = new OptionValidator(options);
+      expect(() => validator.validate()).toThrow(/Duplicate option letter f\./);
     });
   });
 });

--- a/packages/tsargp/test/validator/validator.names.spec.ts
+++ b/packages/tsargp/test/validator/validator.names.spec.ts
@@ -3,7 +3,7 @@ import { type Options, OptionValidator } from '../../lib';
 import '../utils.spec';
 
 describe('OptionValidator', () => {
-  describe('constructor', () => {
+  describe('validate', () => {
     it('should ignore empty option names', () => {
       const options = {
         string: {
@@ -11,11 +11,10 @@ describe('OptionValidator', () => {
           names: ['', 'name', ''],
         },
       } as const satisfies Options;
-      expect(() => new OptionValidator(options)).not.toThrow();
+      const validator = new OptionValidator(options);
+      expect(() => validator.validate()).not.toThrow();
     });
-  });
 
-  describe('validate', () => {
     it('should accept a positional option with no name', () => {
       const options = {
         string: {
@@ -70,6 +69,18 @@ describe('OptionValidator', () => {
       } as const satisfies Options;
       const validator = new OptionValidator(options);
       expect(() => validator.validate()).toThrow(/Invalid option name a = b\./);
+    });
+
+    it('should accept an option with cluster letters', () => {
+      const options = {
+        flag: {
+          type: 'flag',
+          names: ['-f'],
+          clusterLetters: 'abc',
+        },
+      } as const satisfies Options;
+      const validator = new OptionValidator(options);
+      expect(() => validator.validate()).not.toThrow();
     });
   });
 });


### PR DESCRIPTION
A new attribute, `clusterLetters` was added to valued options, in order to support the so called "short-options" style. It was grouped with the `envVar` attribute under a `WithMisc` type.

A new property, `shortStyle`, was added to the parser configuration, to indicate whether the first command-line argument is expected to be an option cluster. This is to be used in conjunction with the above.

The Parser page was updated to document the `shortStyle` property. The Options page was updated to document the `clusterLetters` attribute under a new section called `Miscellaneous attributes`, together with the `envVar` attribute.

Closes #12 
