### PR TITLE
Issues/70

### DIFF
--- a/.changeset/khaki-timers-burn.md
+++ b/.changeset/khaki-timers-burn.md
@@ -2,4 +2,4 @@
 '@trulysimple/tsargp-docs': patch
 ---
 
-The Options page was updated to document the possibility of specifying a `parse` callback in conjunction with a `separator`. The Parser pages was updated with more details about the behavior of the custom parsing callbacks.
+The Options page was updated to document the possibility of specifying a `parse` callback in conjunction with a `separator`. The Parser page was updated with more details about the behavior of the custom parsing callbacks.

--- a/.changeset/khaki-timers-burn.md
+++ b/.changeset/khaki-timers-burn.md
@@ -1,0 +1,5 @@
+---
+'@trulysimple/tsargp-docs': patch
+---
+
+The Options page was updated to document the possibility of specifying a `parse` callback in conjunction with a `separator`. The Parser pages was updated with more details about the behavior of the custom parsing callbacks.

--- a/.changeset/witty-turkeys-drive.md
+++ b/.changeset/witty-turkeys-drive.md
@@ -1,0 +1,5 @@
+---
+'tsargp': minor
+---
+
+The `separator` attribute can now be used in conjunction with the `parse` callback. In this case, the callback will be called for each element split by the separator.

--- a/packages/docs/pages/docs/library/options.mdx
+++ b/packages/docs/pages/docs/library/options.mdx
@@ -299,7 +299,7 @@ Notes about this callback:
 
 - it should return a value of the data type expected by the option (this should not be an array)
 - if asynchronous, and is called, then the resulting option value will be a promise
-- mutually exclusive with [separator](#separator) and [parse delimited](#parse-delimited)
+- mutually exclusive with [parse delimited](#parse-delimited)
 
 #### Enumeration
 
@@ -356,8 +356,7 @@ Array-valued option types share a set of attributes, as described below.
 
 The `separator` attribute, if present, specifies a delimiter by which to split parameter values. If
 specified, the option will accept a single parameter and not multiple parameters[^2]. It can be
-either a string or a regular expression. Mutually exclusive with [parse callback](#parse-callback)
-and [parse delimited](#parse-delimited).
+either a string or a regular expression. Mutually exclusive with [parse delimited](#parse-delimited).
 
 [^2]: we say that it is _delimited_, rather than _variadic_.
 
@@ -388,8 +387,8 @@ constraint.
 
 The `append` attribute, if present, indicates that the option allows appending elements to its
 value if specified multiple times on the command-line. Both the [remove
-duplicates](#remove-duplicates) normalization and the [count limit](#count-limit) constraint (if
-enabled) are applied after appendage.
+duplicates](#remove-duplicates) normalization and the [count limit](#count-limit) constraint, if
+enabled, are applied after appendage.
 
 #### Count limit
 
@@ -476,8 +475,7 @@ value. You can use it to perform many kinds of actions, such as:
 - reading configuration from a file
 - altering the values of previous options
 - altering the option definitions in response to an option value
-  - e.g., if `--verbose` is set, add more help items to the [help format](#help-format) (or replace
-    it altogether)
+  - e.g., if `--verbose` is set, add more help items to the [help format](#help-format)
 
 In addition to the set of [value attributes](#value-attributes), it has the following attributes.
 
@@ -504,7 +502,7 @@ Notes about this callback:
 
 #### Break loop
 
-The `break` attribute indicates whether the parser to exit the parsing loop immediately after
+The `break` attribute indicates whether the parser should exit the parsing loop immediately after
 returning from the callback.
 
 <Callout type="warning">

--- a/packages/docs/pages/docs/library/parser.mdx
+++ b/packages/docs/pages/docs/library/parser.mdx
@@ -156,14 +156,19 @@ They are handled in following manner:
 - The fourth case is handled by chaining the existing promise with a callback that appends the
   normalized elements to the previous value.
 
-Note that, for array-valued options, once a promise is returned from a parsing callback there's no
-turning back to a non-promise.
+Notice that, for array-valued options, once a promise is returned from a parsing callback, there's
+no turning back to a non-promise. It's equally important to note that the order of elements in the
+array is preserved, i.e., it reflects the order in which the parameters were parsed. This is true
+even if the [remove duplicates](options.mdx#remove-duplicates) attribute was set (this is due to the
+nature of JavaScript's [Set] type).
+
+[Set]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set
 
 <Callout type="info">
   A special case occurs when a variadic array option is specified on the command-line without
   parameters. In that case, the parser must initialize the option value to an empty array. This
   means that, even if an option declares an async parsing callback in its definition, the parser
-  might exit the loop before calling the callback, thus leaving the value as an empty array
+  might exit the loop without calling the callback, thus leaving the value as an empty array
   (non-promise). This is not a problem, since the `await` expression can be called on a non-promise.
 </Callout>
 
@@ -177,7 +182,7 @@ The complete, resolve, execute and command callbacks are the ones that may cause
 accumulate promises that will be returned by the `parseAsync` or `parseInto` methods, which then
 need to be awaited in order to await their resolution.
 
-In the case of the complete and resolve callbacks, once awaited, the promise throws a string that
+In the case of the complete and resolve callbacks, once awaited, the promise throws a message that
 should be caught and printed on a terminal. They are the version or the completion words,
 respectively.
 
@@ -231,21 +236,21 @@ an empty string):
    - If the option has [enumerated values](options.mdx#enumeration), those values are converted to
      string, filtered by the prefix _comp_, and then returned; else
    - If it is a variadic array option, and the parameter was specified neither with a positional
-     marker nor as an [inline parameters](#inline-parameters), the available option names are
+     marker nor as an [inline parameter](#inline-parameters), the available option names are
      filtered by the prefix _comp_ and returned; else
-   - No words are returned, and the default bash completion (if enabled with `-o`) is attempted.
+   - No words are returned, and the default bash completion (if enabled with `-o`) will be attempted
 
-During completion, help and version options are skipped, while others are processed as usual. This
-means that a completion callback can inspect the values parsed before it, in order to make better
-suggestions based on those values.
+During completion, help and version options and the [command callback](options.mdx#command-callback)
+are skipped, while others are processed as usual. This means that a completion callback can inspect
+the values parsed before it, in order to make better suggestions based on those values.
 
 ## Requirements checking
 
 Generally, option requirements are evaluated after all arguments have been parsed. During this
 analysis, an option's value is checked against any value required by other options, _except_ if the
-option value is a promise (this may happen if the option was declared with an asynchronous
-[parsing callback](#parsing-callbacks)). This is because the parser cannot await a promise's
-resolution before returning from the parsing loop.
+option value is a promise (this may happen if the value was parsed by an asynchronous [parsing
+callback](#parsing-callbacks)). This is because the parser cannot await a promise's resolution
+before returning from the parsing loop.
 
 This check may also be performed in two more situations:
 
@@ -299,7 +304,7 @@ main script and any nested commands. For example, if the command-line is:
 
 The process title would be updated in the following way:
 
-1. `node` - this the starting title, before any update
+1. `node` - this the starting title, before any updates
 2. `node myscript.js` - the title at the beginning of the parsing loop
 3. `node myscript.js cmd1` - the title at the start of the `cmd1` command
 4. `node myscript.js cmd1 cmd2` - the title at the start of the `cmd2` command

--- a/packages/docs/pages/docs/library/parser.mdx
+++ b/packages/docs/pages/docs/library/parser.mdx
@@ -240,9 +240,10 @@ an empty string):
      filtered by the prefix _comp_ and returned; else
    - No words are returned, and the default bash completion (if enabled with `-o`) will be attempted
 
-During completion, help and version options and the [command callback](options.mdx#command-callback)
-are skipped, while others are processed as usual. This means that a completion callback can inspect
-the values parsed before it, in order to make better suggestions based on those values.
+During completion, both the help and version options as well as the [command
+callback](options.mdx#command-callback) are skipped, while other options are processed as usual.
+This means that a completion callback can inspect the values parsed before it, in order to make
+better suggestions based on those values.
 
 ## Requirements checking
 

--- a/packages/tsargp/lib/options.ts
+++ b/packages/tsargp/lib/options.ts
@@ -322,10 +322,6 @@ export type WithParse<T> = {
   /**
    * @deprecated mutually exclusive with {@link WithParse.parse}
    */
-  readonly separator?: never;
-  /**
-   * @deprecated mutually exclusive with {@link WithParse.parse}
-   */
   readonly parseDelimited?: never;
 };
 
@@ -356,10 +352,6 @@ export type WithSeparator = {
    * The parameter value separator. If specified, the option accepts a single parameter.
    */
   readonly separator?: string | RegExp;
-  /**
-   * @deprecated mutually exclusive with {@link WithSeparator.separator}
-   */
-  readonly parse?: never;
   /**
    * @deprecated mutually exclusive with {@link WithSeparator.separator}
    */
@@ -553,7 +545,7 @@ export type StringsOption = WithType<'strings'> &
   (WithExample<ReadonlyArray<string>> | WithParamName) &
   WithString &
   WithArray &
-  (WithParse<string> | WithParseDelimited<string> | WithSeparator);
+  ((WithParse<string> & WithSeparator) | WithParseDelimited<string>);
 
 /**
  * An option that has a number array value (may accept single or multiple parameters).
@@ -565,7 +557,7 @@ export type NumbersOption = WithType<'numbers'> &
   (WithExample<ReadonlyArray<number>> | WithParamName) &
   WithNumber &
   WithArray &
-  (WithParse<number> | WithParseDelimited<number> | WithSeparator);
+  ((WithParse<number> & WithSeparator) | WithParseDelimited<number>);
 
 /**
  * An option that has a boolean value and is enabled if specified (or disabled if negated).

--- a/packages/tsargp/lib/parser.ts
+++ b/packages/tsargp/lib/parser.ts
@@ -931,52 +931,53 @@ function parseArray<T extends string | number>(
   value: string,
   convertFn: (value: string) => T,
 ) {
+  /** @ignore */
+  function append(vals: Array<T>) {
+    return function (prev: Array<T>) {
+      prev.push(...vals.map((val) => validator.normalize(option, name, val)));
+      return validator.normalize(option, name, prev as ParamValue) as Array<T>;
+    };
+  }
   let result: Array<T> | Promise<Array<T>>;
-  const previous = values[key] as typeof result;
-  if ('parse' in option && option.parse) {
-    const res = option.parse(values, name, value);
-    if (res instanceof Promise) {
-      result = res.then(async (val) => {
-        const prev = await previous;
-        prev.push(validator.normalize(option, name, val) as T);
-        validator.normalize(option, name, prev as ParamValue);
-        return prev;
-      });
-    } else {
-      result = [validator.normalize(option, name, res) as T];
-    }
-  } else if ('parseDelimited' in option && option.parseDelimited) {
+  let previous = values[key] as typeof result;
+  if (option.parseDelimited) {
     const res = option.parseDelimited(values, name, value);
-    if (res instanceof Promise) {
-      result = res.then(async (vals) => {
-        const prev = await previous;
-        prev.push(...vals.map((val) => validator.normalize(option, name, val) as T));
-        validator.normalize(option, name, prev as ParamValue);
-        return prev;
-      });
+    result =
+      res instanceof Promise
+        ? res.then(async (vals) => append(vals as Array<T>)(await previous))
+        : (res as Array<T>);
+  } else {
+    const vals = option.separator ? value.split(option.separator) : [value];
+    if (option.parse) {
+      const parse = option.parse;
+      const res = vals.map((val) => parse(values, name, val));
+      let prevSync: Array<T> = [];
+      for (const val of res) {
+        if (val instanceof Promise) {
+          const copy = prevSync; // save the reference for the closure
+          const prev = previous; // save the reference for the closure
+          previous = val.then(async (val) => append([...copy, val as T])(await prev));
+          prevSync = []; // reset for incoming values
+        } else {
+          prevSync.push(val as T);
+        }
+      }
+      result =
+        previous instanceof Promise
+          ? prevSync.length
+            ? previous.then(append(prevSync))
+            : previous
+          : prevSync;
     } else {
-      result = res.map((val) => validator.normalize(option, name, val) as T);
+      result = vals.map(convertFn);
     }
-  } else {
-    const vals =
-      'separator' in option && option.separator
-        ? value.split(option.separator).map((val) => convertFn(val))
-        : [convertFn(value)];
-    result = vals.map((val) => validator.normalize(option, name, val));
   }
-  if (result instanceof Promise) {
-    values[key] = result;
-  } else if (previous instanceof Promise) {
-    const res = result;
-    values[key] = previous.then((vals) => {
-      vals.push(...res);
-      validator.normalize(option, name, vals as ParamValue);
-      return vals;
-    });
-  } else {
-    previous.push(...result);
-    values[key] = validator.normalize(option, name, previous as ParamValue);
-  }
+  values[key] =
+    result instanceof Promise
+      ? result
+      : previous instanceof Promise
+        ? previous.then(append(result))
+        : append(result)(previous);
 }
 
 /**
@@ -1092,25 +1093,8 @@ function parseValue(
  * @param option The option definition
  */
 function resetValue(values: OptionValues, key: string, option: ArrayOption) {
-  type ArrayVal =
-    | Array<string>
-    | Array<number>
-    | Promise<Array<string>>
-    | Promise<Array<number>>
-    | undefined;
-  const previous = values[key] as ArrayVal;
-  if (!previous) {
+  if (!option.append || values[key] === undefined) {
     values[key] = [];
-  } else if (!option.append) {
-    if (previous instanceof Promise) {
-      const promise = previous.then((val) => {
-        val.length = 0;
-        return val;
-      });
-      values[key] = promise;
-    } else {
-      previous.length = 0;
-    }
   }
 }
 

--- a/packages/tsargp/lib/parser.ts
+++ b/packages/tsargp/lib/parser.ts
@@ -949,17 +949,16 @@ function parseArray<T extends string | number>(
   } else {
     const vals = option.separator ? value.split(option.separator) : [value];
     if (option.parse) {
-      const parse = option.parse;
-      const res = vals.map((val) => parse(values, name, val));
       let prevSync: Array<T> = [];
-      for (const val of res) {
-        if (val instanceof Promise) {
+      for (const val of vals) {
+        const res = option.parse(values, name, val);
+        if (res instanceof Promise) {
           const copy = prevSync; // save the reference for the closure
           const prev = previous; // save the reference for the closure
-          previous = val.then(async (val) => append([...copy, val as T])(await prev));
+          previous = res.then(async (val) => append([...copy, val as T])(await prev));
           prevSync = []; // reset for incoming values
         } else {
-          prevSync.push(val as T);
+          prevSync.push(res as T);
         }
       }
       result =

--- a/packages/tsargp/test/parser/parse.custom.spec.ts
+++ b/packages/tsargp/test/parser/parse.custom.spec.ts
@@ -17,7 +17,7 @@ describe('ArgumentParser', () => {
       expect(options.boolean.parse).toHaveBeenCalledWith(expect.anything(), '-b', '0123');
     });
 
-    it('should handle a boolean option with async custom parsing', () => {
+    it('should handle a boolean option with async custom parsing', async () => {
       const options = {
         boolean: {
           type: 'boolean',
@@ -26,7 +26,7 @@ describe('ArgumentParser', () => {
         },
       } as const satisfies Options;
       const parser = new ArgumentParser(options);
-      expect(parser.parse(['-b', '0123'])).toEqual({ boolean: expect.toResolve(true) });
+      await expect(parser.parse(['-b', '0123']).boolean).resolves.toEqual(true);
     });
 
     it('should handle a string option with custom parsing', () => {
@@ -43,7 +43,7 @@ describe('ArgumentParser', () => {
       expect(options.string.parse).toHaveBeenCalledWith(expect.anything(), '-s', 'abcde');
     });
 
-    it('should handle a string option with async custom parsing', () => {
+    it('should handle a string option with async custom parsing', async () => {
       const options = {
         string: {
           type: 'string',
@@ -53,7 +53,7 @@ describe('ArgumentParser', () => {
         },
       } as const satisfies Options;
       const parser = new ArgumentParser(options);
-      expect(parser.parse(['-s', 'abcde'])).toEqual({ string: expect.toResolve('CDE') });
+      await expect(parser.parse(['-s', 'abcde']).string).resolves.toEqual('CDE');
     });
 
     it('should handle a number option with custom parsing', () => {
@@ -70,7 +70,7 @@ describe('ArgumentParser', () => {
       expect(options.number.parse).toHaveBeenCalledWith(expect.anything(), '-n', '1.2');
     });
 
-    it('should handle a number option with async custom parsing', () => {
+    it('should handle a number option with async custom parsing', async () => {
       const options = {
         number: {
           type: 'number',
@@ -80,47 +80,42 @@ describe('ArgumentParser', () => {
         },
       } as const satisfies Options;
       const parser = new ArgumentParser(options);
-      expect(parser.parse(['-n', '1.2'])).toEqual({ number: expect.toResolve(4) });
+      await expect(parser.parse(['-n', '1.2']).number).resolves.toEqual(4);
     });
 
-    it('should handle a strings option with custom parsing', () => {
+    it('should handle a strings option with mixed-async custom parsing', async () => {
       const options = {
         strings: {
           type: 'strings',
           names: ['-ss'],
           case: 'upper',
           unique: true,
-          parse: vi.fn().mockImplementation((_0, _1, value): string | Promise<string> => {
-            const res = value.slice(2);
-            return value.startsWith('a') ? res : Promise.resolve(res);
+          parse: vi.fn().mockImplementation((_0, _1, value: string) => {
+            return value === 'sync' ? value : Promise.resolve(value);
           }),
         },
       } as const satisfies Options;
       const parser = new ArgumentParser(options);
       expect(parser.parse(['-ss'])).toEqual({ strings: [] });
       expect(options.strings.parse).not.toHaveBeenCalled();
-
-      expect(parser.parse(['-ss', 'abcd', 'abCD'])).toEqual({ strings: ['CD'] });
-      expect(options.strings.parse).toHaveBeenCalledWith(expect.anything(), '-ss', 'abcd');
-      expect(options.strings.parse).toHaveBeenCalledWith(expect.anything(), '-ss', 'abCD');
+      expect(parser.parse(['-ss', 'sync', 'sync'])).toEqual({ strings: ['SYNC'] });
+      expect(options.strings.parse).toHaveBeenCalledWith(expect.anything(), '-ss', 'sync');
       expect(options.strings.parse).toHaveBeenCalledTimes(2);
 
-      expect(parser.parse(['-ss', 'abcd', '12CD'])).toEqual({
-        strings: expect.toResolve(['CD']),
-      });
-      expect(parser.parse(['-ss', '12CD', 'abcd'])).toEqual({
-        strings: expect.toResolve(['CD']),
-      });
-      expect(parser.parse(['-ss', '12CD', '34cd'])).toEqual({
-        strings: expect.toResolve(['CD']),
-      });
-      expect(parser.parse(['-ss', 'abcd', '-ss'])).toEqual({ strings: [] });
-      expect(parser.parse(['-ss', '12CD', '-ss'])).toEqual({
-        strings: expect.toResolve([]),
-      });
+      await expect(parser.parse(['-ss', 'sync', 'async']).strings).resolves.toEqual([
+        'SYNC',
+        'ASYNC',
+      ]);
+      await expect(parser.parse(['-ss', 'async', 'sync']).strings).resolves.toEqual([
+        'ASYNC',
+        'SYNC',
+      ]);
+      await expect(parser.parse(['-ss', 'async', 'async']).strings).resolves.toEqual(['ASYNC']);
+      expect(parser.parse(['-ss', 'sync', '-ss'])).toEqual({ strings: [] });
+      expect(parser.parse(['-ss', 'async', '-ss'])).toEqual({ strings: [] });
     });
 
-    it('should handle a strings option with custom delimited parsing', () => {
+    it('should handle a strings option with mixed-async custom parsing in conjunction with a separator', async () => {
       const options = {
         strings: {
           type: 'strings',
@@ -128,37 +123,79 @@ describe('ArgumentParser', () => {
           case: 'upper',
           append: true,
           unique: true,
-          parseDelimited: (_0, _1, value): Array<string> | Promise<Array<string>> => {
-            const res = value.split(',').flatMap((val) => val.split('|'));
-            return value.startsWith('a') ? res : Promise.resolve(res);
+          separator: ',',
+          parse: vi.fn().mockImplementation((_0, _1, value: string) => {
+            return value === 'sync' ? value : Promise.resolve(value);
+          }),
+        },
+      } as const satisfies Options;
+      const parser = new ArgumentParser(options);
+      expect(parser.parse(['-ss', 'sync,sync'])).toEqual({ strings: ['SYNC'] });
+      expect(options.strings.parse).toHaveBeenCalledWith(expect.anything(), '-ss', 'sync');
+      expect(options.strings.parse).toHaveBeenCalledTimes(2);
+
+      await expect(parser.parse(['-ss', 'sync,async']).strings).resolves.toEqual(['SYNC', 'ASYNC']);
+      await expect(parser.parse(['-ss', 'async,sync']).strings).resolves.toEqual(['ASYNC', 'SYNC']);
+      await expect(parser.parse(['-ss', 'async,async']).strings).resolves.toEqual(['ASYNC']);
+      await expect(parser.parse(['-ss', 'async', '-ss', 'sync,sync']).strings).resolves.toEqual([
+        'ASYNC',
+        'SYNC',
+      ]);
+      await expect(parser.parse(['-ss', 'async', '-ss', 'sync,async']).strings).resolves.toEqual([
+        'ASYNC',
+        'SYNC',
+      ]);
+      await expect(parser.parse(['-ss', 'async', '-ss', 'async,sync']).strings).resolves.toEqual([
+        'ASYNC',
+        'SYNC',
+      ]);
+      await expect(parser.parse(['-ss', 'async', '-ss', 'async,async']).strings).resolves.toEqual([
+        'ASYNC',
+      ]);
+      await expect(parser.parse(['-ss', 'async', '-ss', 'sync,last']).strings).resolves.toEqual([
+        'ASYNC',
+        'SYNC',
+        'LAST', // order is preserved
+      ]);
+    });
+
+    it('should handle a strings option with mixed-async custom delimited parsing', async () => {
+      const options = {
+        strings: {
+          type: 'strings',
+          names: ['-ss'],
+          case: 'upper',
+          append: true,
+          unique: true,
+          parseDelimited: (_0, _1, value: string) => {
+            const res = value.split(',');
+            return value.startsWith('sync') ? res : Promise.resolve(res);
           },
         },
       } as const satisfies Options;
       const parser = new ArgumentParser(options);
       expect(() => parser.parse(['-ss'])).toThrow(/Missing parameter to -ss\./);
-      expect(parser.parse(['-ss', 'a,b|B', '-ss', 'a,B|b'])).toEqual({
-        strings: ['A', 'B'],
-      });
-      expect(parser.parse(['-ss', 'a,b|B', '-ss', 'c,d|D'])).toEqual({
-        strings: expect.toResolve(['A', 'B', 'C', 'D']),
-      });
-      expect(parser.parse(['-ss', 'c,d|D', '-ss', 'a,b|B'])).toEqual({
-        strings: expect.toResolve(['C', 'D', 'A', 'B']),
-      });
-      expect(parser.parse(['-ss', 'c,d|D', '-ss', 'C|D'])).toEqual({
-        strings: expect.toResolve(['C', 'D']),
-      });
+      expect(parser.parse(['-ss', 'sync,sync', '-ss', 'sync,sync'])).toEqual({ strings: ['SYNC'] });
+      await expect(
+        parser.parse(['-ss', 'sync,sync', '-ss', 'async,async']).strings,
+      ).resolves.toEqual(['SYNC', 'ASYNC']);
+      await expect(
+        parser.parse(['-ss', 'async,async', '-ss', 'sync,sync']).strings,
+      ).resolves.toEqual(['ASYNC', 'SYNC']);
+      await expect(
+        parser.parse(['-ss', 'async,async', '-ss', 'async,async']).strings,
+      ).resolves.toEqual(['ASYNC']);
     });
 
-    it('should handle a numbers option with custom parsing', () => {
+    it('should handle a numbers option with mixed-async custom parsing', async () => {
       const options = {
         numbers: {
           type: 'numbers',
           names: ['-ns'],
           round: 'ceil',
           unique: true,
-          parse: vi.fn().mockImplementation((_0, _1, value): number | Promise<number> => {
-            const res = Number(value) + 2;
+          parse: vi.fn().mockImplementation((_0, _1, value) => {
+            const res = Number(value);
             return value.startsWith('1') ? res : Promise.resolve(res);
           }),
         },
@@ -166,28 +203,54 @@ describe('ArgumentParser', () => {
       const parser = new ArgumentParser(options);
       expect(parser.parse(['-ns'])).toEqual({ numbers: [] });
       expect(options.numbers.parse).not.toHaveBeenCalled();
-
-      expect(parser.parse(['-ns', '1.2', '1.7'])).toEqual({ numbers: [4] });
+      expect(parser.parse(['-ns', '1.2', '1.7'])).toEqual({ numbers: [2] });
       expect(options.numbers.parse).toHaveBeenCalledWith(expect.anything(), '-ns', '1.2');
       expect(options.numbers.parse).toHaveBeenCalledWith(expect.anything(), '-ns', '1.7');
       expect(options.numbers.parse).toHaveBeenCalledTimes(2);
 
-      expect(parser.parse(['-ns', '1.2', '2.2'])).toEqual({
-        numbers: expect.toResolve([4, 5]),
-      });
-      expect(parser.parse(['-ns', '2.2', '1.2'])).toEqual({
-        numbers: expect.toResolve([5, 4]),
-      });
-      expect(parser.parse(['-ns', '2.2', '2.7'])).toEqual({
-        numbers: expect.toResolve([5]),
-      });
+      await expect(parser.parse(['-ns', '1.2', '2.2']).numbers).resolves.toEqual([2, 3]);
+      await expect(parser.parse(['-ns', '2.2', '1.2']).numbers).resolves.toEqual([3, 2]);
+      await expect(parser.parse(['-ns', '2.2', '2.7']).numbers).resolves.toEqual([3]);
       expect(parser.parse(['-ns', '1.2', '-ns'])).toEqual({ numbers: [] });
-      expect(parser.parse(['-ns', '2.2', '-ns'])).toEqual({
-        numbers: expect.toResolve([]),
-      });
+      expect(parser.parse(['-ns', '2.2', '-ns'])).toEqual({ numbers: [] });
     });
 
-    it('should handle a numbers option with custom delimited parsing', () => {
+    it('should handle a numbers option with mixed-async custom parsing in conjunction with a separator', async () => {
+      const options = {
+        numbers: {
+          type: 'numbers',
+          names: ['-ns'],
+          round: 'ceil',
+          append: true,
+          unique: true,
+          separator: ',',
+          parse: vi.fn().mockImplementation((_0, _1, value) => {
+            const res = Number(value);
+            return value.startsWith('1') ? res : Promise.resolve(res);
+          }),
+        },
+      } as const satisfies Options;
+      const parser = new ArgumentParser(options);
+      expect(parser.parse(['-ns', '1.2,1.7'])).toEqual({ numbers: [2] });
+      expect(options.numbers.parse).toHaveBeenCalledWith(expect.anything(), '-ns', '1.2');
+      expect(options.numbers.parse).toHaveBeenCalledWith(expect.anything(), '-ns', '1.7');
+      expect(options.numbers.parse).toHaveBeenCalledTimes(2);
+
+      await expect(parser.parse(['-ns', '1.2,2.2']).numbers).resolves.toEqual([2, 3]);
+      await expect(parser.parse(['-ns', '2.2,1.2']).numbers).resolves.toEqual([3, 2]);
+      await expect(parser.parse(['-ns', '2.2,2.7']).numbers).resolves.toEqual([3]);
+      await expect(parser.parse(['-ns', '2.2', '-ns', '1.2,1.2']).numbers).resolves.toEqual([3, 2]);
+      await expect(parser.parse(['-ns', '2.2', '-ns', '1.2,2.7']).numbers).resolves.toEqual([3, 2]);
+      await expect(parser.parse(['-ns', '2.2', '-ns', '2.7,1.2']).numbers).resolves.toEqual([3, 2]);
+      await expect(parser.parse(['-ns', '2.2', '-ns', '2.7,2.8']).numbers).resolves.toEqual([3]);
+      await expect(parser.parse(['-ns', '2.2', '-ns', '1.2,3.3']).numbers).resolves.toEqual([
+        3,
+        2,
+        4, // order is preserved
+      ]);
+    });
+
+    it('should handle a numbers option with mixed-async custom delimited parsing', async () => {
       const options = {
         numbers: {
           type: 'numbers',
@@ -196,26 +259,23 @@ describe('ArgumentParser', () => {
           append: true,
           unique: true,
           parseDelimited: (_0, _1, value): Array<number> | Promise<Array<number>> => {
-            const res = value.split(',').flatMap((val) => val.split('|').map((val) => Number(val)));
+            const res = value.split(',').map((val) => Number(val));
             return value.startsWith('1') ? res : Promise.resolve(res);
           },
         },
       } as const satisfies Options;
       const parser = new ArgumentParser(options);
       expect(() => parser.parse(['-ns'])).toThrow(/Missing parameter to -ns\./);
-      expect(parser.parse(['-ns', '1.1,2.2|2.3'])).toEqual({ numbers: [2, 3] });
-      expect(parser.parse(['-ns', '1.1,2.2|2.3', '-ns', '11|12'])).toEqual({
-        numbers: [2, 3, 11, 12],
-      });
-      expect(parser.parse(['-ns', '1.1,2.2|2.3', '-ns', '21|22'])).toEqual({
-        numbers: expect.toResolve([2, 3, 21, 22]),
-      });
-      expect(parser.parse(['-ns', '21|22', '-ns', '1.1,2.2|2.3'])).toEqual({
-        numbers: expect.toResolve([21, 22, 2, 3]),
-      });
-      expect(parser.parse(['-ns', '21|22', '-ns', '20.2|21.2'])).toEqual({
-        numbers: expect.toResolve([21, 22]),
-      });
+      expect(parser.parse(['-ns', '1.1,1.2', '-ns', '1.1,1.2'])).toEqual({ numbers: [2] });
+      await expect(parser.parse(['-ns', '1.1,1.2', '-ns', '2.1,2.2']).numbers).resolves.toEqual([
+        2, 3,
+      ]);
+      await expect(parser.parse(['-ns', '2.1,2.2', '-ns', '1.1,1.2']).numbers).resolves.toEqual([
+        3, 2,
+      ]);
+      await expect(parser.parse(['-ns', '2.1,2.2', '-ns', '2.1,2.2']).numbers).resolves.toEqual([
+        3,
+      ]);
     });
   });
 });

--- a/packages/tsargp/test/parser/parse.custom.spec.ts
+++ b/packages/tsargp/test/parser/parse.custom.spec.ts
@@ -26,7 +26,7 @@ describe('ArgumentParser', () => {
         },
       } as const satisfies Options;
       const parser = new ArgumentParser(options);
-      await expect(parser.parse(['-b', '0123']).boolean).resolves.toEqual(true);
+      await expect(parser.parse(['-b', '0123']).boolean).resolves.toBeTruthy();
     });
 
     it('should handle a string option with custom parsing', () => {

--- a/packages/tsargp/test/parser/parser.default.spec.ts
+++ b/packages/tsargp/test/parser/parser.default.spec.ts
@@ -71,7 +71,7 @@ describe('ArgumentParser', () => {
       expect(options.function.exec).not.toHaveBeenCalled();
     });
 
-    it('should handle a function option with an async default callback', () => {
+    it('should handle a function option with an async default callback', async () => {
       const options = {
         function: {
           type: 'function',
@@ -81,7 +81,7 @@ describe('ArgumentParser', () => {
         },
       } as const satisfies Options;
       const parser = new ArgumentParser(options);
-      expect(parser.parse([])).toEqual({ function: expect.toResolve(false) });
+      await expect(parser.parse([]).function).resolves.toBeFalsy();
       expect(options.function.exec).not.toHaveBeenCalled();
     });
 
@@ -135,7 +135,7 @@ describe('ArgumentParser', () => {
       expect(options.command.cmd).not.toHaveBeenCalled();
     });
 
-    it('should handle a command option with an async default callback', () => {
+    it('should handle a command option with an async default callback', async () => {
       const options = {
         command: {
           type: 'command',
@@ -146,7 +146,7 @@ describe('ArgumentParser', () => {
         },
       } as const satisfies Options;
       const parser = new ArgumentParser(options);
-      expect(parser.parse([])).toEqual({ command: expect.toResolve(false) });
+      await expect(parser.parse([]).command).resolves.toBeFalsy();
       expect(options.command.cmd).not.toHaveBeenCalled();
     });
 
@@ -175,7 +175,7 @@ describe('ArgumentParser', () => {
       expect(parser.parse([])).toEqual({ flag: false });
     });
 
-    it('should handle a flag option with an async default callback', () => {
+    it('should handle a flag option with an async default callback', async () => {
       const options = {
         flag: {
           type: 'flag',
@@ -185,7 +185,7 @@ describe('ArgumentParser', () => {
         },
       } as const satisfies Options;
       const parser = new ArgumentParser(options);
-      expect(parser.parse([])).toEqual({ flag: expect.toResolve(false) });
+      await expect(parser.parse([]).flag).resolves.toBeFalsy();
     });
 
     it('should handle a boolean option with a default value', () => {
@@ -212,7 +212,7 @@ describe('ArgumentParser', () => {
       expect(parser.parse([])).toEqual({ boolean: true });
     });
 
-    it('should handle a boolean option with an async default callback', () => {
+    it('should handle a boolean option with an async default callback', async () => {
       const options = {
         boolean: {
           type: 'boolean',
@@ -221,7 +221,7 @@ describe('ArgumentParser', () => {
         },
       } as const satisfies Options;
       const parser = new ArgumentParser(options);
-      expect(parser.parse([])).toEqual({ boolean: expect.toResolve(true) });
+      await expect(parser.parse([]).boolean).resolves.toBeTruthy();
     });
 
     it('should handle a string option with a default value', () => {
@@ -248,7 +248,7 @@ describe('ArgumentParser', () => {
       expect(parser.parse([])).toEqual({ string: '123' });
     });
 
-    it('should handle a string option with an async default callback', () => {
+    it('should handle a string option with an async default callback', async () => {
       const options = {
         string: {
           type: 'string',
@@ -257,7 +257,7 @@ describe('ArgumentParser', () => {
         },
       } as const satisfies Options;
       const parser = new ArgumentParser(options);
-      expect(parser.parse([])).toEqual({ string: expect.toResolve('123') });
+      await expect(parser.parse([]).string).resolves.toEqual('123');
     });
 
     it('should handle a number option with a default value', () => {
@@ -284,7 +284,7 @@ describe('ArgumentParser', () => {
       expect(parser.parse([])).toEqual({ number: 123 });
     });
 
-    it('should handle a number option with an async default callback', () => {
+    it('should handle a number option with an async default callback', async () => {
       const options = {
         number: {
           type: 'number',
@@ -293,7 +293,7 @@ describe('ArgumentParser', () => {
         },
       } as const satisfies Options;
       const parser = new ArgumentParser(options);
-      expect(parser.parse([])).toEqual({ number: expect.toResolve(123) });
+      await expect(parser.parse([]).number).resolves.toEqual(123);
     });
 
     it('should handle a strings option with a default value', () => {
@@ -322,7 +322,7 @@ describe('ArgumentParser', () => {
       expect(parser.parse([])).toEqual({ strings: ['ONE', 'TWO'] });
     });
 
-    it('should handle a strings option with an async default callback', () => {
+    it('should handle a strings option with an async default callback', async () => {
       const options = {
         strings: {
           type: 'strings',
@@ -332,7 +332,7 @@ describe('ArgumentParser', () => {
         },
       } as const satisfies Options;
       const parser = new ArgumentParser(options);
-      expect(parser.parse([])).toEqual({ strings: expect.toResolve(['ONE', 'TWO']) });
+      await expect(parser.parse([]).strings).resolves.toEqual(['ONE', 'TWO']);
     });
 
     it('should handle a numbers option with a default value', () => {
@@ -361,7 +361,7 @@ describe('ArgumentParser', () => {
       expect(parser.parse([])).toEqual({ numbers: [1, 2] });
     });
 
-    it('should handle a numbers option with an async default callback', () => {
+    it('should handle a numbers option with an async default callback', async () => {
       const options = {
         numbers: {
           type: 'numbers',
@@ -371,7 +371,7 @@ describe('ArgumentParser', () => {
         },
       } as const satisfies Options;
       const parser = new ArgumentParser(options);
-      expect(parser.parse([])).toEqual({ numbers: expect.toResolve([1, 2]) });
+      await expect(parser.parse([]).numbers).resolves.toEqual([1, 2]);
     });
   });
 });

--- a/packages/tsargp/test/utils.spec.ts
+++ b/packages/tsargp/test/utils.spec.ts
@@ -1,4 +1,3 @@
-import type { SyncExpectationResult, AsyncExpectationResult, MatcherState } from '@vitest/expect';
 import { describe, expect, it } from 'vitest';
 import {
   overrides,
@@ -9,45 +8,12 @@ import {
   isTrue,
 } from '../lib/utils';
 
-interface CustomMatchers<R = unknown> {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  toEqual(expected: any): R;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  toResolve(expected: any): R;
-}
-
-declare module 'vitest' {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  interface Assertion<T = any> extends CustomMatchers<T> {}
-  interface AsymmetricMatchersContaining extends CustomMatchers {}
-}
-
-/** @ignore */
-function toEqual(this: MatcherState, actual: unknown, expected: unknown): SyncExpectationResult {
-  const pass = this.equals(actual, expected);
-  const message = () => `expected ${actual} to match ${expected}`;
-  return { message, pass, actual, expected };
-}
-
-/** @ignore */
-async function toResolve(
-  this: MatcherState,
-  received: Promise<unknown>,
-  expected: unknown,
-): AsyncExpectationResult {
-  const actual = await received;
-  const pass = this.equals(actual, expected);
-  const message = () => `expected ${actual} to match ${expected}`;
-  return { message, pass, actual, expected };
-}
-
 /*
   Initialization section. Do not do any of the following:
   - wrap this code in an IIFE, default export or vitest's `beforeAll`
   - assign `undefined` to `process.env`, as it will be converted to the string 'undefined'
 */
 {
-  expect.extend({ toEqual, toResolve });
   overrides.stderrCols = 0;
   overrides.stdoutCols = 0;
   resetEnv();


### PR DESCRIPTION
The `parseArray` function was refactored in order to allow the `separator` and `parse` attributes to be used in conjunction. In this case, the callback will be called for each element split by the separator.

The documentation was updated to reflect this new possibility, and the Parser page was updated with more details about the behavior of the custom parsing callbacks.

Closes #70 
