### PR TITLE
Issues/22

### DIFF
--- a/.changeset/cuddly-sloths-lick.md
+++ b/.changeset/cuddly-sloths-lick.md
@@ -1,0 +1,5 @@
+---
+'@trulysimple/tsargp-docs': patch
+---
+
+Documented the new `useFilters` attribute for help options. Also added a tip in the Demo page for users to try out the new feature.

--- a/.changeset/cuddly-sloths-lick.md
+++ b/.changeset/cuddly-sloths-lick.md
@@ -2,4 +2,4 @@
 '@trulysimple/tsargp-docs': patch
 ---
 
-Documented the new `useFilters` attribute for help options. Also added a tip in the Demo page for users to try out the new feature.
+Updated the Options page to document the new `useFilters` attribute for help options. Also added a tip in the Demo page for users to try out the new feature.

--- a/.changeset/rotten-bears-heal.md
+++ b/.changeset/rotten-bears-heal.md
@@ -1,0 +1,5 @@
+---
+'tsargp': minor
+---
+
+Added the `useFilters` attribute to help option to allow remaining arguments to be used as option filters for the help message.

--- a/packages/docs/pages/demo.mdx
+++ b/packages/docs/pages/demo.mdx
@@ -65,6 +65,7 @@ export const Demo = dynamic(() => import('@components/demo'), { ssr: false });
 - check if the `-f` option can be specified without a parameter, and negated with `--no-flag`
 - check if the `-b` option can be specified in combination with other options
 - check if values can be inlined with option names (e.g., `-ss=abc`)
+- check if the help option accepts option filters (e.g., `-h -b`)
 
 ### Nested commands
 

--- a/packages/docs/pages/docs/library/options.mdx
+++ b/packages/docs/pages/docs/library/options.mdx
@@ -442,6 +442,19 @@ the help message. The default is to include two:
 - groups section - with `'Options'{:ts}` as default group heading - appending a colon to group
   headings
 
+#### Use filters
+
+The `useFilters` attribute is an opt-in feature that allows the remaining arguments to be used as
+option filters. For example, the invocation `cli --help flag` would only include in the help message
+those options whose names or synopsis match the regex `/flag/i{:ts}`. There can be as many arguments
+as the user wants.
+
+<Callout type="default">
+  This is inherently different from what a text search utility like `grep` would produce. The
+  library will print the _whole_ help entry of options matching the given patterns, not just the
+  matching lines.
+</Callout>
+
 ### Version option
 
 The **version** option is another specialization of the [function option](#function-option) that
@@ -514,8 +527,8 @@ the callback.
 #### Skip count
 
 The `skipCount` attribute indicates the number of remaining arguments to skip, after the callback
-returns. You may change this value inside a _synchronous_ callback. Otherwise, it should be left
-unchanged. The parser does not alter this value and ignores it during bash completion.
+returns. You may only change this value inside a _synchronous_ callback. Otherwise, it should be
+left unchanged. The parser does not alter this value and ignores it during bash completion.
 
 Here is an example of how it might be used inside the callback:
 

--- a/packages/tsargp/examples/demo.options.ts
+++ b/packages/tsargp/examples/demo.options.ts
@@ -98,6 +98,7 @@ Report a bug: ${style(tf.faint)}https://github.com/trulysimple/tsargp/issues`,
         noWrap: true,
       },
     ],
+    useFilters: true,
   },
   /**
    * A version option that throws the package version.

--- a/packages/tsargp/lib/options.ts
+++ b/packages/tsargp/lib/options.ts
@@ -625,6 +625,10 @@ export type HelpOption = WithType<'help'> & {
    * The help sections to be rendered.
    */
   readonly sections?: HelpSections;
+  /**
+   * Opt-in feature: set this to true to allow the remaining arguments to be used as option filters.
+   */
+  readonly useFilters?: true;
 };
 
 /**

--- a/packages/tsargp/lib/parser.ts
+++ b/packages/tsargp/lib/parser.ts
@@ -355,7 +355,7 @@ class ParserLoop {
       case 'command':
         return this.handleCommand(key, option, name, index);
       default:
-        return this.handleSpecial(option);
+        return this.handleSpecial(option, index);
     }
   }
 
@@ -444,14 +444,17 @@ class ParserLoop {
   /**
    * Handles a special option.
    * @param option The option definition
+   * @param index The current argument index
    * @returns True if the parsing loop should be broken
    */
-  private handleSpecial(option: SpecialOption): boolean {
+  private handleSpecial(option: SpecialOption, index: number): boolean {
     if (this.completing) {
       return false; // skip special options during completion
     }
     if (option.type === 'help') {
-      const formatter = new HelpFormatter(this.validator, option.format);
+      const filters =
+        option.useFilters && this.args.slice(index + 1).map((arg) => RegExp(arg, 'i'));
+      const formatter = new HelpFormatter(this.validator, option.format, filters);
       const sections = option.sections ?? [
         { type: 'usage', title: 'Usage:', indent: 2 },
         { type: 'groups', title: 'Options', phrase: '%s:' },

--- a/packages/tsargp/test/formatter/formatter.spec.ts
+++ b/packages/tsargp/test/formatter/formatter.spec.ts
@@ -9,6 +9,56 @@ describe('HelpFormatter', () => {
       expect(message.wrap()).toEqual('');
     });
 
+    it('should filter options with a single regular expression', () => {
+      const options = {
+        flag1: {
+          type: 'flag',
+          names: ['-f', '--flag'],
+        },
+        flag2: {
+          type: 'flag',
+          desc: 'A flag option',
+        },
+        boolean: {
+          type: 'boolean',
+          names: ['-b', '--boolean'],
+          desc: 'A boolean option',
+        },
+      } as const satisfies Options;
+      const validator = new OptionValidator(options);
+      const config = { descr: { absolute: true } };
+      const message = new HelpFormatter(validator, config, [/flag/]).formatHelp();
+      expect(message.wrap()).toEqual('  -f, --flag\n  A flag option\n');
+    });
+
+    it('should filter options with multiple regular expressions', () => {
+      const options = {
+        flag1: {
+          type: 'flag',
+          names: ['-f', '--flag'],
+        },
+        flag2: {
+          type: 'flag',
+          desc: 'A flag option',
+        },
+        boolean: {
+          type: 'boolean',
+          names: ['-b', '--boolean'],
+        },
+        help: {
+          type: 'help',
+          names: ['-h'],
+          format: { descr: { absolute: true } },
+          sections: [{ type: 'groups' }],
+          useFilters: true,
+        },
+      } as const satisfies Options;
+      const validator = new OptionValidator(options);
+      const config = { descr: { absolute: true } };
+      const message = new HelpFormatter(validator, config, [/^-f/, /^-b/]).formatHelp();
+      expect(message.wrap()).toEqual('  -f, --flag\n  -b, --boolean  <boolean>\n');
+    });
+
     it('should handle a function option', () => {
       const options = {
         function: {

--- a/packages/tsargp/test/formatter/formatter.spec.ts
+++ b/packages/tsargp/test/formatter/formatter.spec.ts
@@ -22,7 +22,6 @@ describe('HelpFormatter', () => {
         boolean: {
           type: 'boolean',
           names: ['-b', '--boolean'],
-          desc: 'A boolean option',
         },
       } as const satisfies Options;
       const validator = new OptionValidator(options);
@@ -45,17 +44,9 @@ describe('HelpFormatter', () => {
           type: 'boolean',
           names: ['-b', '--boolean'],
         },
-        help: {
-          type: 'help',
-          names: ['-h'],
-          format: { descr: { absolute: true } },
-          sections: [{ type: 'groups' }],
-          useFilters: true,
-        },
       } as const satisfies Options;
       const validator = new OptionValidator(options);
-      const config = { descr: { absolute: true } };
-      const message = new HelpFormatter(validator, config, [/^-f/, /^-b/]).formatHelp();
+      const message = new HelpFormatter(validator, {}, [/^-f/, /^-b/]).formatHelp();
       expect(message.wrap()).toEqual('  -f, --flag\n  -b, --boolean  <boolean>\n');
     });
 

--- a/packages/tsargp/test/parser/parser.spec.ts
+++ b/packages/tsargp/test/parser/parser.spec.ts
@@ -103,7 +103,6 @@ describe('ArgumentParser', () => {
           help: {
             type: 'help',
             names: ['-h'],
-            format: { descr: { absolute: true } },
             sections: [{ type: 'groups' }],
             useFilters: true,
           },

--- a/packages/tsargp/test/parser/parser.spec.ts
+++ b/packages/tsargp/test/parser/parser.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import { type Options, ArgumentParser, OptionValues, HelpMessage } from '../../lib';
+import { type Options, ArgumentParser, OptionValues } from '../../lib';
 import '../utils.spec'; // initialize globals
 
 describe('ArgumentParser', () => {
@@ -61,13 +61,9 @@ describe('ArgumentParser', () => {
         } as const satisfies Options;
         const parser = new ArgumentParser(options);
         expect(parser.parse([])).not.toHaveProperty('help');
-        try {
-          parser.parse(['-h'], { progName: 'prog' });
-        } catch (err) {
-          expect((err as HelpMessage).wrap(0)).toMatch(
-            /^Usage:\n\n {2}prog \[-f\] \[-h\]\n\nArgs:\n\n {2}-f\n\nOptions:\n\n {2}-h/,
-          );
-        }
+        expect(() => parser.parse(['-h'], { progName: 'prog' })).toThrow(
+          /^Usage:\n\n {2}prog \[-f\] \[-h\]\n\nArgs:\n\n {2}-f\n\nOptions:\n\n {2}-h$/,
+        );
       });
 
       it('should throw a help message with usage and custom indentation', () => {
@@ -85,13 +81,37 @@ describe('ArgumentParser', () => {
         } as const satisfies Options;
         const parser = new ArgumentParser(options);
         expect(parser.parse([])).not.toHaveProperty('help');
-        try {
-          parser.parse(['-h'], { progName: 'prog' });
-        } catch (err) {
-          expect((err as HelpMessage).wrap(0)).toMatch(
-            /^usage heading\n\nprog \[-h\]\n\ngroup {2}heading\n\n-h/,
-          );
-        }
+        expect(() => parser.parse(['-h'], { progName: 'prog' })).toThrow(
+          /^usage heading\n\nprog \[-h\]\n\ngroup {2}heading\n\n-h$/,
+        );
+      });
+
+      it('should throw a help message with filtered options', () => {
+        const options = {
+          flag1: {
+            type: 'flag',
+            names: ['-f', '--flag'],
+          },
+          flag2: {
+            type: 'flag',
+            desc: 'A flag option',
+          },
+          boolean: {
+            type: 'boolean',
+            names: ['-b', '--boolean'],
+          },
+          help: {
+            type: 'help',
+            names: ['-h'],
+            format: { descr: { absolute: true } },
+            sections: [{ type: 'groups' }],
+            useFilters: true,
+          },
+        } as const satisfies Options;
+        const parser = new ArgumentParser(options);
+        expect(() => parser.parse(['-h', '^-F', '^-B'], { progName: 'prog' })).toThrow(
+          /^ {2}-f, --flag\n {2}-b, --boolean {2}<boolean>$/,
+        );
       });
     });
 
@@ -765,10 +785,8 @@ describe('tryParse', () => {
     await expect(parser.tryParse(values, ['-f1', '-f2'])).resolves.toHaveProperty(
       'message',
       expect.stringMatching(
-        new RegExp(
-          'Option -f1 is deprecated and may be removed in future releases.\n' +
-            'Option -f2 is deprecated and may be removed in future releases.',
-        ),
+        'Option -f1 is deprecated and may be removed in future releases.\n' +
+          'Option -f2 is deprecated and may be removed in future releases.',
       ),
     );
   });


### PR DESCRIPTION
A new attribute, `useFilters`, was added to help options to allow remaining arguments to be used as option filters.

The parser was updated to collect the remaining arguments after the help option and convert them to regexes.

The formatter constructor was updated to implement filtering of options based on a list of regular expressions.

The Options page was updated to document the new attribute, and the Demo page updated with a tip for users to try out the new feature.

Closes #22 
