### PR TITLE
Issues/43

### DIFF
--- a/.changeset/big-fishes-stare.md
+++ b/.changeset/big-fishes-stare.md
@@ -1,0 +1,5 @@
+---
+'tsargp': minor
+---
+
+Added the `skipCount` attribute to function options to indicate the number of remaining command-line arguments to skip after returning from the execute callback.

--- a/.changeset/hip-baboons-smash.md
+++ b/.changeset/hip-baboons-smash.md
@@ -1,0 +1,5 @@
+---
+'@trulysimple/tsargp-docs': patch
+---
+
+Documented the new `skipCount` attribute for function options in the Options page.

--- a/packages/docs/pages/docs/library/options.mdx
+++ b/packages/docs/pages/docs/library/options.mdx
@@ -502,14 +502,32 @@ Notes about this callback:
 
 #### Break loop
 
-The `break` attribute indicates whether the parser should exit the parsing loop immediately after
-returning from the callback.
+The `break` attribute indicates whether the parser should exit the parsing loop after returning from
+the callback.
 
 <Callout type="warning">
   When setting this attribute, the requirements of all options specified up to the current iteration
   (including the function option) will be verified. Hence, you should make it clear in the help
   message that any option required by the affected one must be specified _before_ it.
 </Callout>
+
+#### Skip count
+
+The `skipCount` attribute is an output parameter that indicates the number of remaining arguments to
+skip, after the callback returns. This only works if the callback is synchronous, and should not be
+used during bash completion.
+
+Here is an example of how it might be used:
+
+```ts
+{
+  // other attributes...
+  exec(_, _, rest: string[]) {
+    this.skipCount = 1;
+    return JSON.parse(rest[0]);
+  },
+}
+```
 
 ### Command option
 
@@ -542,6 +560,12 @@ Notes about this callback:
 <Callout type="default">
   The simplest implementation would just return `cmdValues`. This way, the values can be handled
   after the parser returns from the parsing loop.
+</Callout>
+
+<Callout type="info">
+  Please note that the library does not offer a direct way for a command to access the parsed values
+  of ancestor commands (except its immediate parent) during parsing. However, this can be achieved
+  by waiting until the parser returns from the parsing loop before acting upon the option values.
 </Callout>
 
 #### Command options | callback

--- a/packages/docs/pages/docs/library/options.mdx
+++ b/packages/docs/pages/docs/library/options.mdx
@@ -513,11 +513,11 @@ the callback.
 
 #### Skip count
 
-The `skipCount` attribute is an output parameter that indicates the number of remaining arguments to
-skip, after the callback returns. This only works if the callback is synchronous, and should not be
-used during bash completion.
+The `skipCount` attribute indicates the number of remaining arguments to skip, after the callback
+returns. You may change this value inside a _synchronous_ callback. Otherwise, you should leave it
+unchanged. The parser does not alter this value and ignores it during bash completion.
 
-Here is an example of how it might be used:
+Here is an example of how it might be used inside the callback:
 
 ```ts
 {

--- a/packages/docs/pages/docs/library/options.mdx
+++ b/packages/docs/pages/docs/library/options.mdx
@@ -514,7 +514,7 @@ the callback.
 #### Skip count
 
 The `skipCount` attribute indicates the number of remaining arguments to skip, after the callback
-returns. You may change this value inside a _synchronous_ callback. Otherwise, you should leave it
+returns. You may change this value inside a _synchronous_ callback. Otherwise, it should be left
 unchanged. The parser does not alter this value and ignores it during bash completion.
 
 Here is an example of how it might be used inside the callback:
@@ -522,7 +522,7 @@ Here is an example of how it might be used inside the callback:
 ```ts
 {
   // other attributes...
-  exec(_, _, rest: string[]) {
+  exec(_, _, rest: Array<string>) {
     this.skipCount = 1;
     return JSON.parse(rest[0]);
   },

--- a/packages/tsargp/lib/options.ts
+++ b/packages/tsargp/lib/options.ts
@@ -586,8 +586,9 @@ export type FunctionOption = WithType<'function'> &
      */
     readonly break?: true;
     /**
-     * An output parameter that indicates the number of remaining arguments to skip. This only works
-     * if the execute callback is synchronous. This should not be used during bash completion.
+     * The number of remaining arguments to skip. You may change this value inside a synchronous
+     * callback. Otherwise, you should leave it unchanged. The parser does not alter this value.
+     * During bash completion, it is ignored.
      */
     skipCount?: number;
   };

--- a/packages/tsargp/lib/options.ts
+++ b/packages/tsargp/lib/options.ts
@@ -585,6 +585,11 @@ export type FunctionOption = WithType<'function'> &
      * True to break the parsing loop.
      */
     readonly break?: true;
+    /**
+     * An output parameter that indicates the number of remaining arguments to skip. This only works
+     * if the execute callback is synchronous. This should not be used during bash completion.
+     */
+    skipCount?: number;
   };
 
 /**

--- a/packages/tsargp/lib/parser.ts
+++ b/packages/tsargp/lib/parser.ts
@@ -372,7 +372,11 @@ class ParserLoop {
       this.checkRequired();
     }
     try {
+      delete option.skipCount;
       const result = option.exec(this.values, this.completing, this.args.slice(index + 1));
+      if (option.skipCount) {
+        this.args.splice(index + 1, Math.max(0, option.skipCount));
+      }
       if (result instanceof Promise) {
         this.promises.push(
           result.then(

--- a/packages/tsargp/lib/parser.ts
+++ b/packages/tsargp/lib/parser.ts
@@ -376,7 +376,6 @@ class ParserLoop {
       if (!this.completing && option.skipCount) {
         this.args.splice(index + 1, Math.max(0, option.skipCount));
       }
-      JSON.parse;
       if (result instanceof Promise) {
         this.promises.push(
           result.then(

--- a/packages/tsargp/lib/parser.ts
+++ b/packages/tsargp/lib/parser.ts
@@ -372,11 +372,11 @@ class ParserLoop {
       this.checkRequired();
     }
     try {
-      delete option.skipCount;
       const result = option.exec(this.values, this.completing, this.args.slice(index + 1));
-      if (option.skipCount) {
+      if (!this.completing && option.skipCount) {
         this.args.splice(index + 1, Math.max(0, option.skipCount));
       }
+      JSON.parse;
       if (result instanceof Promise) {
         this.promises.push(
           result.then(

--- a/packages/tsargp/test/parser/parser.completion.spec.ts
+++ b/packages/tsargp/test/parser/parser.completion.spec.ts
@@ -33,6 +33,20 @@ describe('ArgumentParser', () => {
       expect(options.function.exec).toHaveBeenCalledWith(anything, true, anything);
     });
 
+    it('should ignore the skip count of a function option during completion', () => {
+      const options = {
+        function: {
+          type: 'function',
+          names: ['-f'],
+          exec() {
+            this.skipCount = 1;
+          },
+        },
+      } as const satisfies Options;
+      const parser = new ArgumentParser(options);
+      expect(() => parser.parse('cmd -f ', { compIndex: 7 })).toThrow(/^-f$/);
+    });
+
     it('should handle the completion of a help option', () => {
       const options = {
         help: {

--- a/packages/tsargp/test/parser/parser.spec.ts
+++ b/packages/tsargp/test/parser/parser.spec.ts
@@ -111,6 +111,45 @@ describe('ArgumentParser', () => {
     });
 
     describe('function', () => {
+      it('should skip a certain number of remaining arguments', () => {
+        const options = {
+          flag: {
+            type: 'flag',
+            names: ['-f1'],
+          },
+          function: {
+            type: 'function',
+            names: ['-f2'],
+            exec() {
+              this.skipCount = 1;
+            },
+          },
+        } as const satisfies Options;
+        const parser = new ArgumentParser(options);
+        expect(parser.parse(['-f2', 'skipped', '-f1'])).toEqual({
+          flag: true,
+          function: undefined,
+        });
+      });
+
+      it('should not skip any argument when the skip count is negative', () => {
+        const options = {
+          flag: {
+            type: 'flag',
+            names: ['-f1'],
+          },
+          function: {
+            type: 'function',
+            names: ['-f2'],
+            exec() {
+              this.skipCount = -1;
+            },
+          },
+        } as const satisfies Options;
+        const parser = new ArgumentParser(options);
+        expect(() => parser.parse(['-f2', 'arg', '-f1'])).toThrow('Unknown option arg.');
+      });
+
       it('should throw an error on function option specified with value', () => {
         const options = {
           function: {


### PR DESCRIPTION
A new attribute, `skipCount`, was added to function options. It indicates the number of remaining command-line arguments to skip after returning from the `exec` callback.

Closes #43 
