### PR TITLE
Issues/23

### DIFF
--- a/.changeset/great-weeks-destroy.md
+++ b/.changeset/great-weeks-destroy.md
@@ -1,0 +1,5 @@
+---
+'@trulysimple/tsargp-docs': minor
+---
+
+The Validator page was updated to document the new behaviour of the `validate` method, namely, that it returns validation warnings as a result. The "Names validation" section was updated to document the detection of naming inconsistencies. The Playground page was updated to report validation warnings when validating the input source.

--- a/.changeset/real-mice-explode.md
+++ b/.changeset/real-mice-explode.md
@@ -1,0 +1,5 @@
+---
+'tsargp': minor
+---
+
+The `validate` method now returns a list of warnings. The validator was updated to detect naming inconsistencies in the option definitions and report them as warnings.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -14,7 +14,16 @@ export default [
   jsdoc.configs['flat/recommended-typescript-error'],
   {
     plugins: { '@cspell': cspell },
-    rules: { '@cspell/spellchecker': 'error' },
+    rules: {
+      '@cspell/spellchecker': [
+        'error',
+        {
+          cspell: {
+            words: ['ruleset'],
+          },
+        },
+      ],
+    },
   },
   {
     files: ['**/*.ts'],

--- a/packages/docs/components/play.tsx
+++ b/packages/docs/components/play.tsx
@@ -40,7 +40,12 @@ class PlayCommand extends Command<PlayProps> {
   private init() {
     const source = this.props.callbacks.getSource();
     const options = Function('tsargp', `'use strict';${source}`)(tsargp);
-    this.parser = new ArgumentParser(options).validate();
+    const parser = new ArgumentParser(options);
+    const warnings = parser.validate();
+    if (warnings.length) {
+      this.println(warnings.wrap(this.state.width));
+    }
+    this.parser = parser;
   }
 
   override run(line: string, compIndex?: number) {

--- a/packages/docs/pages/docs/index.mdx
+++ b/packages/docs/pages/docs/index.mdx
@@ -18,7 +18,7 @@ title: Introduction - Docs
 | ESM-native             | Asynchronous callbacks  | Custom phrases           |
 | Online documentation   | Recursive commands      | Option grouping/hiding   |
 
-[^1]: ~33KB minified
+[^1]: ~34KB minified
 
 ## Motivation
 

--- a/packages/docs/pages/docs/library/validator.mdx
+++ b/packages/docs/pages/docs/library/validator.mdx
@@ -55,7 +55,7 @@ such as:
 - **Too similar names** -
   When an option name is too similar to other names (e.g., if it differs by a single character in a
   five-character name), this may be a development mistake at best, or at worst it can become a
-  source of headaches for end-users . Hence, the validator tries to find names that closely match a
+  source of headaches for end-users. Hence, the validator tries to find names that closely match a
   given name using the same algorithm used by the parser in [name suggestions], just a little
   stricter.
 - **Mixed naming convention** -
@@ -291,8 +291,8 @@ The `phrases` property specifies the phrases to be used for each kind of error m
 - `duplicateClusterLetter` - `'Option %o has duplicate cluster letter %s.'{:ts}`
 - `invalidClusterOption` - `'Option letter %o must be the last in a cluster.'{:ts}`
 - `invalidClusterLetter` - `'Option %o has invalid cluster letter %s.'{:ts}`
-- `tooSimilarOptionNames` - `'[%o] Option name %s1 has too similar names %s2.'{:ts}`
-- `mixedNamingConvention` - `'[%o] Name slot %n has mixed naming conventions %s.'{:ts}`
+- `tooSimilarOptionNames` - `'%o: Option name %s1 has too similar names %s2.'{:ts}`
+- `mixedNamingConvention` - `'%o: Name slot %n has mixed naming conventions %s.'{:ts}`
 
 These phrases will be formatted according to [text formatting] rules.
 

--- a/packages/docs/pages/docs/library/validator.mdx
+++ b/packages/docs/pages/docs/library/validator.mdx
@@ -18,9 +18,13 @@ on your application. The validations behave like assertions: they assert that yo
 as expected when delivered to end-users.
 
 To validate a set of option definitions, you must call the `validate` method on the parser instance.
-The following sections describe the various kinds of validation performed by this method. Any option
-definition that does not satisfy one of these restrictions will trigger an error with an explanatory
-message that may include the option's key.
+This method accepts no argument and returns a list of warning messages that represent
+not-so-dangerous issues encountered in the option definitions. You may want to print this to see if
+they are important to your application.
+
+The following sections describe the various kinds of validation performed by this method. Unless
+otherwise noted, any option definition that does not satisfy one of these restrictions will raise an
+error with an explanatory message that may include the option's key.
 
 <Callout type="info">
   Validation is performed recursively for nested commands, skipping circular references when
@@ -44,6 +48,21 @@ Option names are subject to the restrictions listed below:
   In any of these restrictions, empty strings and `null{:ts}`s are ignored, while flags' [negation
   names] and the [positional marker] are included.
 </Callout>
+
+In addition to the above, the validator may generate warnings if it detects naming inconsistencies,
+such as:
+
+- **Too similar names** -
+  When an option name is too similar to other names (e.g., if it differs by a single character in a
+  five-character name), this may be a development mistake at best, or at worst it can become a
+  source of headaches for end-users . Hence, the validator tries to find names that closely match a
+  given name using the same algorithm used by the parser in [name suggestions], just a little
+  stricter.
+- **Mixed naming convention** -
+  When a [name slot] contains names with different naming conventions (e.g., all-uppercase vs
+  all-lowercase, or single-dash vs double-dash), this may be a sign of code review negligence at
+  best, or at worst it can make it hard for end-users to reason about your application. Thus, the
+  validator tries to find names within a slot that contain mixed naming patterns.
 
 ### Cluster letter validation
 
@@ -220,7 +239,7 @@ The `ErrorItem` enumeration lists the kinds of error messages that may be raised
   raised by both the parser and validator when a value fails to satisfy an array option's limit
   constraint
 - `deprecatedOption` -
-  warning saved by the parser when a deprecated option is specified on the command-line
+  warning produced by the parser when a deprecated option is specified on the command-line
 - `unsatisfiedCondRequirement` -
   raised by the parser when a conditional option requirement is not satisfied
 - `duplicateClusterLetter` -
@@ -230,6 +249,11 @@ The `ErrorItem` enumeration lists the kinds of error messages that may be raised
   middle of a cluster argument
 - `invalidClusterLetter` -
   raised by the validator when an option has an invalid cluster letter
+- `tooSimilarOptionNames` -
+  warning produced by the validator when an option name is too similar to other names
+- `mixedNamingConvention` -
+  warning produced by the validator when a name slot contains names with different naming
+  conventions
 
 ### Error phrases
 
@@ -267,6 +291,8 @@ The `phrases` property specifies the phrases to be used for each kind of error m
 - `duplicateClusterLetter` - `'Option %o has duplicate cluster letter %s.'{:ts}`
 - `invalidClusterOption` - `'Option letter %o must be the last in a cluster.'{:ts}`
 - `invalidClusterLetter` - `'Option %o has invalid cluster letter %s.'{:ts}`
+- `tooSimilarOptionNames` - `'[%o] Option name %s1 has too similar names %s2.'{:ts}`
+- `mixedNamingConvention` - `'[%o] Name slot %n has mixed naming conventions %s.'{:ts}`
 
 These phrases will be formatted according to [text formatting] rules.
 
@@ -287,40 +313,42 @@ Specifiers may end with a single digit that represents a specific value in the e
 following table lists the available specifiers for each kind of error message, along with a
 description of the corresponding value.
 
-| Error                          | Specifiers                                                                        |
-| ------------------------------ | --------------------------------------------------------------------------------- |
-| parseError                     | `%o` = the unknown option name                                                    |
-| parseErrorWithSimilar          | `%o1`= the unknown option name; `%o2` = similar option names                      |
-| unknownOption                  | `%o` = the unknown option name                                                    |
-| unknownOptionWithSimilar       | `%o1` = the unknown option name; `%o2` = similar option names                     |
-| unsatisfiedRequirement         | `%o` = the specified option name; `%t` = the option's requirements                |
-| missingRequiredOption          | `%o` = the option's preferred name                                                |
-| missingParameter               | `%o` = the specified option name                                                  |
-| missingPackageJson             |                                                                                   |
-| disallowedInlineValue          | `%o` = the specified option name or positional marker                             |
-| emptyPositionalMarker          | `%o` = the option's key                                                           |
-| unnamedOption                  | `%o` = the option's key                                                           |
-| invalidOptionName              | `%o` = the option's key; `%s` = the invalid name                                  |
-| emptyVersionDefinition         | `%o` = the option's key                                                           |
-| invalidSelfRequirement         | `%o` = the option's key                                                           |
-| unknownRequiredOption          | `%o` = the required option's key                                                  |
-| invalidRequiredOption          | `%o` = the required option's key                                                  |
-| emptyEnumsDefinition           | `%o` = the option's key                                                           |
-| duplicateOptionName            | `%o` = the option's key; `%s` = the duplicate name                                |
-| duplicatePositionalOption      | `%o1` = the duplicate option's key; `%o2` = the previous option's key             |
-| duplicateStringEnum            | `%o` = the option's key; `%s` = the duplicate enum value                          |
-| duplicateNumberEnum            | `%o` = the option's key; `%n` = the duplicate enum value                          |
-| incompatibleRequiredValue      | `%o` = the option's key; `%p` = the incompatible value; `%s` = the expected type  |
-| stringEnumsConstraintViolation | `%o` = the option's key or name; `%s1` = the specified value; `%s2` = the enums   |
-| regexConstraintViolation       | `%o` = the option's key or name; `%s` = the specified value; `%r` = the regex     |
-| numberEnumsConstraintViolation | `%o` = the option's key or name; `%n1` = the specified value; `%n2` = the enums   |
-| rangeConstraintViolation       | `%o` = the option's key or name; `%n1` = the specified value; `%n2` = the range   |
-| limitConstraintViolation       | `%o` = the option's key or name; `%n1` = the value count; `%n2` = the count limit |
-| deprecatedOption               | `%o` = the specified option name                                                  |
-| unsatisfiedCondRequirement     | `%o` = the specified option name; `%t` = the option's requirements                |
-| duplicateClusterLetter         | `%o` = the option's key; `%s` = the duplicate letter                              |
-| invalidClusterOption           | `%o` = the specified cluster letter                                               |
-| invalidClusterLetter           | `%o` = the option's key; `%s` = the invalid letter                                |
+| Error                          | Specifiers                                                                          |
+| ------------------------------ | ----------------------------------------------------------------------------------- |
+| parseError                     | `%o` = the unknown option name                                                      |
+| parseErrorWithSimilar          | `%o1`= the unknown option name; `%o2` = similar option names                        |
+| unknownOption                  | `%o` = the unknown option name                                                      |
+| unknownOptionWithSimilar       | `%o1` = the unknown option name; `%o2` = similar option names                       |
+| unsatisfiedRequirement         | `%o` = the specified option name; `%t` = the option's requirements                  |
+| missingRequiredOption          | `%o` = the option's preferred name                                                  |
+| missingParameter               | `%o` = the specified option name                                                    |
+| missingPackageJson             |                                                                                     |
+| disallowedInlineValue          | `%o` = the specified option name or positional marker                               |
+| emptyPositionalMarker          | `%o` = the option's key                                                             |
+| unnamedOption                  | `%o` = the option's key                                                             |
+| invalidOptionName              | `%o` = the option's key; `%s` = the invalid name                                    |
+| emptyVersionDefinition         | `%o` = the option's key                                                             |
+| invalidSelfRequirement         | `%o` = the option's key                                                             |
+| unknownRequiredOption          | `%o` = the required option's key                                                    |
+| invalidRequiredOption          | `%o` = the required option's key                                                    |
+| emptyEnumsDefinition           | `%o` = the option's key                                                             |
+| duplicateOptionName            | `%o` = the option's key; `%s` = the duplicate name                                  |
+| duplicatePositionalOption      | `%o1` = the duplicate option's key; `%o2` = the previous option's key               |
+| duplicateStringEnum            | `%o` = the option's key; `%s` = the duplicate enum value                            |
+| duplicateNumberEnum            | `%o` = the option's key; `%n` = the duplicate enum value                            |
+| incompatibleRequiredValue      | `%o` = the option's key; `%p` = the incompatible value; `%s` = the expected type    |
+| stringEnumsConstraintViolation | `%o` = the option's key or name; `%s1` = the specified value; `%s2` = the enums     |
+| regexConstraintViolation       | `%o` = the option's key or name; `%s` = the specified value; `%r` = the regex       |
+| numberEnumsConstraintViolation | `%o` = the option's key or name; `%n1` = the specified value; `%n2` = the enums     |
+| rangeConstraintViolation       | `%o` = the option's key or name; `%n1` = the specified value; `%n2` = the range     |
+| limitConstraintViolation       | `%o` = the option's key or name; `%n1` = the value count; `%n2` = the count limit   |
+| deprecatedOption               | `%o` = the specified option name                                                    |
+| unsatisfiedCondRequirement     | `%o` = the specified option name; `%t` = the option's requirements                  |
+| duplicateClusterLetter         | `%o` = the option's key; `%s` = the duplicate letter                                |
+| invalidClusterOption           | `%o` = the specified cluster letter                                                 |
+| invalidClusterLetter           | `%o` = the option's key; `%s` = the invalid letter                                  |
+| tooSimilarOptionNames          | `%o` = the command prefix[^1]; `%s1` = the option name; `%s2` = the similar names   |
+| mixedNamingConvention          | `%o` = the command prefix[^1]; `%n` = the slot index; `%s` = the naming conventions |
 
 [value validation]: #value-validation
 [negation names]: options#negation-names
@@ -334,3 +362,13 @@ description of the corresponding value.
 [positional]: options#positional--marker
 [text formatting]: styles#text-splitting
 [parameter column]: formatter#parameter-column
+[name suggestions]: parser#name-suggestions
+[name slot]: formatter#names-column
+[nested command]: options#command-option
+
+[^1]:
+    the command prefix is a series of option keys interspersed with periods, denoting the current
+    [nested command] in a hierarquical option definition. It starts as the empty string and is
+    appended with the command option's key whenever a nested command is encountered. This prefix
+    also appears in other validation error messages, embedded in the value that replaces the `%o`
+    specifier. Here's an example: `cmd1.cmd2.flag`.

--- a/packages/tsargp/lib/enums.ts
+++ b/packages/tsargp/lib/enums.ts
@@ -152,6 +152,15 @@ export const enum ErrorItem {
    * Raised by the validator when an option has an invalid cluster letter.
    */
   invalidClusterLetter,
+  /**
+   * Warning produced by the validator when an option name is too similar to other names.
+   */
+  tooSimilarOptionNames,
+  /**
+   * Warning produced by the validator when a name slot contains names with different naming
+   * conventions.
+   */
+  mixedNamingConvention,
 }
 
 /**

--- a/packages/tsargp/lib/parser.ts
+++ b/packages/tsargp/lib/parser.ts
@@ -117,11 +117,10 @@ export class ArgumentParser<T extends Options = Options> {
   /**
    * Validates the option definitions. This should only be called during development and in unit
    * tests, but should be skipped in production.
-   * @returns The parser instance
+   * @returns A list of validation warnings
    */
-  validate(): this {
-    this.validator.validate();
-    return this;
+  validate(): WarnMessage {
+    return this.validator.validate();
   }
 
   /**

--- a/packages/tsargp/lib/utils.ts
+++ b/packages/tsargp/lib/utils.ts
@@ -64,8 +64,8 @@ export interface URL extends _URL {}
 /**
  * A naming rule to match a name.
  * @param name The original name
- * @param lower The lowercase version of name
- * @param upper The uppercase version of name
+ * @param lower The lower-cased name
+ * @param upper The upper-cased name
  * @returns True if the name was matched
  * @internal
  */

--- a/packages/tsargp/lib/validator.ts
+++ b/packages/tsargp/lib/validator.ts
@@ -120,8 +120,8 @@ export const defaultConfig: ConcreteError = {
     [ErrorItem.duplicateClusterLetter]: 'Option %o has duplicate cluster letter %s.',
     [ErrorItem.invalidClusterOption]: 'Option letter %o must be the last in a cluster.',
     [ErrorItem.invalidClusterLetter]: 'Option %o has invalid cluster letter %s.',
-    [ErrorItem.tooSimilarOptionNames]: '[%o] Option name %s1 has too similar names %s2.',
-    [ErrorItem.mixedNamingConvention]: '[%o] Name slot %n has mixed naming conventions %s.',
+    [ErrorItem.tooSimilarOptionNames]: '%o: Option name %s1 has too similar names %s2.',
+    [ErrorItem.mixedNamingConvention]: '%o: Name slot %n has mixed naming conventions %s.',
   },
 };
 
@@ -131,9 +131,9 @@ export const defaultConfig: ConcreteError = {
  */
 const namingConventions: NamingRules = {
   cases: {
-    lowercase: (name, lower, upper) => name == lower && name != upper,
-    UPPERCASE: (name, lower, upper) => name != lower && name == upper,
-    Capitalized: (name, lower, upper) => name[0] != lower[0] && name != upper,
+    lowercase: (name, lower, upper) => name == lower && name != upper, // has at least one lower
+    UPPERCASE: (name, lower, upper) => name != lower && name == upper, // has at least one upper
+    Capitalized: (name, lower, upper) => name[0] != lower[0] && name != upper, // has at least one lower
   },
   dashes: {
     noDash: (name) => name[0] != '-',
@@ -372,11 +372,10 @@ export class OptionValidator {
     getNamesInEachSlot(this.options).forEach((slot, i) => {
       const match = matchNamingRules(slot, namingConventions);
       for (const key in match) {
-        const entries = Object.entries(match[key]).map(([rule, name]) => rule + ': ' + name);
+        const entries = Object.entries(match[key]);
         if (entries.length > 1) {
-          result.push(
-            this.format(ErrorItem.mixedNamingConvention, { o: prefix, n: i, s: entries }),
-          );
+          const list = entries.map(([rule, name]) => rule + ': ' + name);
+          result.push(this.format(ErrorItem.mixedNamingConvention, { o: prefix, n: i, s: list }));
         }
       }
     });

--- a/packages/tsargp/test/parser/parser.spec.ts
+++ b/packages/tsargp/test/parser/parser.spec.ts
@@ -5,7 +5,7 @@ import '../utils.spec'; // initialize globals
 describe('ArgumentParser', () => {
   describe('validate', () => {
     it('should validate', () => {
-      expect(() => new ArgumentParser({}).validate()).not.toThrow();
+      expect(new ArgumentParser({}).validate()).toEqual([]);
     });
   });
 

--- a/packages/tsargp/test/utils.spec.ts
+++ b/packages/tsargp/test/utils.spec.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import {
   overrides,
   checkRequiredArray,
@@ -6,6 +6,8 @@ import {
   getArgs,
   splitPhrase,
   isTrue,
+  matchNamingRules,
+  type NamingRules,
 } from '../lib/utils';
 
 /*
@@ -193,5 +195,31 @@ describe('isTrue', () => {
     expect(isTrue(' 1 ')).toBeTruthy();
     expect(isTrue('a')).toBeTruthy();
     expect(isTrue(' A ')).toBeTruthy();
+  });
+});
+
+describe('matchNamingRules', () => {
+  it('should match the first name against each rule', () => {
+    const rules = {
+      ruleset: {
+        rule1: vi.fn().mockImplementation((name) => name.startsWith('Match')),
+        rule2: vi.fn().mockImplementation(() => false),
+      },
+    } as const satisfies NamingRules;
+    const match = matchNamingRules(['Match1', 'Non-match', 'Match2'], rules);
+    expect(match).toEqual({ ruleset: { rule1: 'Match1' } });
+    expect(rules.ruleset.rule1).toHaveBeenCalledWith('Match1', 'match1', 'MATCH1');
+    expect(rules.ruleset.rule1).not.toHaveBeenCalledWith(
+      'Non-match',
+      expect.anything(),
+      expect.anything(),
+    );
+    expect(rules.ruleset.rule1).not.toHaveBeenCalledWith(
+      'Match2',
+      expect.anything(),
+      expect.anything(),
+    );
+    expect(rules.ruleset.rule1).toHaveBeenCalledTimes(1);
+    expect(rules.ruleset.rule2).toHaveBeenCalledTimes(3);
   });
 });

--- a/packages/tsargp/test/validator/validator.names.spec.ts
+++ b/packages/tsargp/test/validator/validator.names.spec.ts
@@ -93,5 +93,53 @@ describe('OptionValidator', () => {
       const validator = new OptionValidator(options);
       expect(() => validator.validate()).toThrow(`Option flag has invalid cluster letter ' '.`);
     });
+
+    it('should return a warning on option name too similar to other names', () => {
+      const options = {
+        flag1: {
+          type: 'flag',
+          names: ['flag1'],
+        },
+        flag2: {
+          type: 'flag',
+          names: ['flag2'],
+        },
+        flag3: {
+          type: 'flag',
+          names: ['flag3'],
+        },
+      } as const satisfies Options;
+      const validator = new OptionValidator(options);
+      const warnings = validator.validate();
+      expect(warnings).toHaveLength(1);
+      expect(warnings.message).toEqual(
+        `[] Option name 'flag1' has too similar names ['flag2', 'flag3'].\n`,
+      );
+    });
+
+    it('should return a warning on mixed naming conventions', () => {
+      const options = {
+        flag1: {
+          type: 'flag',
+          names: ['lower', 'abc', 'keb-ab'],
+        },
+        flag2: {
+          type: 'flag',
+          names: ['UPPER', '-def', 'sna_ke'],
+        },
+        flag3: {
+          type: 'flag',
+          names: ['Capital', '--ghi', 'col:on'],
+        },
+      } as const satisfies Options;
+      const validator = new OptionValidator(options);
+      const warnings = validator.validate();
+      expect(warnings).toHaveLength(3);
+      expect(warnings.message).toEqual(
+        `[] Name slot 0 has mixed naming conventions ['lowercase: lower', 'UPPERCASE: UPPER', 'Capitalized: Capital'].\n` +
+          `[] Name slot 1 has mixed naming conventions ['noDash: abc', '-singleDash: -def', '--doubleDash: --ghi'].\n` +
+          `[] Name slot 2 has mixed naming conventions ['kebab-case: keb-ab', 'snake_case: sna_ke', 'colon:case: col:on'].\n`,
+      );
+    });
   });
 });

--- a/packages/tsargp/test/validator/validator.names.spec.ts
+++ b/packages/tsargp/test/validator/validator.names.spec.ts
@@ -113,7 +113,7 @@ describe('OptionValidator', () => {
       const warnings = validator.validate();
       expect(warnings).toHaveLength(1);
       expect(warnings.message).toEqual(
-        `[] Option name 'flag1' has too similar names ['flag2', 'flag3'].\n`,
+        `: Option name 'flag1' has too similar names ['flag2', 'flag3'].\n`,
       );
     });
 
@@ -136,9 +136,9 @@ describe('OptionValidator', () => {
       const warnings = validator.validate();
       expect(warnings).toHaveLength(3);
       expect(warnings.message).toEqual(
-        `[] Name slot 0 has mixed naming conventions ['lowercase: lower', 'UPPERCASE: UPPER', 'Capitalized: Capital'].\n` +
-          `[] Name slot 1 has mixed naming conventions ['noDash: abc', '-singleDash: -def', '--doubleDash: --ghi'].\n` +
-          `[] Name slot 2 has mixed naming conventions ['kebab-case: keb-ab', 'snake_case: sna_ke', 'colon:case: col:on'].\n`,
+        `: Name slot 0 has mixed naming conventions ['lowercase: lower', 'UPPERCASE: UPPER', 'Capitalized: Capital'].\n` +
+          `: Name slot 1 has mixed naming conventions ['noDash: abc', '-singleDash: -def', '--doubleDash: --ghi'].\n` +
+          `: Name slot 2 has mixed naming conventions ['kebab-case: keb-ab', 'snake_case: sna_ke', 'colon:case: col:on'].\n`,
       );
     });
   });


### PR DESCRIPTION
The `validate` method was updated to return a list of warnings as `WarnMessage`. A new private method, `validateNames`, was added to the validator class, in order to detect naming inconsistencies in the option definitions and report them as warnings.

A new utility function, `matchNamingRules`, as well as related types, `NamingRule`, `NamingRuleSet`, `NamingRules` and `NamingMatch`, were added to `utils.ts`. They are used by the validator to validate option names against a collection of rules. These rules are declared as a constant named `namingConventions` in `validator.ts`.

The Validator page was updated to document the new behaviour of the `validate` method, as well as to list the new kinds of name validation in the "Names validation" section. The "Error items" and related sections were updated to reflect the new `ErrorItem` enumerators: `tooSimilarOptionNames` and `mixedNamingConvention`. The Playground page was updated to report validation warnings when validating the input source.

Closes #23 
