### PR TITLE
Refactor/79

### DIFF
--- a/.changeset/clever-pandas-approve.md
+++ b/.changeset/clever-pandas-approve.md
@@ -1,0 +1,11 @@
+---
+'tsargp': minor
+---
+
+Removed the `parseDelimited` attribute in anticipation for a new and better feature that will yet be implemented. This parsing callback was not really important, and the same effect can be achieved with the `parse` callback by modifying the previous option value.
+
+Improved the formatting of custom phrases for both error and help messages. Now they can contain multiple groups that reference the same phrase alternatives across groups. This also allowed the help item phrases to use specifiers for different value data types.
+
+Added a new kind of validation, `invalidNumericRange`, that validates the option's numeric range definition. Some other enumerators were merged into one that uses a phrase containing a different format specifier for each alternative.
+
+Refactored the `ul` enumeration into a constant that holds underline styles instead of underline colors (since it had just one color that is not strictly necessary).

--- a/.changeset/clever-pandas-approve.md
+++ b/.changeset/clever-pandas-approve.md
@@ -2,10 +2,10 @@
 'tsargp': minor
 ---
 
-Removed the `parseDelimited` attribute in anticipation for a new and better feature that will yet be implemented. This parsing callback was not really important, and the same effect can be achieved with the `parse` callback by modifying the previous option value.
+Removed the `parseDelimited` attribute in anticipation for a new and better feature yet to be implemented. This parsing callback was not really important, whereas the same effect can be achieved with the `parse` callback by modifying the previous option value.
 
-Improved the formatting of custom phrases for both error and help messages. Now they can contain multiple groups that reference the same phrase alternatives across groups. This also allowed the help item phrases to use specifiers for different value data types.
+Improved the formatting of custom phrases for both error and help messages. Now they can contain multiple groups referencing the same phrase alternatives across groups. This also allowed the help item phrases to use specifiers for different value data types.
 
-Added a new kind of validation, `invalidNumericRange`, that validates the option's numeric range definition. Some other enumerators were merged into one that uses a phrase containing a different format specifier for each alternative.
+Added a new kind of validation, `invalidNumericRange`, for the option's numeric range definition. Some other enumerators were merged into one that uses a phrase containing different format specifiers for each alternative.
 
-Refactored the `ul` enumeration into a constant that holds underline styles instead of underline colors (since it had just one color that is not strictly necessary).
+Refactored the `ul` enumeration into a constant that holds underline styles instead of underline colors (since it had just one color that was not strictly necessary).

--- a/.changeset/silly-seals-camp.md
+++ b/.changeset/silly-seals-camp.md
@@ -1,0 +1,9 @@
+---
+'@trulysimple/tsargp-docs': minor
+---
+
+Removed the `parseDelimited` attribute from the "Parameter attributes", to reflect changes in code. Moved some text about custom phrases and format specifiers to the Styles page, where the information on this subject is now centralized.
+
+Updated the "Error items" section of the Validator page, to reflect changes in code. In the same page, the "Enums validation" section was renamed to "Constraints validation", where the new validation rule for numeric ranges was documented.
+
+Updated the "Help phrases" of the Formatter page to reflect changes in code. Also added a table of format specifiers to document the available phrase specifiers for help items.

--- a/.changeset/silly-seals-camp.md
+++ b/.changeset/silly-seals-camp.md
@@ -2,7 +2,7 @@
 '@trulysimple/tsargp-docs': minor
 ---
 
-Removed the `parseDelimited` attribute from the "Parameter attributes", to reflect changes in code. Moved some text about custom phrases and format specifiers to the Styles page, where the information on this subject is now centralized.
+Removed the `parseDelimited` attribute from the "Parameter attributes" in the Options page, to reflect changes in code. Moved some text about custom phrases and format specifiers from both Formatter and Validator pages to the Styles page, where the information on this subject is now centralized.
 
 Updated the "Error items" section of the Validator page, to reflect changes in code. In the same page, the "Enums validation" section was renamed to "Constraints validation", where the new validation rule for numeric ranges was documented.
 

--- a/packages/docs/components/play.tsx
+++ b/packages/docs/components/play.tsx
@@ -3,8 +3,8 @@
 //--------------------------------------------------------------------------------------------------
 import React from 'react';
 import { ArgumentParser, ErrorMessage, HelpMessage } from 'tsargp';
-import { style, req, fg8, bg8, ul8 } from 'tsargp';
-import { HelpItem, ErrorItem, tf, fg, bg, ul } from 'tsargp/enums';
+import { style, req, fg8, bg8, ul8, ul } from 'tsargp';
+import { HelpItem, ErrorItem, tf, fg, bg } from 'tsargp/enums';
 import { type Props, Command } from './classes/command';
 
 const tsargp = { req, tf, fg, bg, ul, HelpItem, ErrorItem, style, fg8, bg8, ul8 };

--- a/packages/docs/pages/docs/library/formatter.mdx
+++ b/packages/docs/pages/docs/library/formatter.mdx
@@ -157,9 +157,9 @@ properties:
 
 ## Help format
 
-In addition to the validator instance, the formatter constructor accepts a `HelpConfig` object that
-can be used to customize the message format. This configuration will apply to all help entries. Its
-properties are optional and are described below.
+In addition to the validator instance, the formatter constructor accepts a `FormatterConfig` object
+that can be used to customize the message format. This configuration will apply to all help entries.
+Its properties are optional and are described below.
 
 ### Help columns
 
@@ -209,8 +209,7 @@ The following is an extract of a help message produced with these settings:
   [95m-ns[0m,   [95m--numbers[0m
             [90m<numbers>...[0m
                       [0mA numbers option. Accepts multiple parameters. Values
-                     will be rounded to the nearest integer. Values must be
-                            in the range [[33m0[0m, [33mInfinity[0m]. Defaults to [[33m1[0m, [33m2[0m].[0m
+                    must be in the range [[33m0[0m, [33mInfinity[0m]. Defaults to [[33m1[0m, [33m2[0m].[0m
 ```
 
 ### Help items
@@ -226,7 +225,7 @@ and in what order. It is an array whose values can be one of the enumerators fro
 - `append` - reports if an array option can be specified multiple times
 - `trim` - reports if string parameters will be trimmed (have leading and trailing whitespace removed)
 - `case` - the kind of case-conversion applied to string parameters, if enabled
-- `round` - the kind of rounding applied to number parameters, if enabled
+- `conv` - the kind of math-conversion applied to number parameters, if enabled
 - `enums` - the enumerated values that the option accepts as parameters, if any
 - `regex` - the regular expression that string parameters should match, if enabled
 - `range` - the numeric range that number parameters should be within, if enabled
@@ -245,43 +244,63 @@ The default is to print all items in the order listed above.
 
 ### Help phrases
 
-The `phrases` property specifies custom phrases to be used for each kind of help item. If an item
-has a value, the `%s` specifier can be used to indicate where in the phrase to place the value. If
-an item has multiple alternatives, such as `HelpItem.case`, different texts can separated with
-`'|'{:ts}` and grouped in parentheses.
+The `phrases` property specifies the phrases to be used for each kind of help item:
 
-The the default values are listed below:
-
-- `synopsis` - `'%s'{:ts}`
-- `negation` - `'Can be negated with %s.'{:ts}`
-- `separator` - `'Values are delimited by %s.'{:ts}`
+- `synopsis` - `'%t'{:ts}`
+- `negation` - `'Can be negated with %o.'{:ts}`
+- `separator` - `'Values are delimited by (%s|%r).'{:ts}`
 - `variadic` - `'Accepts multiple parameters.'{:ts}`
-- `positional` - `'Accepts positional parameters(| that may be preceded by %s).'{:ts}`
+- `positional` - `'Accepts positional parameters(| that may be preceded by %o).'{:ts}`
 - `append` - `'May be specified multiple times.'{:ts}`
 - `trim` - `'Values will be trimmed.'{:ts}`
 - `case` - `'Values will be converted to (lowercase|uppercase).'{:ts}`
-- `round` - `'Values will be rounded (towards zero|down|up|to the nearest integer).'{:ts}`
-- `enums` - `'Values must be one of %s.'{:ts}`
-- `regex` - `'Values must match the regex %s.'{:ts}`
-- `range` - `'Values must be in the range %s.'{:ts}`
+- `conv` - `'Values will be converted with Math.%t.'{:ts}`
+- `enums` - `'Values must be one of {(%s|%n)}.'{:ts}`
+- `regex` - `'Values must match the regex %r.'{:ts}`
+- `range` - `'Values must be in the range [%n].'{:ts}`
 - `unique` - `'Duplicate values will be removed.'{:ts}`
-- `limit` - `'Value count is limited to %s.'{:ts}`
-- `requires` - `'Requires %s.'{:ts}`
+- `limit` - `'Value count is limited to %n.'{:ts}`
+- `requires` - `'Requires %p.'{:ts}`
 - `required` - `'Always required.'{:ts}`
-- `default` - `'Defaults to %s.'{:ts}`
-- `deprecated` - `'Deprecated for %s.'{:ts}`
-- `link` - `'Refer to %s for details.'{:ts}`
-- `envVar` - `'Can be specified through the %s environment variable.'{:ts}`
-- `requiredIf` - `'Required if %s.'{:ts}`
+- `default` - `'Defaults to (%b|%s|%n|[%s]|[%n]|%v).'{:ts}`
+- `deprecated` - `'Deprecated for %t.'{:ts}`
+- `link` - `'Refer to %u for details.'{:ts}`
+- `envVar` - `'Can be specified through the %o environment variable.'{:ts}`
+- `requiredIf` - `'Required if %p.'{:ts}`
 - `clusterLetters` - `'Can be clusterd with %s.'{:ts}`
 
 These phrases will be formatted according to [text formatting] rules.
 
-<Callout type="warning">
-  Phrases can contain inline styles, but not in the same word as the `%s` specifier. Otherwise, they
-  will mess up the text wrapping. For example, the following phrase is not valid:
-  ``` `Requires ${style(tf.bold)}%s`{:ts} ```. You should insert a space in between.
-</Callout>
+#### Format specifiers
+
+Help phrases may have [format specifiers] prefixed with a percent sign `%`, which get replaced with
+a value. The following table lists the available specifiers for each kind of help item, along with a
+description of the corresponding value:
+
+| Error          | Specifiers                                        |
+| -------------- | ------------------------------------------------- |
+| synopsis       | `%t` = the option synopsis                        |
+| negation       | `%o` = the negation names                         |
+| separator      | `%s`/`%r` = the parameter separator               |
+| variadic       |                                                   |
+| positional     | `%o` = the positional marker                      |
+| append         |                                                   |
+| trim           |                                                   |
+| case           |                                                   |
+| conv           | `%t` = the math function                          |
+| enums          | `%s`/`%n` = the enum values                       |
+| regex          | `%r` = the regular expression                     |
+| range          | `%n` = the numeric range                          |
+| unique         |                                                   |
+| limit          | `%n` = the count limit                            |
+| requires       | `%p` = the requirements                           |
+| required       |                                                   |
+| default        | `%b`/`%s`/`%n`/`%s`/`%n`/`%v` = the default value |
+| deprecated     | `%t` = the deprecation reason                     |
+| link           | `%u` = the hyperlink                              |
+| envVar         | `%o` = the variable name                          |
+| requiredIf     | `%p` = the requirements                           |
+| clusterLetters | `%s` = the cluster letters                        |
 
 ## Help styles
 
@@ -306,3 +325,5 @@ overriden by (or combined with) an option's [display styles], if present.
 [text formatting]: styles#text-splitting
 [error messages]: validator#error-styles
 [display styles]: options#display-styles
+[error phrases]: validator#error-phrases
+[format specifiers]: styles#format-specifiers

--- a/packages/docs/pages/docs/library/formatter.mdx
+++ b/packages/docs/pages/docs/library/formatter.mdx
@@ -277,30 +277,30 @@ Help phrases may have [format specifiers] prefixed with a percent sign `%`, whic
 a value. The following table lists the available specifiers for each kind of help item, along with a
 description of the corresponding value:
 
-| Error          | Specifiers                                        |
-| -------------- | ------------------------------------------------- |
-| synopsis       | `%t` = the option synopsis                        |
-| negation       | `%o` = the negation names                         |
-| separator      | `%s`/`%r` = the parameter separator               |
-| variadic       |                                                   |
-| positional     | `%o` = the positional marker                      |
-| append         |                                                   |
-| trim           |                                                   |
-| case           |                                                   |
-| conv           | `%t` = the math function                          |
-| enums          | `%s`/`%n` = the enum values                       |
-| regex          | `%r` = the regular expression                     |
-| range          | `%n` = the numeric range                          |
-| unique         |                                                   |
-| limit          | `%n` = the count limit                            |
-| requires       | `%p` = the requirements                           |
-| required       |                                                   |
-| default        | `%b`/`%s`/`%n`/`%s`/`%n`/`%v` = the default value |
-| deprecated     | `%t` = the deprecation reason                     |
-| link           | `%u` = the hyperlink                              |
-| envVar         | `%o` = the variable name                          |
-| requiredIf     | `%p` = the requirements                           |
-| clusterLetters | `%s` = the cluster letters                        |
+| Error          | Specifiers                              |
+| -------------- | --------------------------------------- |
+| synopsis       | `%t` = the option synopsis              |
+| negation       | `%o` = the negation names               |
+| separator      | `%s`/`%r` = the parameter separator     |
+| variadic       |                                         |
+| positional     | `%o` = the positional marker            |
+| append         |                                         |
+| trim           |                                         |
+| case           |                                         |
+| conv           | `%t` = the math function                |
+| enums          | `%s`/`%n` = the enum values             |
+| regex          | `%r` = the regular expression           |
+| range          | `%n` = the numeric range                |
+| unique         |                                         |
+| limit          | `%n` = the count limit                  |
+| requires       | `%p` = the requirements                 |
+| required       |                                         |
+| default        | `%b`/`%s`/`%n`/`%v` = the default value |
+| deprecated     | `%t` = the deprecation reason           |
+| link           | `%u` = the hyperlink                    |
+| envVar         | `%o` = the variable name                |
+| requiredIf     | `%p` = the requirements                 |
+| clusterLetters | `%s` = the cluster letters              |
 
 ## Help styles
 

--- a/packages/docs/pages/docs/library/options.mdx
+++ b/packages/docs/pages/docs/library/options.mdx
@@ -24,9 +24,9 @@ There is a total of ten option types, as summarized in the table below:
 | [flag]      | niladic                                 | `boolean{:ts}`     |                    |                     |
 | [boolean]   | positional, monadic                     | `boolean{:ts}`     |                    |                     |
 | [string]    | positional, monadic                     | `string{:ts}`      | trim, case         | enums, regex        |
-| [number]    | positional, monadic                     | `number{:ts}`      | round              | enums, range        |
+| [number]    | positional, monadic                     | `number{:ts}`      | conv               | enums, range        |
 | [strings]   | positional, variadic, delimited, append | `string[]{:ts}`    | unique, trim, case | enums, regex, limit |
-| [numbers]   | positional, variadic, delimited, append | `number[]{:ts}`    | unique, round      | enums, range, limit |
+| [numbers]   | positional, variadic, delimited, append | `number[]{:ts}`    | unique, conv       | enums, range, limit |
 
 In the above table, _niladic_ means that the option expects zero parameters on the command-line;
 _monadic_, that the option accepts a single parameter; and _variadic_, multiple parameters (possibly
@@ -288,7 +288,6 @@ Notes about this callback:
 
 - it should return a value of the data type expected by the option (this should not be an array)
 - if asynchronous, and is called, then the resulting option value will be a promise
-- mutually exclusive with [parse delimited]
 
 #### Enumeration
 
@@ -330,12 +329,11 @@ be within. Any parameter that is _not_ within the given range (after normalizati
 error to be thrown. You may want to use `[-Infinity, Infinity]{:ts}` to disallow `NaN{:ts}`.
 Mutually exclusive with [enumeration].
 
-#### Rounding
+#### Math convertion
 
-The `round` attribute, if present, specifies the kind of rounding to apply to number parameters. Can
-be one of `'trunc'{:ts}` (round towards zero), `'floor'{:ts}` (round down), `'ceil'{:ts}` (round up)
-or `'round'{:ts}` (round to the nearest integer). This normalization is applied _before_ checking
-value constraints.
+The `conv` attribute, if present, specifies the kind of math convertion to apply to number
+parameters. Can be any of JavaScript's [Math] functions that accept a single number parameter. This
+normalization is applied _before_ checking value constraints.
 
 ### Array attributes
 
@@ -345,24 +343,7 @@ Array-valued option types share a set of attributes, as described below.
 
 The `separator` attribute, if present, specifies a delimiter by which to split parameter values. If
 specified, the option will accept a single parameter and not multiple parameters[^2]. It can be
-either a string or a regular expression. Mutually exclusive with [parse delimited].
-
-#### Parse delimited
-
-The `parseDelimited` attribute, if present, specifies a custom callback to parse the value of the
-option parameter. It accepts three parameters:
-
-- `values` - the values parsed up to the current iteration
-- `name` - the option name, as was specified on the command-line
-- `value` - the parameter string value
-
-Notes about this callback:
-
-- unlike [parse callback] that returns a single value, this callback should return
-  an array
-- if specified, the option will accept a single parameter and not multiple parameters[^2]
-- if asynchronous, and is called, then the resulting option value will be a promise
-- mutually exclusive with [separator] and [parse callback]
+either a string or a regular expression.
 
 #### Remove duplicates
 
@@ -680,10 +661,8 @@ The **numbers** option has these sets of attributes:
 [parameter name]: #parameter-name
 [example value]: #example-value
 [preferred name]: #names--preferred-name
-[parse delimited]: #parse-delimited
 [regular expression]: #regular-expression
 [numeric range]: #numeric-range
-[parse delimited]: #parse-delimited
 [parse callback]: #parse-callback
 [count limit]: #count-limit
 [remove duplicates]: #remove-duplicates
@@ -710,6 +689,7 @@ The **numbers** option has these sets of attributes:
 [`tryParse`]: parser#avoiding-trycatch
 [`shortStyle`]: parser#short-option-style
 [`parseAsync`]: parser#executing-callbacks
+[Math]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math
 [`import.meta.resolve`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/import.meta/resolve
 [_short-option_ style]: https://www.linuxtopia.org/online_books/linux_tool_guides/tar_user_guide/Short-Options.html
 

--- a/packages/docs/pages/docs/library/styles.mdx
+++ b/packages/docs/pages/docs/library/styles.mdx
@@ -33,50 +33,48 @@ In the next sections we present the various styling attributes available.
 The `tf` enumeration declares text type faces that can be combined together. Here is the full list:
 
 - `clear` - reset or normal (resets any other preceding SGR attribute)
-- `bold` - bold or increased intensity
-- `faint` - faint, decreased intensity, or dim
-- `italic` - italic
-- `underlined` - underlined
-- `slowlyBlinking` - slowly blinking
-- `rapidlyBlinking` - rapidly blinking
-- `inverse` - reverse video or inverse (flips foreground and background color)
-- `invisible` - invisible, concealed or hidden
-- `crossedOut` - crossed-out or strikethrough
-- `primaryFont` - primary font
-- `alternative1` - alternative font 1
-- `alternative2` - alternative font 2
-- `alternative3` - alternative font 3
-- `alternative4` - alternative font 4
-- `alternative5` - alternative font 5
-- `alternative6` - alternative font 6
-- `alternative7` - alternative font 7
-- `alternative8` - alternative font 8
-- `alternative9` - alternative font 9
-- `fraktur` - black-letter font
-- `doublyUnderlined` - doubly underlined
-- `notBoldOrFaint` - normal intensity (neither bold nor faint)
-- `notItalicNorFraktur` - regular face (neither italic nor black-letter)
-- `notUnderlined` - not underlined
-- `notBlinking` - steady (not blinking)
-- `proportionalSpacing` - proportional spacing
-- `notInverse` - positive (not inverse)
-- `notInvisible` - visible (reveal, or not hidden)
-- `notCrossedOut` - not crossed out (no strikethrough)
-- `notProportionalSpacing` - disable proportional spacing
-- `framed` - framed
-- `encircled` - encircled
-- `overlined` - overlined
-- `notFramedOrEncircled` - neither framed nor encircled
-- `notOverlined` - not overlined
-- `ideogramUnderline` - ideogram underline or right side line
-- `ideogramDoubleUnderline` - ideogram double underline, or double line on the right side
-- `ideogramOverline` - ideogram overline or left side line
-- `ideogramDoubleOverline` - ideogram double overline, or double line on the left side
-- `ideogramStressMarking` - ideogram stress marking
-- `noIdeogram` - no ideogram attributes
-- `superscript` - superscript
-- `subscript` - subscript.
-- `notSuperscriptOrSubscript` - neither superscript nor subscript.
+- enable attributes:
+  - `bold` - bold or increased intensity
+  - `faint` - faint, decreased intensity, or dim
+  - `italic` - italic
+  - `underlined` - underlined
+  - `slowlyBlinking` - slowly blinking
+  - `rapidlyBlinking` - rapidly blinking
+  - `inverse` - reverse video or inverse (flips foreground and background color)
+  - `invisible` - invisible, concealed or hidden
+  - `crossedOut` - crossed-out or strikethrough
+  - `doublyUnderlined` - doubly underlined
+  - `proportionalSpacing` - proportional spacing
+- change font:
+  - `primaryFont` - primary font
+  - `alternative[1-9]` - alternative font 1 through 9
+  - `fraktur` - black-letter font
+- disable attributes:
+  - `notBoldOrFaint` - normal intensity (neither bold nor faint)
+  - `notItalicNorFraktur` - regular face (neither italic nor black-letter)
+  - `notUnderlined` - not underlined
+  - `notBlinking` - steady (not blinking)
+  - `notInverse` - positive (not inverse)
+  - `notInvisible` - visible (reveal, or not hidden)
+  - `notCrossedOut` - not crossed out (no strikethrough)
+  - `notProportionalSpacing` - disable proportional spacing
+- framing:
+  - `framed` - framed
+  - `encircled` - encircled
+  - `overlined` - overlined
+  - `notFramedOrEncircled` - neither framed nor encircled
+  - `notOverlined` - not overlined
+- ideogram attributes:
+  - `ideogramUnderline` - ideogram underline or right side line
+  - `ideogramDoubleUnderline` - ideogram double underline, or double line on the right side
+  - `ideogramOverline` - ideogram overline or left side line
+  - `ideogramDoubleOverline` - ideogram double overline, or double line on the left side
+  - `ideogramStressMarking` - ideogram stress marking
+  - `noIdeogram` - no ideogram attributes
+- superscript or subscript:
+  - `superscript` - superscript
+  - `subscript` - subscript.
+  - `notSuperscriptOrSubscript` - neither superscript nor subscript
 
 ### Predefined text colors
 
@@ -102,8 +100,6 @@ The `fg` and `bg` enumerations declare predefined foreground and background colo
   - `brightCyan` - bright cyan
   - `brightWhite` - bright white
 
-The `ul` enumeration has a single value of `default` for the default underline color.
-
 ### Extended text colors
 
 In addition to predefined colors, there are three utility functions to get custom 8-bit colors:
@@ -111,6 +107,17 @@ In addition to predefined colors, there are three utility functions to get custo
 - `fg8` - creates a foreground color from an 8-bit decimal value
 - `bg8` - creates a background color from an 8-bit decimal value
 - `ul8` - creates an underline color from an 8-bit decimal value
+
+### Underline styles
+
+The `ul` constant holds the styles of underlined text:
+
+- `none` - no underline
+- `single` - single underline
+- `double` - double underline
+- `curly` - curly underline
+- `dotted` - dotted underline
+- `dashed` - dashed underline
 
 ## Terminal strings
 
@@ -129,14 +136,30 @@ expressions. The following features are supported in text splitting.
 
 #### Format specifiers
 
-Format specifiers can be extracted from the text and processed by a formatting callback. This is
-used in different places in the library:
+Format specifiers, prefixed with a percent sign `%`, can be extracted from the text and processed by
+a formatting callback. This is used in different places in the library:
 
 - by the parser to produce error messages based on configured [error phrases]
 - by the formatter to assemble help items from configured [help phrases]
 - by the formatter to create group headings from configured [heading phrases]
 
 This particular feature is only available in _phrases_, not in text attributes of option definitions.
+The specifiers get replaced with a value (or values, in case of arrays). The available ones are:
+
+- `b` - a boolean value
+- `s` - a string value
+- `n` - a number value
+- `r` - a regular expression
+- `o` - an option name
+- `v` - a generic value enclosed in angle brackets (like the [parameter column])
+- `u` - a URL hyperlink
+- `t` - general text
+- `p` - a previously formatted string
+
+If a phrase supports values, the specifier can be used to indicate where in the phrase to place the
+value. If an item has multiple alternatives depending on the context, different texts can separated
+with `'|'{:ts}` and grouped in parentheses. Specifiers may also end with a single digit that
+represents a predefined value in an error message or help item.
 
 #### Inline styles
 
@@ -146,6 +169,12 @@ formatter splits into words before adding to the option description.
 When splitting text, the terminal string instance will try its best to preserve styles. However,
 if you find some corner case that is not currently covered by the unit tests, please submit a [bug
 report].
+
+<Callout type="warning">
+  Phrases can contain inline styles, but not in the same word as a format specifier. Otherwise, they
+  will mess up the text wrapping. For example, the following phrase is not valid:
+  ``` `Requires ${style(tf.bold)}%v`{:ts} ```. You should insert a space in between.
+</Callout>
 
 #### Paragraphs and lists
 
@@ -278,5 +307,6 @@ with `console.log` or equivalent.
 [help section texts]: formatter#help-sections
 [description column]: formatter#description-column
 [synopsis and deprecation reason]: options#synopsis--deprecated
+[parameter column]: formatter#parameter-column
 [bug report]: https://github.com/trulysimple/tsargp/issues/new?labels=bug
 [SGR]: https://www.wikiwand.com/en/ANSI_escape_code#SGR_(Select_Graphic_Rendition)_parameters

--- a/packages/docs/pages/docs/library/styles.mdx
+++ b/packages/docs/pages/docs/library/styles.mdx
@@ -157,9 +157,9 @@ The specifiers get replaced with a value (or values, in case of arrays). The ava
 - `p` - a previously formatted string
 
 If a phrase supports values, the specifier can be used to indicate where in the phrase to place the
-value. If an item has multiple alternatives depending on the context, different texts can separated
-with `'|'{:ts}` and grouped in parentheses. Specifiers may also end with a single digit that
-represents a predefined value in an error message or help item.
+value. If a phrase has multiple alternatives depending on the context, different texts may be
+specified separated with `'|'{:ts}` and grouped in parentheses. Specifiers may also end with a
+single digit that represents a predefined value in an error message or help item.
 
 #### Inline styles
 

--- a/packages/docs/pages/docs/library/validator.mdx
+++ b/packages/docs/pages/docs/library/validator.mdx
@@ -49,6 +49,8 @@ Option names are subject to the restrictions listed below:
   names] and the [positional marker] are included.
 </Callout>
 
+#### Naming inconsistencies
+
 In addition to the above, the validator may generate warnings if it detects naming inconsistencies,
 such as:
 
@@ -74,16 +76,19 @@ Cluster letters are subject to the restrictions listed below:
 - **Invalid cluster letter** -
   A cluster letter must not contain whitespace. Any other Unicode character is allowed.
 
-### Enums validation
+### Constraints validation
 
-Enumerated values are subject to the restrictions listed below:
+Constraint definitions are subject to the restrictions listed below:
 
 - **Zero enum values** -
-  There cannot be an option with zero enumerated values. The enumeration array should have
-  _non-zero_ length.
+  In number-valued and string-valued options, if the [enums] attribute is present, it must _not_ be
+  empty. It should have non-zero length.
 - **Duplicate enum value** -
-  There cannot be an option with duplicate enumerated values. The enumeration array should _not_
+  In number-valued and string-valued options, if the [enums] attribute is present, it must _not_
   contain duplicate elements.
+- **Invalid numeric range** -
+  In a number-valued option, if the [range] attribute is present, then its minimum value should be
+  strictly less than the maximum.
 
 ### Value validation
 
@@ -118,7 +123,8 @@ the restrictions listed below:
 - **Unknown required option** -
   An option must not declare a requirement that references an _unknown_ option.
 - **Invalid required option** -
-  An option must not declare a requirement that references a _non-valued_ option.
+  An option must not declare a requirement that references either a non-valued option (help and
+  version) or an option with unknown values (function and command) in a requirement.
 - **Incompatible required value** -
   Since a requirement may be an object with values of any kind, the data type of these values must
   be validated at run-time. Thus, an option must not declare a requirement that references a valued
@@ -164,7 +170,7 @@ optional properties:
 - `number` - the style of number values (defaults to `fg.yellow`)
 - `regex` - the style of regular expressions (defaults to `fg.red`)
 - `option` - the style of option names (defaults to `fg.brightMagenta`)
-- `param` - the style of option parameters (defaults to `fg.brightBlack`)
+- `value` - the style of generic (or unknown) values (defaults to `fg.brightBlack`)
 - `url` - the style of URLs (defaults to `fg.brightBlack`)
 - `text` - The style of general text (defaults to `tf.clear`)
 
@@ -178,14 +184,10 @@ optional properties:
 The `ErrorItem` enumeration lists the kinds of error messages that may be raised by the library:
 
 - `parseError` -
-  raised by the parser when an option parameter fails to be parsed
-- `parseErrorWithSimilar` -
-  raised by the parser when an option parameter fails to be parsed, and there are option name
+  raised by the parser when an option parameter fails to be parsed, with possible option name
   suggestions
 - `unknownOption` -
-  raised by the parser when an option name is not found
-- `unknownOptionWithSimilar` -
-  raised by the parser when an option name is not found, and there are option name suggestions
+  raised by the parser when an option name is not found, with possible option name suggestions
 - `unsatisfiedRequirement` -
   raised by the parser when an option requirement is not satisfied
 - `missingRequiredOption` -
@@ -210,34 +212,27 @@ The `ErrorItem` enumeration lists the kinds of error messages that may be raised
 - `unknownRequiredOption` -
   raised by the validator when an option references an unknown option in a requirement
 - `invalidRequiredOption` -
-  raised by the validator when an option references a non-valued option in a requirement
+  raised by the validator when an option references either a non-valued option or an option with
+  unknown values in a requirement
 - `emptyEnumsDefinition` -
   raised by the validator when an option has a zero-length enumeration array
 - `duplicateOptionName` -
   raised by the validator when an option has a duplicate name
 - `duplicatePositionalOption` -
   raised by the validator when there are two or more positional options
-- `duplicateStringEnum` -
-  raised by the validator when a string enumeration constraint has duplicate values
-- `duplicateNumberEnum` -
-  raised by the validator when a number enumeration constraint has duplicate values
+- `duplicateEnumValue` -
+  raised by the validator when a string or number enumeration constraint has duplicate values
 - `incompatibleRequiredValue` -
   raised by the validator when an option is required with a value of incompatible data type
-- `stringEnumsConstraintViolation` -
-  raised by both the parser and validator when a value fails to satisfy a string option's
+- `enumsConstraintViolation` -
+  raised by both the parser and validator when a value fails to satisfy either a string or a number
   enumeration constraint
 - `regexConstraintViolation` -
-  raised by both the parser and validator when a value fails to satisfy a string option's regex
-  constraint
-- `numberEnumsConstraintViolation` -
-  raised by both the parser and validator when a value fails to satisfy a number option's
-  enumeration constraint
+  raised by both the parser and validator when a value fails to satisfy a string regex constraint
 - `rangeConstraintViolation` -
-  raised by both the parser and validator when a value fails to satisfy a number option's range
-  constraint
+  raised by both the parser and validator when a value fails to satisfy a number range constraint
 - `limitConstraintViolation` -
-  raised by both the parser and validator when a value fails to satisfy an array option's limit
-  constraint
+  raised by both the parser and validator when a value fails to satisfy an array limit constraint
 - `deprecatedOption` -
   warning produced by the parser when a deprecated option is specified on the command-line
 - `unsatisfiedCondRequirement` -
@@ -254,101 +249,85 @@ The `ErrorItem` enumeration lists the kinds of error messages that may be raised
 - `mixedNamingConvention` -
   warning produced by the validator when a name slot contains names with different naming
   conventions
+- `invalidNumericRange` -
+  raised by the validator when an option has an invalid numeric range
 
 ### Error phrases
 
 The `phrases` property specifies the phrases to be used for each kind of error message:
 
-- `parseError` - `'Did you mean to specify an option name instead of %o?'{:ts}`
-- `parseErrorWithSimilar` - `'Did you mean to specify an option name instead of %o1? Similar names are %o2.'{:ts}`
-- `unknownOption` - `'Unknown option %o.'{:ts}`
-- `unknownOptionWithSimilar` - `'Unknown option %o1. Similar names are %o2.'{:ts}`
-- `unsatisfiedRequirement` - `'Option %o requires %t.'{:ts}`
+- `parseError` - `'Did you mean to specify an option name instead of (%o|%o1)?(| Similar names are [%o2].)'{:ts}`
+- `unknownOption` - `'Unknown option (%o|%o1).(| Similar names are [%o2].)'{:ts}`
+- `unsatisfiedRequirement` - `'Option %o requires %p.'{:ts}`
 - `missingRequiredOption` - `'Option %o is required.'{:ts}`
 - `missingParameter` - `'Missing parameter to %o.'{:ts}`
 - `missingPackageJson` - `'Could not find a "package.json" file.'{:ts}`
-- `disallowedInlineValue` - `'Option %o does not accept inline values.'{:ts}`
+- `disallowedInlineValue` - `'(Option|Positional marker) %o does not accept inline values.'{:ts}`
 - `emptyPositionalMarker` - `'Option %o contains empty positional marker.'{:ts}`
 - `unnamedOption` - `'Non-positional option %o has no name.'{:ts}`
 - `invalidOptionName` - `'Option %o has invalid name %s.'{:ts}`
 - `emptyVersionDefinition` - `'Option %o contains empty version.'{:ts}`
 - `invalidSelfRequirement` - `'Option %o requires itself.'{:ts}`
 - `unknownRequiredOption` - `'Unknown option %o in requirement.'{:ts}`
-- `invalidRequiredOption` - `'Non-valued option %o in requirement.'{:ts}`
+- `invalidRequiredOption` - `'Invalid option %o in requirement.'{:ts}`
 - `emptyEnumsDefinition` - `'Option %o has zero enum values.'{:ts}`
 - `duplicateOptionName` - `'Option %o has duplicate name %s.'{:ts}`
 - `duplicatePositionalOption` - `'Duplicate positional option %o1: previous was %o2.'{:ts}`
-- `duplicateStringEnum` - `'Option %o has duplicate enum %s.'{:ts}`
-- `duplicateNumberEnum` - `'Option %o has duplicate enum %n.'{:ts}`
-- `incompatibleRequiredValue` - `'Option %o has incompatible value %p. Should be of type %s.'{:ts}`
-- `stringEnumsConstraintViolation` - `'Invalid parameter to %o: %s1. Possible values are %s2.'{:ts}`
+- `duplicateEnumValue` - `'Option %o has duplicate enum (%s|%n).'{:ts}`
+- `incompatibleRequiredValue` - `'Option %o has incompatible value %v. Should be of type %s.'{:ts}`
+- `enumsConstraintViolation` - `'Invalid parameter to %o: (%s1|%n1). Possible values are {(%s2|%n2)}.'{:ts}`
 - `regexConstraintViolation` - `'Invalid parameter to %o: %s. Value must match the regex %r.'{:ts}`
-- `numberEnumsConstraintViolation` - `'Invalid parameter to %o: %n1. Possible values are %n2.'{:ts}`
-- `rangeConstraintViolation` - `'Invalid parameter to %o: %n1. Value must be in the range %n2.'{:ts}`
+- `rangeConstraintViolation` - `'Invalid parameter to %o: %n1. Value must be in the range [%n2].'{:ts}`
 - `limitConstraintViolation` - `'Option %o has too many values (%n1). Should have at most %n2.'{:ts}`
 - `deprecatedOption` - `'Option %o is deprecated and may be removed in future releases.'{:ts}`
-- `unsatisfiedCondRequirement` - `'Option %o is required if %t.'{:ts}`
+- `unsatisfiedCondRequirement` - `'Option %o is required if %p.'{:ts}`
 - `duplicateClusterLetter` - `'Option %o has duplicate cluster letter %s.'{:ts}`
 - `invalidClusterOption` - `'Option letter %o must be the last in a cluster.'{:ts}`
 - `invalidClusterLetter` - `'Option %o has invalid cluster letter %s.'{:ts}`
 - `tooSimilarOptionNames` - `'%o: Option name %s1 has too similar names %s2.'{:ts}`
 - `mixedNamingConvention` - `'%o: Name slot %n has mixed naming conventions %s.'{:ts}`
+- `invalidNumericRange` - `'Option %o has invalid numeric range [%n].'{:ts}`
 
 These phrases will be formatted according to [text formatting] rules.
 
-### Error specifiers
+#### Format specifiers
 
-Error phrases may have specifiers that are replaced with a value:
+Error phrases may have [format specifiers] prefixed with a percent sign `%`, which get replaced with
+a value. The following table lists the available specifiers for each kind of error message, along
+with a description of the corresponding value:
 
-- `b` - a boolean value
-- `s` - a string value (or values)
-- `n` - a number value (or values)
-- `r` - a regular expression
-- `o` - an option name
-- `p` - a generic value enclosed in angle brackets (like the [parameter column])
-- `u` - a URL
-- `t` - a previously formatted string that is enhanced with additional details
-
-Specifiers may end with a single digit that represents a specific value in the error message. The
-following table lists the available specifiers for each kind of error message, along with a
-description of the corresponding value.
-
-| Error                          | Specifiers                                                                          |
-| ------------------------------ | ----------------------------------------------------------------------------------- |
-| parseError                     | `%o` = the unknown option name                                                      |
-| parseErrorWithSimilar          | `%o1`= the unknown option name; `%o2` = similar option names                        |
-| unknownOption                  | `%o` = the unknown option name                                                      |
-| unknownOptionWithSimilar       | `%o1` = the unknown option name; `%o2` = similar option names                       |
-| unsatisfiedRequirement         | `%o` = the specified option name; `%t` = the option's requirements                  |
-| missingRequiredOption          | `%o` = the option's preferred name                                                  |
-| missingParameter               | `%o` = the specified option name                                                    |
-| missingPackageJson             |                                                                                     |
-| disallowedInlineValue          | `%o` = the specified option name or positional marker                               |
-| emptyPositionalMarker          | `%o` = the option's key                                                             |
-| unnamedOption                  | `%o` = the option's key                                                             |
-| invalidOptionName              | `%o` = the option's key; `%s` = the invalid name                                    |
-| emptyVersionDefinition         | `%o` = the option's key                                                             |
-| invalidSelfRequirement         | `%o` = the option's key                                                             |
-| unknownRequiredOption          | `%o` = the required option's key                                                    |
-| invalidRequiredOption          | `%o` = the required option's key                                                    |
-| emptyEnumsDefinition           | `%o` = the option's key                                                             |
-| duplicateOptionName            | `%o` = the option's key; `%s` = the duplicate name                                  |
-| duplicatePositionalOption      | `%o1` = the duplicate option's key; `%o2` = the previous option's key               |
-| duplicateStringEnum            | `%o` = the option's key; `%s` = the duplicate enum value                            |
-| duplicateNumberEnum            | `%o` = the option's key; `%n` = the duplicate enum value                            |
-| incompatibleRequiredValue      | `%o` = the option's key; `%p` = the incompatible value; `%s` = the expected type    |
-| stringEnumsConstraintViolation | `%o` = the option's key or name; `%s1` = the specified value; `%s2` = the enums     |
-| regexConstraintViolation       | `%o` = the option's key or name; `%s` = the specified value; `%r` = the regex       |
-| numberEnumsConstraintViolation | `%o` = the option's key or name; `%n1` = the specified value; `%n2` = the enums     |
-| rangeConstraintViolation       | `%o` = the option's key or name; `%n1` = the specified value; `%n2` = the range     |
-| limitConstraintViolation       | `%o` = the option's key or name; `%n1` = the value count; `%n2` = the count limit   |
-| deprecatedOption               | `%o` = the specified option name                                                    |
-| unsatisfiedCondRequirement     | `%o` = the specified option name; `%t` = the option's requirements                  |
-| duplicateClusterLetter         | `%o` = the option's key; `%s` = the duplicate letter                                |
-| invalidClusterOption           | `%o` = the specified cluster letter                                                 |
-| invalidClusterLetter           | `%o` = the option's key; `%s` = the invalid letter                                  |
-| tooSimilarOptionNames          | `%o` = the command prefix[^1]; `%s1` = the option name; `%s2` = the similar names   |
-| mixedNamingConvention          | `%o` = the command prefix[^1]; `%n` = the slot index; `%s` = the naming conventions |
+| Error                      | Specifiers                                                                                  |
+| -------------------------- | ------------------------------------------------------------------------------------------- |
+| parseError                 | `%o`/`%o1` = the unknown option name; `%o2` = similar option names                          |
+| unknownOption              | `%o`/`%o1` = the unknown option name; `%o2` = similar option names                          |
+| unsatisfiedRequirement     | `%o` = the specified option name; `%p` = the option's requirements                          |
+| missingRequiredOption      | `%o` = the option's preferred name                                                          |
+| missingParameter           | `%o` = the specified option name                                                            |
+| missingPackageJson         |                                                                                             |
+| disallowedInlineValue      | `%o` = the specified option name or positional marker                                       |
+| emptyPositionalMarker      | `%o` = the option's key                                                                     |
+| unnamedOption              | `%o` = the option's key                                                                     |
+| invalidOptionName          | `%o` = the option's key; `%s` = the invalid name                                            |
+| emptyVersionDefinition     | `%o` = the option's key                                                                     |
+| invalidSelfRequirement     | `%o` = the option's key                                                                     |
+| unknownRequiredOption      | `%o` = the required option's key                                                            |
+| invalidRequiredOption      | `%o` = the required option's key                                                            |
+| emptyEnumsDefinition       | `%o` = the option's key                                                                     |
+| duplicateOptionName        | `%o` = the option's key; `%s` = the duplicate name                                          |
+| duplicatePositionalOption  | `%o1` = the duplicate option's key; `%o2` = the previous option's key                       |
+| duplicateEnumValue         | `%o` = the option's key; `%s` or `%n` = the duplicate enum value                            |
+| incompatibleRequiredValue  | `%o` = the option's key; `%v` = the incompatible value; `%s` = the expected type            |
+| enumsConstraintViolation   | `%o` = the option's key or name; `%s1`/`%n1` = the specified value; `%s2`/`%n2` = the enums |
+| regexConstraintViolation   | `%o` = the option's key or name; `%s` = the specified value; `%r` = the regex               |
+| rangeConstraintViolation   | `%o` = the option's key or name; `%n1` = the specified value; `%n2` = the range             |
+| limitConstraintViolation   | `%o` = the option's key or name; `%n1` = the value count; `%n2` = the count limit           |
+| deprecatedOption           | `%o` = the specified option name                                                            |
+| unsatisfiedCondRequirement | `%o` = the specified option name; `%p` = the option's requirements                          |
+| duplicateClusterLetter     | `%o` = the option's key; `%s` = the duplicate letter                                        |
+| invalidClusterOption       | `%o` = the specified cluster letter                                                         |
+| invalidClusterLetter       | `%o` = the option's key; `%s` = the invalid letter                                          |
+| tooSimilarOptionNames      | `%o` = the command prefix[^1]; `%s1` = the option name; `%s2` = the similar names           |
+| mixedNamingConvention      | `%o` = the command prefix[^1]; `%n` = the slot index; `%s` = the naming conventions         |
 
 [value validation]: #value-validation
 [negation names]: options#negation-names
@@ -361,10 +340,10 @@ description of the corresponding value.
 [requirement callbacks]: options#forward-requirements
 [positional]: options#positional--marker
 [text formatting]: styles#text-splitting
-[parameter column]: formatter#parameter-column
 [name suggestions]: parser#name-suggestions
 [name slot]: formatter#names-column
 [nested command]: options#command-option
+[format specifiers]: styles#format-specifiers
 
 [^1]:
     the command prefix is a series of option keys interspersed with periods, denoting the current

--- a/packages/docs/pages/docs/library/validator.mdx
+++ b/packages/docs/pages/docs/library/validator.mdx
@@ -285,7 +285,7 @@ The `phrases` property specifies the phrases to be used for each kind of error m
 - `invalidClusterOption` - `'Option letter %o must be the last in a cluster.'{:ts}`
 - `invalidClusterLetter` - `'Option %o has invalid cluster letter %s.'{:ts}`
 - `tooSimilarOptionNames` - `'%o: Option name %s1 has too similar names %s2.'{:ts}`
-- `mixedNamingConvention` - `'%o: Name slot %n has mixed naming conventions %s.'{:ts}`
+- `mixedNamingConvention` - `'%o: Name slot %n has mixed naming conventions [%s].'{:ts}`
 - `invalidNumericRange` - `'Option %o has invalid numeric range [%n].'{:ts}`
 
 These phrases will be formatted according to [text formatting] rules.
@@ -315,7 +315,7 @@ with a description of the corresponding value:
 | emptyEnumsDefinition       | `%o` = the option's key                                                                     |
 | duplicateOptionName        | `%o` = the option's key; `%s` = the duplicate name                                          |
 | duplicatePositionalOption  | `%o1` = the duplicate option's key; `%o2` = the previous option's key                       |
-| duplicateEnumValue         | `%o` = the option's key; `%s` or `%n` = the duplicate enum value                            |
+| duplicateEnumValue         | `%o` = the option's key; `%s`/`%n` = the duplicate enum value                               |
 | incompatibleRequiredValue  | `%o` = the option's key; `%v` = the incompatible value; `%s` = the expected type            |
 | enumsConstraintViolation   | `%o` = the option's key or name; `%s1`/`%n1` = the specified value; `%s2`/`%n2` = the enums |
 | regexConstraintViolation   | `%o` = the option's key or name; `%s` = the specified value; `%r` = the regex               |

--- a/packages/docs/typedoc.json
+++ b/packages/docs/typedoc.json
@@ -7,5 +7,20 @@
   "githubPages": false,
   "excludeExternals": true,
   "treatWarningsAsErrors": true,
-  "intentionallyNotExported": ["OptionDataType", "HelpEntry", "Positional", "ParamValue"]
+  "intentionallyNotExported": [
+    "HelpEntry",
+    "OptionInfo",
+    "OpaqueOption",
+    "OpaqueOptionValues",
+    "OptionDataType",
+    "WithRequired",
+    "WithDefault",
+    "WithExample",
+    "WithParamName",
+    "WithEnums",
+    "WithRegex",
+    "WithRange",
+    "WithVerInfo",
+    "WithResolve"
+  ]
 }

--- a/packages/tsargp/examples/demo.options.ts
+++ b/packages/tsargp/examples/demo.options.ts
@@ -217,7 +217,7 @@ Report a bug: ${style(tf.faint)}https://github.com/trulysimple/tsargp/issues`,
     group: 'Number options',
     range: [0, Infinity],
     default: [1, 2],
-    round: 'round',
+    conv: 'round',
   },
   /**
    * A strings option that has an enumeration constraint.

--- a/packages/tsargp/lib/enums.ts
+++ b/packages/tsargp/lib/enums.ts
@@ -17,22 +17,14 @@ export {
  */
 export const enum ErrorItem {
   /**
-   * Raised by the parser when an option parameter fails to be parsed.
+   * Raised by the parser when an option parameter fails to be parsed, with possibe option name
+   * suggestions.
    */
   parseError,
   /**
-   * Raised by the parser when an option parameter fails to be parsed, and there are option name
-   * suggestions.
-   */
-  parseErrorWithSimilar,
-  /**
-   * Raised by the parser when an option name is not found.
+   * Raised by the parser when an option name is not found, with possible option name suggestions.
    */
   unknownOption,
-  /**
-   * Raised by the parser when an option name is not found, and there are option name suggestions.
-   */
-  unknownOptionWithSimilar,
   /**
    * Raised by the parser when an option requirement is not satisfied.
    */
@@ -161,6 +153,10 @@ export const enum ErrorItem {
    * conventions.
    */
   mixedNamingConvention,
+  /**
+   * Raised by the validator when an option has an invalid numeric range.
+   */
+  invalidNumericRange,
 }
 
 /**
@@ -200,9 +196,9 @@ export const enum HelpItem {
    */
   case,
   /**
-   * The kind of rounding applied to number parameters, if enabled.
+   * The kind of math conversion applied to number parameters, if enabled.
    */
-  round,
+  conv,
   /**
    * The enumerated values that the option accepts as parameters, if any.
    */

--- a/packages/tsargp/lib/enums.ts
+++ b/packages/tsargp/lib/enums.ts
@@ -65,7 +65,8 @@ export const enum ErrorItem {
    */
   unknownRequiredOption,
   /**
-   * Raised by the validator when an option references a non-valued option in a requirement.
+   * Raised by the validator when an option references either a non-valued option or an option with
+   * unknown values in a requirement.
    */
   invalidRequiredOption,
   /**
@@ -81,40 +82,28 @@ export const enum ErrorItem {
    */
   duplicatePositionalOption,
   /**
-   * Raised by the validator when a string enumeration constraint has duplicate values.
+   * Raised by the validator when a string or number enumeration constraint has duplicate values.
    */
-  duplicateStringEnum,
-  /**
-   * Raised by the validator when a number enumeration constraint has duplicate values.
-   */
-  duplicateNumberEnum,
+  duplicateEnumValue,
   /**
    * Raised by the validator when an option is required with a value of incompatible data type.
    */
   incompatibleRequiredValue,
   /**
-   * Raised by both the parser and validator when a value fails to satisfy a string option's
-   * enumeration constraint.
+   * Raised by both the parser and validator when a value fails to satisfy either a string or a
+   * number enumeration constraint.
    */
-  stringEnumsConstraintViolation,
+  enumsConstraintViolation,
   /**
-   * Raised by both the parser and validator when a value fails to satisfy a string option's regex
-   * constraint.
+   * Raised by both the parser and validator when a value fails to satisfy a string regex constraint.
    */
   regexConstraintViolation,
   /**
-   * Raised by both the parser and validator when a value fails to satisfy a number option's
-   * enumeration constraint.
-   */
-  numberEnumsConstraintViolation,
-  /**
-   * Raised by both the parser and validator when a value fails to satisfy a number option's range
-   * constraint.
+   * Raised by both the parser and validator when a value fails to satisfy a number range constraint.
    */
   rangeConstraintViolation,
   /**
-   * Raised by both the parser and validator when a value fails to satisfy an array option's limit
-   * constraint.
+   * Raised by both the parser and validator when a value fails to satisfy an array limit constraint.
    */
   limitConstraintViolation,
   /**

--- a/packages/tsargp/lib/enums.ts
+++ b/packages/tsargp/lib/enums.ts
@@ -1,13 +1,7 @@
 //--------------------------------------------------------------------------------------------------
 // Exports - NOTE: some enumerations are abbreviated for ease of use in client code.
 //--------------------------------------------------------------------------------------------------
-export {
-  ControlSequence as cs,
-  TypeFace as tf,
-  Foreground as fg,
-  Background as bg,
-  Underline as ul,
-};
+export { ControlSequence as cs, TypeFace as tf, Foreground as fg, Background as bg };
 
 //--------------------------------------------------------------------------------------------------
 // Constants - NOTE: please add new enumerators at the _end_ of the enumeration.
@@ -17,7 +11,7 @@ export {
  */
 export const enum ErrorItem {
   /**
-   * Raised by the parser when an option parameter fails to be parsed, with possibe option name
+   * Raised by the parser when an option parameter fails to be parsed, with possible option name
    * suggestions.
    */
   parseError,
@@ -635,11 +629,4 @@ const enum Background {
   brightMagenta,
   brightCyan,
   brightWhite,
-}
-
-/**
- * A predefined text underline color.
- */
-const enum Underline {
-  default = 59,
 }

--- a/packages/tsargp/lib/formatter.ts
+++ b/packages/tsargp/lib/formatter.ts
@@ -1,16 +1,23 @@
 //--------------------------------------------------------------------------------------------------
 // Imports
 //--------------------------------------------------------------------------------------------------
-import type { Option, Options, Requires, ValuedOption, RequiresVal, ParamOption } from './options';
-import type { Style } from './styles';
+import type { Option, InternalOptions, Requires, RequiresVal } from './options';
+import type { Style, FormatStyles, FormatConfig } from './styles';
 import type { Concrete } from './utils';
-import type { ConcreteStyles, FormatFunction, OptionValidator } from './validator';
+import type { OptionValidator } from './validator';
 
 import { tf, HelpItem } from './enums';
-import { RequiresAll, RequiresNot, RequiresOne, isArray, isVariadic, isNiladic } from './options';
-import { HelpMessage, TerminalString, style } from './styles';
-import { formatFunctions } from './validator';
-import { assert, splitPhrase } from './utils';
+import {
+  RequiresAll,
+  RequiresNot,
+  RequiresOne,
+  isNiladic,
+  isString,
+  isBoolean,
+  isNumber,
+  isVariadic,
+} from './options';
+import { HelpMessage, TerminalString, style, format } from './styles';
 
 //--------------------------------------------------------------------------------------------------
 // Types
@@ -55,9 +62,9 @@ export type WithAbsolute = {
 };
 
 /**
- * The help format configuration.
+ * The formatter configuration.
  */
-export type HelpConfig = {
+export type FormatterConfig = {
   /**
    * The settings for the names column.
    */
@@ -94,7 +101,7 @@ type ConcreteColumn = Concrete<WithColumn>;
 /**
  * A concrete version of the format configuration.
  */
-type ConcreteFormat = Concrete<HelpConfig>;
+type ConcreteFormat = Concrete<FormatterConfig>;
 
 /**
  * Precomputed texts used by the formatter.
@@ -237,7 +244,7 @@ const defaultConfig: ConcreteFormat = {
     HelpItem.append,
     HelpItem.trim,
     HelpItem.case,
-    HelpItem.round,
+    HelpItem.conv,
     HelpItem.enums,
     HelpItem.regex,
     HelpItem.range,
@@ -253,27 +260,27 @@ const defaultConfig: ConcreteFormat = {
     HelpItem.clusterLetters,
   ],
   phrases: {
-    [HelpItem.synopsis]: '%s',
-    [HelpItem.negation]: 'Can be negated with %s.',
-    [HelpItem.separator]: 'Values are delimited by %s.',
+    [HelpItem.synopsis]: '%t',
+    [HelpItem.negation]: 'Can be negated with %o.',
+    [HelpItem.separator]: 'Values are delimited by (%s|%r).',
     [HelpItem.variadic]: 'Accepts multiple parameters.',
-    [HelpItem.positional]: 'Accepts positional parameters(| that may be preceded by %s).',
+    [HelpItem.positional]: 'Accepts positional parameters(| that may be preceded by %o).',
     [HelpItem.append]: 'May be specified multiple times.',
     [HelpItem.trim]: 'Values will be trimmed.',
     [HelpItem.case]: 'Values will be converted to (lowercase|uppercase).',
-    [HelpItem.round]: 'Values will be rounded (towards zero|down|up|to the nearest integer).',
-    [HelpItem.enums]: 'Values must be one of %s.',
-    [HelpItem.regex]: 'Values must match the regex %s.',
-    [HelpItem.range]: 'Values must be in the range %s.',
+    [HelpItem.conv]: 'Values will be converted with Math.%t.',
+    [HelpItem.enums]: 'Values must be one of (%s|%n).',
+    [HelpItem.regex]: 'Values must match the regex %r.',
+    [HelpItem.range]: 'Values must be in the range %n.',
     [HelpItem.unique]: 'Duplicate values will be removed.',
-    [HelpItem.limit]: 'Value count is limited to %s.',
-    [HelpItem.requires]: 'Requires %s.',
+    [HelpItem.limit]: 'Value count is limited to %n.',
+    [HelpItem.requires]: 'Requires %p.',
     [HelpItem.required]: 'Always required.',
-    [HelpItem.default]: 'Defaults to %s.',
-    [HelpItem.deprecated]: 'Deprecated for %s.',
-    [HelpItem.link]: 'Refer to %s for details.',
-    [HelpItem.envVar]: 'Can be specified through the %s environment variable.',
-    [HelpItem.requiredIf]: 'Required if %s.',
+    [HelpItem.default]: 'Defaults to (%b|%s|%n|%v).',
+    [HelpItem.deprecated]: 'Deprecated for %t.',
+    [HelpItem.link]: 'Refer to %u for details.',
+    [HelpItem.envVar]: 'Can be specified through the %o environment variable.',
+    [HelpItem.requiredIf]: 'Required if %p.',
     [HelpItem.clusterLetters]: 'Can be clustered with %s.',
   },
 };
@@ -285,8 +292,8 @@ const defaultConfig: ConcreteFormat = {
  * Implements formatting of help messages for a set of option definitions.
  */
 export class HelpFormatter {
-  private readonly options: Options;
-  private readonly styles: ConcreteStyles;
+  private readonly options: InternalOptions;
+  private readonly styles: FormatStyles;
   private readonly groups = new Map<string, Array<HelpEntry>>();
   private readonly config: ConcreteFormat;
   private readonly nameWidths: Array<number> | number;
@@ -304,7 +311,7 @@ export class HelpFormatter {
     formatAppend,
     formatTrim,
     formatCase,
-    formatRound,
+    formatConv,
     formatEnums,
     formatRegex,
     formatRange,
@@ -326,7 +333,7 @@ export class HelpFormatter {
    * @param config The format configuration
    * @param filters The option filters
    */
-  constructor(validator: OptionValidator, config?: HelpConfig, filters?: Array<RegExp>) {
+  constructor(validator: OptionValidator, config?: FormatterConfig, filters?: Array<RegExp>) {
     /** @ignore */
     function exclude(option: Option) {
       return (
@@ -380,8 +387,8 @@ export class HelpFormatter {
     if (this.config.names.hidden || !option.names) {
       return [];
     }
-    const style = option.styles?.names ?? this.styles.option;
-    return formatNameSlots(this.config, option.names, this.nameWidths, style, this.styles.text);
+    this.styles.current = option.styles?.names;
+    return formatNameSlots(this.config, this.styles, option.names, this.nameWidths);
   }
 
   /**
@@ -393,11 +400,14 @@ export class HelpFormatter {
     if (this.config.param.hidden || isNiladic(option)) {
       return new TerminalString();
     }
-    const result = new TerminalString(0, this.config.param.breaks);
-    const len = formatParam(option, this.styles, this.styles.text, result);
+    this.styles.current = option.styles?.param;
+    const result = new TerminalString(0, this.config.param.breaks).addSequence(
+      this.styles.current ?? this.styles.text,
+    );
+    const len = formatParam(option, this.styles, result);
     this.paramWidth = Math.max(this.paramWidth, len);
     result.indent = len; // hack: save the length, since we will need it in `adjustEntries`
-    return result;
+    return result.addSequence(style(tf.clear));
   }
 
   /**
@@ -410,16 +420,16 @@ export class HelpFormatter {
     if (this.config.descr.hidden || !this.config.items.length) {
       return new TerminalString(0, 1);
     }
-    const descrStyle = option.styles?.descr ?? this.styles.text;
+    this.styles.current = option.styles?.descr;
     const result = new TerminalString(
       0,
       this.config.descr.breaks,
       this.config.descr.align === 'right',
-    ).addSequence(descrStyle);
+    ).addSequence(this.styles.current ?? this.styles.text);
     const count = result.count;
     for (const item of this.config.items) {
       const phrase = this.config.phrases[item];
-      this.format[item](option, phrase, this.styles, descrStyle, result);
+      this.format[item](option, phrase, this.styles, result);
     }
     if (result.count == count) {
       return new TerminalString(0, 1); // this string does not contain any word
@@ -432,21 +442,17 @@ export class HelpFormatter {
    * @param option The option definition
    * @param phrase The description item phrase
    * @param styles The set of styles
-   * @param style The default style
    * @param result The resulting string
    */
   private formatRequires(
     option: Option,
     phrase: string,
-    styles: ConcreteStyles,
-    style: Style,
+    styles: FormatStyles,
     result: TerminalString,
   ) {
-    if ('requires' in option && option.requires) {
+    if (option.requires) {
       const requires = option.requires;
-      result.splitText(phrase, () => {
-        formatRequirements(this.options, requires, styles, style, result);
-      });
+      result.splitText(phrase, () => formatRequirements(this.options, requires, styles, result));
     }
   }
 
@@ -455,21 +461,17 @@ export class HelpFormatter {
    * @param option The option definition
    * @param phrase The description item phrase
    * @param styles The set of styles
-   * @param style The default style
    * @param result The resulting string
    */
   private formatRequiredIf(
     option: Option,
     phrase: string,
-    styles: ConcreteStyles,
-    style: Style,
+    styles: FormatStyles,
     result: TerminalString,
   ) {
-    if ('requiredIf' in option && option.requiredIf) {
+    if (option.requiredIf) {
       const requiredIf = option.requiredIf;
-      result.splitText(phrase, () => {
-        formatRequirements(this.options, requiredIf, styles, style, result);
-      });
+      result.splitText(phrase, () => formatRequirements(this.options, requiredIf, styles, result));
     }
   }
 
@@ -530,7 +532,7 @@ export class HelpFormatter {
  * @param config The provided configuration
  * @returns The merged configuration
  */
-function mergeConfig(config: HelpConfig = {}): ConcreteFormat {
+function mergeConfig(config: FormatterConfig = {}): ConcreteFormat {
   return {
     names: { ...defaultConfig.names, ...config.names },
     param: { ...defaultConfig.param, ...config.param },
@@ -545,7 +547,7 @@ function mergeConfig(config: HelpConfig = {}): ConcreteFormat {
  * @param options The option definitions
  * @returns The name slot widths
  */
-function getNameWidths(options: Options): Array<number> {
+function getNameWidths(options: InternalOptions): Array<number> {
   const result = new Array<number>();
   for (const key in options) {
     const option = options[key];
@@ -563,7 +565,7 @@ function getNameWidths(options: Options): Array<number> {
  * @param options The option definitions
  * @returns The maximum width
  */
-function getMaxNamesWidth(options: Options): number {
+function getMaxNamesWidth(options: InternalOptions): number {
   let result = 0;
   for (const key in options) {
     const option = options[key];
@@ -614,18 +616,16 @@ function adjustEntries(
 /**
  * Formats a list of names to be printed on the terminal.
  * @param config The format configuration
+ * @param styles The set of styles
  * @param names The list of option names
  * @param nameWidths The name slot widths
- * @param namesStyle The style to apply
- * @param defStyle The default style
  * @returns The resulting strings
  */
 function formatNameSlots(
   config: ConcreteFormat,
+  styles: FormatStyles,
   names: ReadonlyArray<string | null>,
   nameWidths: Array<number> | number,
-  namesStyle: Style,
-  defStyle: Style,
 ): Array<TerminalString> {
   const slotted = typeof nameWidths !== 'number';
   const result = new Array<TerminalString>();
@@ -640,11 +640,11 @@ function formatNameSlots(
         len += 2;
       }
       if (!str || slotted) {
-        str = new TerminalString(indent, breaks);
+        str = new TerminalString(indent, breaks).addSequence(styles.current ?? styles.text);
         result.push(str);
         breaks = 0; // break only on the first name
       }
-      str.addAndRevert(namesStyle, name, defStyle);
+      format.o(name, styles, str);
       len += name.length;
     } else if (slotted) {
       str = undefined;
@@ -657,84 +657,6 @@ function formatNameSlots(
     str.indent += nameWidths - len;
   }
   return result;
-}
-
-/**
- * Formats a value from an option's property.
- * @param option The option definition
- * @param value The option value
- * @param result The resulting string
- * @param styles The set of styles
- * @param style The default style
- * @param inDesc True if in the description
- */
-function formatValue(
-  option: ValuedOption,
-  value: unknown,
-  result: TerminalString,
-  styles: ConcreteStyles,
-  style: Style,
-  inDesc: boolean,
-) {
-  switch (typeof value) {
-    case 'boolean':
-      formatFunctions.b(value, styles, style, result);
-      break;
-    case 'string':
-      formatFunctions.s(value, styles, style, result);
-      break;
-    case 'number':
-      formatFunctions.n(value, styles, style, result);
-      break;
-    default:
-      if (isArray(option) && Array.isArray(value)) {
-        const formatFn = option.type === 'strings' ? formatFunctions.s : formatFunctions.n;
-        if (inDesc) {
-          formatArray(value, style, result, styles, formatFn, ['[', ']'], ',');
-        } else if ('separator' in option && option.separator) {
-          const sep = option.separator;
-          const text = value.join(typeof sep === 'string' ? sep : sep.source);
-          formatFunctions.s(text, styles, style, result);
-        } else {
-          formatArray(value, style, result, styles, formatFn);
-        }
-      } else if (value !== undefined) {
-        formatFunctions.p(value, styles, style, result);
-      }
-  }
-}
-
-/**
- * Formats a list of values to be printed on the terminal.
- * @param values The array values
- * @param style The style to be applied
- * @param result The resulting string
- * @param styles The set of styles
- * @param formatFn The function to convert a value to string
- * @param brackets An optional pair of brackets to surround the values
- * @param separator An optional separator to delimit the values
- */
-function formatArray(
-  values: ReadonlyArray<string> | ReadonlyArray<number>,
-  style: Style,
-  result: TerminalString,
-  styles: ConcreteStyles,
-  formatFn: FormatFunction,
-  brackets?: [string, string],
-  separator?: string,
-) {
-  if (brackets) {
-    result.addOpening(brackets[0]);
-  }
-  values.forEach((value, i) => {
-    formatFn(value, styles, style, result);
-    if (separator && i < values.length - 1) {
-      result.addClosing(separator);
-    }
-  });
-  if (brackets) {
-    result.addClosing(brackets[1]);
-  }
 }
 
 /**
@@ -761,9 +683,9 @@ function formatEntries(entries: Array<HelpEntry>): HelpMessage {
  * @param result The resulting message
  */
 function formatSection(
-  options: Options,
+  options: InternalOptions,
   groups: Map<string, Array<HelpEntry>>,
-  styles: ConcreteStyles,
+  styles: FormatStyles,
   section: HelpSection,
   progName: string,
   result: HelpMessage,
@@ -796,8 +718,8 @@ function formatSection(
  * @param result The resulting message
  */
 function formatUsageSection(
-  options: Options,
-  styles: ConcreteStyles,
+  options: InternalOptions,
+  styles: FormatStyles,
   breaks: number,
   section: HelpUsage,
   progName: string,
@@ -815,7 +737,7 @@ function formatUsageSection(
     breaks = 0;
   }
   const filterKeys = filter && new Set(filter);
-  result.push(formatUsage(options, styles, styles.text, indent2, breaks, filterKeys, exclude));
+  result.push(formatUsage(options, styles, indent2, breaks, filterKeys, exclude));
 }
 
 /**
@@ -887,7 +809,6 @@ function formatText(
  * Options are rendered in the same order as was declared in the option definitions.
  * @param options The option definitions
  * @param styles The set of styles
- * @param defStyle The default style
  * @param indent The indentation level (negative values are replaced by zero)
  * @param breaks The number of line breaks (non-positive values are ignored)
  * @param filterKeys An optional set of options keys to filter
@@ -895,20 +816,19 @@ function formatText(
  * @returns The terminal string
  */
 function formatUsage(
-  options: Options,
-  styles: ConcreteStyles,
-  defStyle: Style,
+  options: InternalOptions,
+  styles: FormatStyles,
   indent?: number,
   breaks?: number,
   filterKeys?: Set<string>,
   exclude = false,
 ): TerminalString {
-  const result = new TerminalString(indent, breaks).addSequence(defStyle);
+  const result = new TerminalString(indent, breaks).addSequence(styles.text);
   const count = result.count;
   for (const key in options) {
     const option = options[key];
     if (!option.hide && (filterKeys?.has(key) ?? !exclude) != exclude) {
-      formatUsageOption(option, styles, defStyle, result);
+      formatUsageOption(option, styles, result);
     }
   }
   if (result.count == count) {
@@ -921,22 +841,16 @@ function formatUsage(
  * Formats an option to be included in the the usage text.
  * @param option The option definition
  * @param styles The set of styles
- * @param style The default style
  * @param result The resulting string
  */
-function formatUsageOption(
-  option: Option,
-  styles: ConcreteStyles,
-  style: Style,
-  result: TerminalString,
-) {
-  const required = 'required' in option && option.required;
+function formatUsageOption(option: Option, styles: FormatStyles, result: TerminalString) {
+  const required = option.required;
   if (!required) {
     result.addOpening('[');
   }
-  formatUsageNames(option, styles, style, result);
+  formatUsageNames(option, styles, result);
   if (!isNiladic(option)) {
-    formatParam(option, styles, style, result);
+    formatParam(option, styles, result);
   }
   if (!required) {
     result.addClosing(']');
@@ -947,21 +861,15 @@ function formatUsageOption(
  * Formats an option's names to be included in the usage text.
  * @param option The option definition
  * @param styles The set of styles
- * @param style The default style
  * @param result The resulting string
  */
-function formatUsageNames(
-  option: Option,
-  styles: ConcreteStyles,
-  style: Style,
-  result: TerminalString,
-) {
+function formatUsageNames(option: Option, styles: FormatStyles, result: TerminalString) {
   const names = option.names?.filter((name): name is string => !!name);
   if (names?.length) {
-    if (option.type === 'flag' && option.negationNames) {
+    if (option.negationNames) {
       names.push(...option.negationNames.filter((name) => name));
     }
-    const positional = 'positional' in option && option.positional;
+    const positional = option.positional;
     if (typeof positional === 'string') {
       names.push(positional);
     }
@@ -969,16 +877,10 @@ function formatUsageNames(
       result.addOpening('[');
     }
     if (names.length > 1) {
-      result.addOpening('(');
-      names.forEach((name, i) => {
-        formatFunctions.o(name, styles, style, result);
-        if (i < names.length - 1) {
-          result.addClosing('|').setMerge();
-        }
-      });
-      result.addClosing(')');
+      const config: FormatConfig = { brackets: ['(', ')'], sep: '|', mergeAfter: true };
+      result.formatArgs(styles, '%o', { o: names }, config);
     } else {
-      formatFunctions.o(names[0], styles, style, result);
+      format.o(names[0], styles, result);
     }
     if (positional) {
       result.addClosing(']');
@@ -988,53 +890,63 @@ function formatUsageNames(
 
 /**
  * Formats an option's parameter to be included in the description or the usage text.
+ * Assumes that the option is not niladic.
  * @param option The option definition
  * @param styles The set of styles
- * @param style The default style
  * @param result The resulting string
- * @returns The string length, counting spaces in example values
+ * @returns The string length
  */
-function formatParam(
-  option: ParamOption,
-  styles: ConcreteStyles,
-  style: Style,
-  result: TerminalString,
-): number {
-  const variadic = isArray(option) && isVariadic(option);
-  if ('example' in option && option.example !== undefined) {
-    formatValue(option, option.example, result, styles, style, false);
-    return result.length + (variadic ? option.example.length - 1 : 0);
+function formatParam(option: Option, styles: FormatStyles, result: TerminalString): number {
+  if (option.example !== undefined) {
+    return formatExample(option, styles, result);
   }
-  const ellipsis = variadic ? '...' : '';
-  const paramStyle = option.styles?.param ?? styles.param;
-  const param =
-    'paramName' in option && option.paramName
-      ? option.paramName.includes('<')
-        ? option.paramName
-        : `<${option.paramName}>${ellipsis}`
-      : `<${option.type}>${ellipsis}`;
-  result.addAndRevert(paramStyle, param, style);
+  const ellipsis = isVariadic(option) ? '...' : '';
+  const param = option.paramName
+    ? option.paramName.includes('<')
+      ? option.paramName
+      : `<${option.paramName}>${ellipsis}`
+    : `<${option.type}>${ellipsis}`;
+  result.addWord(param);
   return param.length;
+}
+
+/**
+ * Formats an option's example value to be included in the description or the usage text.
+ * @param option The option definition
+ * @param styles The set of styles
+ * @param result The resulting string
+ * @returns The string length, counting spaces in non-delimited array values
+ */
+function formatExample(option: Option, styles: FormatStyles, result: TerminalString): number {
+  const separator = option.separator;
+  if (separator) {
+    const sep = typeof separator === 'string' ? separator : separator.source;
+    const value = (option.example as Array<unknown>).join(sep);
+    result.formatArgs(styles, '%s', { s: value }, {});
+  } else {
+    const spec = isBoolean(option) ? 'b' : isString(option) ? 's' : isNumber(option) ? 'n' : 'v';
+    result.formatArgs(styles, `%${spec}`, { [spec]: option.example }, {});
+  }
+  const nonDelimited = !separator && Array.isArray(option.example);
+  return result.length + (nonDelimited ? option.example.length - 1 : 0);
 }
 
 /**
  * Formats an option's synopsis to be included in the description.
  * @param option The option definition
  * @param phrase The description item phrase
- * @param _styles unused
- * @param _style unused
+ * @param styles The set of styles
  * @param result The resulting string
  */
 function formatSynopsis(
   option: Option,
   phrase: string,
-  _styles: ConcreteStyles,
-  _style: Style,
+  styles: FormatStyles,
   result: TerminalString,
 ) {
-  if (option.desc) {
-    const text = option.desc;
-    result.splitText(phrase, () => result.splitText(text));
+  const desc = option.desc;
+  if (desc) {
+    result.formatArgs(styles, phrase, { t: desc });
   }
 }
 
@@ -1043,26 +955,17 @@ function formatSynopsis(
  * @param option The option definition
  * @param phrase The description item phrase
  * @param styles The set of styles
- * @param style The default style
  * @param result The resulting string
  */
 function formatNegation(
   option: Option,
   phrase: string,
-  styles: ConcreteStyles,
-  style: Style,
+  styles: FormatStyles,
   result: TerminalString,
 ) {
-  if (option.type === 'flag' && option.negationNames) {
-    const names = option.negationNames.filter((name) => name);
-    result.splitText(phrase, () => {
-      names.forEach((name, i) => {
-        formatFunctions.o(name, styles, style, result);
-        if (i < names.length - 1) {
-          result.addWord('or');
-        }
-      });
-    });
+  const names = option.negationNames?.filter((name) => name);
+  if (names?.length) {
+    result.formatArgs(styles, phrase, { o: names }, { sep: 'or', merge: false });
   }
 }
 
@@ -1071,28 +974,18 @@ function formatNegation(
  * @param option The option definition
  * @param phrase The description item phrase
  * @param styles The set of styles
- * @param style The default style
  * @param result The resulting string
  */
 function formatSeparator(
   option: Option,
   phrase: string,
-  styles: ConcreteStyles,
-  style: Style,
+  styles: FormatStyles,
   result: TerminalString,
 ) {
-  if ('separator' in option && option.separator) {
-    const sep = option.separator;
-    const formatFn = typeof sep === 'string' ? formatFunctions.s : formatFunctions.r;
-    type FormatFn = (
-      value: string | RegExp,
-      styles: ConcreteStyles,
-      style: Style,
-      result: TerminalString,
-    ) => void;
-    result.splitText(phrase, () => {
-      (formatFn as FormatFn)(sep, styles, style, result);
-    });
+  const separator = option.separator;
+  if (separator) {
+    const [spec, alt] = typeof separator === 'string' ? ['s', 0] : ['r', 1];
+    result.formatArgs(styles, phrase, { [spec]: separator }, { alt });
   }
 }
 
@@ -1100,18 +993,16 @@ function formatSeparator(
  * Formats an option's variadic nature to be included in the description.
  * @param option The option definition
  * @param phrase The description item phrase
- * @param _styles unused
- * @param _style unused
+ * @param _styles The set of styles
  * @param result The resulting string
  */
 function formatVariadic(
   option: Option,
   phrase: string,
-  _styles: ConcreteStyles,
-  _style: Style,
+  _styles: FormatStyles,
   result: TerminalString,
 ) {
-  if (isArray(option) && isVariadic(option)) {
+  if (isVariadic(option)) {
     result.splitText(phrase);
   }
 }
@@ -1121,26 +1012,18 @@ function formatVariadic(
  * @param option The option definition
  * @param phrase The description item phrase
  * @param styles The set of styles
- * @param style The default style
  * @param result The resulting string
  */
 function formatPositional(
   option: Option,
   phrase: string,
-  styles: ConcreteStyles,
-  style: Style,
+  styles: FormatStyles,
   result: TerminalString,
 ) {
-  if ('positional' in option && option.positional) {
-    const pos = option.positional;
-    const [p, m] = splitPhrase(phrase);
-    if (pos === true || !m) {
-      result.splitText(p);
-    } else {
-      result.splitText(m, () => {
-        formatFunctions.o(pos, styles, style, result);
-      });
-    }
+  const positional = option.positional;
+  if (positional) {
+    const [spec, alt] = positional === true ? ['', 0] : ['o', 1];
+    result.formatArgs(styles, phrase, { [spec]: positional }, { alt });
   }
 }
 
@@ -1148,18 +1031,16 @@ function formatPositional(
  * Formats an option's append attribute to be included in the description.
  * @param option The option definition
  * @param phrase The description item phrase
- * @param _styles unused
- * @param _style unused
+ * @param _styles The set of styles
  * @param result The resulting string
  */
 function formatAppend(
   option: Option,
   phrase: string,
-  _styles: ConcreteStyles,
-  _style: Style,
+  _styles: FormatStyles,
   result: TerminalString,
 ) {
-  if ('append' in option && option.append) {
+  if (option.append) {
     result.splitText(phrase);
   }
 }
@@ -1168,64 +1049,40 @@ function formatAppend(
  * Formats an option's trim normalization to be included in the description.
  * @param option The option definition
  * @param phrase The description item phrase
- * @param _styles unused
- * @param _style unused
+ * @param _styles The set of styles
  * @param result The resulting string
  */
-function formatTrim(
-  option: Option,
-  phrase: string,
-  _styles: ConcreteStyles,
-  _style: Style,
-  result: TerminalString,
-) {
-  if ('trim' in option && option.trim) {
+function formatTrim(option: Option, phrase: string, _styles: FormatStyles, result: TerminalString) {
+  if (option.trim) {
     result.splitText(phrase);
   }
 }
 
 /**
- * Formats an option's case normalization to be included in the description.
+ * Formats an option's case conversion to be included in the description.
  * @param option The option definition
  * @param phrase The description item phrase
- * @param _styles unused
- * @param _style unused
+ * @param styles The set of styles
  * @param result The resulting string
  */
-function formatCase(
-  option: Option,
-  phrase: string,
-  _styles: ConcreteStyles,
-  _style: Style,
-  result: TerminalString,
-) {
-  if ('case' in option && option.case) {
-    const [l, u] = splitPhrase(phrase);
-    result.splitText(option.case === 'lower' || !u ? l : u);
+function formatCase(option: Option, phrase: string, styles: FormatStyles, result: TerminalString) {
+  const conv = option.case;
+  if (conv) {
+    result.formatArgs(styles, phrase, {}, { alt: conv === 'lower' ? 0 : 1 });
   }
 }
 
 /**
- * Formats an option's rounding normalization to be included in the description.
+ * Formats an option's math conversion to be included in the description.
  * @param option The option definition
  * @param phrase The description item phrase
- * @param _styles unused
- * @param _style unused
+ * @param styles The set of styles
  * @param result The resulting string
  */
-function formatRound(
-  option: Option,
-  phrase: string,
-  _styles: ConcreteStyles,
-  _style: Style,
-  result: TerminalString,
-) {
-  if ('round' in option && option.round) {
-    const round = option.round;
-    const [t, f, c, r] = splitPhrase(phrase);
-    const text =
-      round === 'trunc' || !f ? t : round === 'floor' || !c ? f : round === 'ceil' || !r ? c : r;
-    result.splitText(text);
+function formatConv(option: Option, phrase: string, styles: FormatStyles, result: TerminalString) {
+  const conv = option.conv;
+  if (conv) {
+    result.formatArgs(styles, phrase, { t: conv });
   }
 }
 
@@ -1234,23 +1091,14 @@ function formatRound(
  * @param option The option definition
  * @param phrase The description item phrase
  * @param styles The set of styles
- * @param style The default style
  * @param result The resulting string
  */
-function formatEnums(
-  option: Option,
-  phrase: string,
-  styles: ConcreteStyles,
-  style: Style,
-  result: TerminalString,
-) {
-  if ('enums' in option && option.enums) {
-    const enums = option.enums;
-    const formatFn =
-      option.type === 'string' || option.type === 'strings' ? formatFunctions.s : formatFunctions.n;
-    result.splitText(phrase, () => {
-      formatArray(enums, style, result, styles, formatFn, ['{', '}'], ',');
-    });
+function formatEnums(option: Option, phrase: string, styles: FormatStyles, result: TerminalString) {
+  const enums = option.enums;
+  if (enums) {
+    const [spec, alt] = isString(option) ? ['s', 0] : ['n', 1];
+    const config: FormatConfig = { alt, brackets: ['{', '}'], sep: ',' };
+    result.formatArgs(styles, phrase, { [spec]: enums }, config);
   }
 }
 
@@ -1259,21 +1107,12 @@ function formatEnums(
  * @param option The option definition
  * @param phrase The description item phrase
  * @param styles The set of styles
- * @param style The default style
  * @param result The resulting string
  */
-function formatRegex(
-  option: Option,
-  phrase: string,
-  styles: ConcreteStyles,
-  style: Style,
-  result: TerminalString,
-) {
-  if ('regex' in option && option.regex) {
-    const regex = option.regex;
-    result.splitText(phrase, () => {
-      formatFunctions.r(regex, styles, style, result);
-    });
+function formatRegex(option: Option, phrase: string, styles: FormatStyles, result: TerminalString) {
+  const regex = option.regex;
+  if (regex) {
+    result.formatArgs(styles, phrase, { r: regex });
   }
 }
 
@@ -1282,21 +1121,12 @@ function formatRegex(
  * @param option The option definition
  * @param phrase The description item phrase
  * @param styles The set of styles
- * @param style The default style
  * @param result The resulting string
  */
-function formatRange(
-  option: Option,
-  phrase: string,
-  styles: ConcreteStyles,
-  style: Style,
-  result: TerminalString,
-) {
-  if ('range' in option && option.range) {
-    const range = option.range;
-    result.splitText(phrase, () => {
-      formatArray(range, style, result, styles, formatFunctions.n, ['[', ']'], ',');
-    });
+function formatRange(option: Option, phrase: string, styles: FormatStyles, result: TerminalString) {
+  const range = option.range;
+  if (range) {
+    result.formatArgs(styles, phrase, { n: range });
   }
 }
 
@@ -1304,18 +1134,16 @@ function formatRange(
  * Formats an option's unique constraint to be included in the description.
  * @param option The option definition
  * @param phrase The description item phrase
- * @param _styles unused
- * @param _style unused
+ * @param _styles The set of styles
  * @param result The resulting string
  */
 function formatUnique(
   option: Option,
   phrase: string,
-  _styles: ConcreteStyles,
-  _style: Style,
+  _styles: FormatStyles,
   result: TerminalString,
 ) {
-  if ('unique' in option && option.unique) {
+  if (option.unique) {
     result.splitText(phrase);
   }
 }
@@ -1325,21 +1153,12 @@ function formatUnique(
  * @param option The option definition
  * @param phrase The description item phrase
  * @param styles The set of styles
- * @param style The default style
  * @param result The resulting string
  */
-function formatLimit(
-  option: Option,
-  phrase: string,
-  styles: ConcreteStyles,
-  style: Style,
-  result: TerminalString,
-) {
-  if ('limit' in option && option.limit !== undefined) {
-    const limit = option.limit;
-    result.splitText(phrase, () => {
-      formatFunctions.n(limit, styles, style, result);
-    });
+function formatLimit(option: Option, phrase: string, styles: FormatStyles, result: TerminalString) {
+  const limit = option.limit;
+  if (limit !== undefined) {
+    result.formatArgs(styles, phrase, { n: limit });
   }
 }
 
@@ -1347,18 +1166,16 @@ function formatLimit(
  * Formats an option's required attribute to be included in the description.
  * @param option The option definition
  * @param phrase The description item phrase
- * @param _styles unused
- * @param _style unused
+ * @param _styles The set of styles
  * @param result The resulting string
  */
 function formatRequired(
   option: Option,
   phrase: string,
-  _styles: ConcreteStyles,
-  _style: Style,
+  _styles: FormatStyles,
   result: TerminalString,
 ) {
-  if ('required' in option && option.required) {
+  if (option.required) {
     result.splitText(phrase);
   }
 }
@@ -1368,21 +1185,28 @@ function formatRequired(
  * @param option The option definition
  * @param phrase The description item phrase
  * @param styles The set of styles
- * @param style The default style
  * @param result The resulting string
  */
 function formatDefault(
   option: Option,
   phrase: string,
-  styles: ConcreteStyles,
-  style: Style,
+  styles: FormatStyles,
   result: TerminalString,
 ) {
-  if ('default' in option && option.default !== undefined) {
-    const def = option.default;
-    result.splitText(phrase, () => {
-      formatValue(option, def, result, styles, style, true);
-    });
+  const value = option.default;
+  if (value !== undefined) {
+    const [spec, alt] =
+      typeof value === 'function'
+        ? ['v', 3]
+        : typeof value === 'boolean'
+          ? ['b', 0]
+          : typeof value === 'string' || option.type === 'strings'
+            ? ['s', 1]
+            : typeof value === 'number' || option.type === 'numbers'
+              ? ['n', 2]
+              : ['v', 3];
+    const config: FormatConfig = { alt, brackets: ['[', ']'], sep: ',' };
+    result.formatArgs(styles, phrase, { [spec]: value }, config);
   }
 }
 
@@ -1390,20 +1214,18 @@ function formatDefault(
  * Formats an option's deprecation reason to be included in the description.
  * @param option The option definition
  * @param phrase The description item phrase
- * @param _styles unused
- * @param _style unused
+ * @param styles The set of styles
  * @param result The resulting string
  */
 function formatDeprecated(
   option: Option,
   phrase: string,
-  _styles: ConcreteStyles,
-  _style: Style,
+  styles: FormatStyles,
   result: TerminalString,
 ) {
-  if (option.deprecated) {
-    const text = option.deprecated;
-    result.splitText(phrase, () => result.splitText(text));
+  const deprecated = option.deprecated;
+  if (deprecated) {
+    result.formatArgs(styles, phrase, { t: deprecated });
   }
 }
 
@@ -1412,21 +1234,12 @@ function formatDeprecated(
  * @param option The option definition
  * @param phrase The description item phrase
  * @param styles The set of styles
- * @param style The default style
  * @param result The resulting string
  */
-function formatLink(
-  option: Option,
-  phrase: string,
-  styles: ConcreteStyles,
-  style: Style,
-  result: TerminalString,
-) {
-  if (option.link) {
-    const link = option.link;
-    result.splitText(phrase, () => {
-      formatFunctions.u(link, styles, style, result);
-    });
+function formatLink(option: Option, phrase: string, styles: FormatStyles, result: TerminalString) {
+  const link = option.link;
+  if (link) {
+    result.formatArgs(styles, phrase, { u: link });
   }
 }
 
@@ -1435,21 +1248,17 @@ function formatLink(
  * @param option The option definition
  * @param phrase The description item phrase
  * @param styles The set of styles
- * @param style The default style
  * @param result The resulting string
  */
 function formatEnvVar(
   option: Option,
   phrase: string,
-  styles: ConcreteStyles,
-  style: Style,
+  styles: FormatStyles,
   result: TerminalString,
 ) {
-  if ('envVar' in option && option.envVar) {
-    const envVar = option.envVar;
-    result.splitText(phrase, () => {
-      formatFunctions.o(envVar, styles, style, result);
-    });
+  const envVar = option.envVar;
+  if (envVar) {
+    result.formatArgs(styles, phrase, { o: envVar });
   }
 }
 
@@ -1458,21 +1267,17 @@ function formatEnvVar(
  * @param option The option definition
  * @param phrase The description item phrase
  * @param styles The set of styles
- * @param style The default style
  * @param result The resulting string
  */
 function formatClusterLetters(
   option: Option,
   phrase: string,
-  styles: ConcreteStyles,
-  style: Style,
+  styles: FormatStyles,
   result: TerminalString,
 ) {
-  if ('clusterLetters' in option && option.clusterLetters) {
-    const letters = option.clusterLetters;
-    result.splitText(phrase, () => {
-      formatFunctions.s(letters, styles, style, result);
-    });
+  const letters = option.clusterLetters;
+  if (letters) {
+    result.formatArgs(styles, phrase, { s: letters });
   }
 }
 
@@ -1481,15 +1286,13 @@ function formatClusterLetters(
  * @param options The option definitions
  * @param requires The option requirements
  * @param styles The set of styles
- * @param style The default style
  * @param result The resulting string
  * @param negate True if the requirement should be negated
  */
 function formatRequirements(
-  options: Options,
+  options: InternalOptions,
   requires: Requires,
-  styles: ConcreteStyles,
-  style: Style,
+  styles: FormatStyles,
   result: TerminalString,
   negate: boolean = false,
 ) {
@@ -1498,18 +1301,18 @@ function formatRequirements(
       result.addWord('no');
     }
     const name = options[requires].preferredName ?? '';
-    formatFunctions.o(name, styles, style, result);
+    format.o(name, styles, result);
   } else if (requires instanceof RequiresNot) {
-    formatRequirements(options, requires.item, styles, style, result, !negate);
+    formatRequirements(options, requires.item, styles, result, !negate);
   } else if (requires instanceof RequiresAll || requires instanceof RequiresOne) {
-    formatRequiresExp(options, requires, styles, style, result, negate);
+    formatRequiresExp(options, requires, styles, result, negate);
   } else if (typeof requires === 'object') {
-    formatRequiresVal(options, requires, styles, style, result, negate);
+    formatRequiresVal(options, requires, styles, result, negate);
   } else {
     if (negate) {
       result.addWord('not');
     }
-    formatFunctions.p(requires, styles, style, result);
+    format.v(requires, styles, result);
   }
 }
 
@@ -1518,15 +1321,13 @@ function formatRequirements(
  * @param options The option definitions
  * @param requires The requirement expression
  * @param styles The set of styles
- * @param style The default style
  * @param result The resulting string
  * @param negate True if the requirement should be negated
  */
 function formatRequiresExp(
-  options: Options,
+  options: InternalOptions,
   requires: RequiresAll | RequiresOne,
-  styles: ConcreteStyles,
-  style: Style,
+  styles: FormatStyles,
   result: TerminalString,
   negate: boolean,
 ) {
@@ -1535,7 +1336,7 @@ function formatRequiresExp(
     result.addOpening('(');
   }
   requires.items.forEach((item, i) => {
-    formatRequirements(options, item, styles, style, result, negate);
+    formatRequirements(options, item, styles, result, negate);
     if (i < requires.items.length - 1) {
       result.addWord(op);
     }
@@ -1550,15 +1351,13 @@ function formatRequiresExp(
  * @param options The option definitions
  * @param requires The requirement object
  * @param styles The set of styles
- * @param style The default style
  * @param result The resulting string
  * @param negate True if the requirement should be negated
  */
 function formatRequiresVal(
-  options: Options,
+  options: InternalOptions,
   requires: RequiresVal,
-  styles: ConcreteStyles,
-  style: Style,
+  styles: FormatStyles,
   result: TerminalString,
   negate: boolean,
 ) {
@@ -1567,7 +1366,7 @@ function formatRequiresVal(
     result.addOpening('(');
   }
   entries.forEach(([key, value], i) => {
-    formatRequiredValue(options[key], value, styles, style, result, negate);
+    formatRequiredValue(options[key], value, styles, result, negate);
     if (i < entries.length - 1) {
       result.addWord('and');
     }
@@ -1582,26 +1381,23 @@ function formatRequiresVal(
  * @param option The option definition
  * @param value The option value
  * @param styles The set of styles
- * @param style The default style
  * @param result The resulting string
  * @param negate True if the requirement should be negated
  */
 function formatRequiredValue(
   option: Option,
   value: RequiresVal[string],
-  styles: ConcreteStyles,
-  style: Style,
+  styles: FormatStyles,
   result: TerminalString,
   negate: boolean,
 ) {
   if ((value === null && !negate) || (value === undefined && negate)) {
     result.addWord('no');
   }
-  const name = option.preferredName ?? '';
-  formatFunctions.o(name, styles, style, result);
+  format.o(option.preferredName ?? '', styles, result);
   if (value !== null && value !== undefined) {
-    assert(!isNiladic(option));
     result.addWord(negate ? '!=' : '=');
-    formatValue(option, value, result, styles, style, true);
+    const spec = isBoolean(option) ? 'b' : isString(option) ? 's' : isNumber(option) ? 'n' : 'v';
+    result.formatArgs(styles, `%${spec}`, { [spec]: value });
   }
 }

--- a/packages/tsargp/lib/index.ts
+++ b/packages/tsargp/lib/index.ts
@@ -7,5 +7,5 @@ export * from './formatter';
 export * from './parser';
 export * from './styles';
 
-export { req, RequiresAll, RequiresOne, RequiresNot } from './options';
+export { req } from './options';
 export { OptionValidator } from './validator';

--- a/packages/tsargp/lib/options.ts
+++ b/packages/tsargp/lib/options.ts
@@ -182,14 +182,20 @@ export type CompleteCallback = (
 ) => Array<string> | Promise<Array<string>>;
 
 /**
- * Defines attributes common to all options.
+ * Defines the type of an option.
  * @template T The option type
  */
-export type WithBasic<T extends string> = {
+export type WithType<T extends string> = {
   /**
    * The option type.
    */
   readonly type: T;
+};
+
+/**
+ * Defines attributes common to all options.
+ */
+export type WithBasic = {
   /**
    * The option names, as they appear on the command-line (e.g. `-h` or `--help`).
    *
@@ -454,27 +460,30 @@ export type WithFlag = {
 /**
  * An option that throws a help message.
  */
-export type HelpOption = WithBasic<'help'> & WithHelp;
+export type HelpOption = WithType<'help'> & WithBasic & WithHelp;
 
 /**
  * An option that throws a version information.
  */
-export type VersionOption = WithBasic<'version'> & WithVersion & (WithVerInfo | WithResolve);
+export type VersionOption = WithType<'version'> &
+  WithBasic &
+  WithVersion &
+  (WithVerInfo | WithResolve);
 
 /**
  * An option that executes a callback function.
  */
-export type FunctionOption = WithBasic<'function'> &
+export type FunctionOption = WithType<'function'> &
+  WithBasic &
   WithFunction &
   WithValue<unknown> &
-  WithParam<unknown> &
-  (WithDefault | WithRequired) &
-  (WithExample | WithParamName);
+  (WithDefault | WithRequired);
 
 /**
  * An option that executes a command.
  */
-export type CommandOption = WithBasic<'command'> &
+export type CommandOption = WithType<'command'> &
+  WithBasic &
   WithCommand &
   WithValue<unknown> &
   (WithDefault | WithRequired);
@@ -482,7 +491,8 @@ export type CommandOption = WithBasic<'command'> &
 /**
  * An option that has a boolean value and is enabled if specified (or disabled if negated).
  */
-export type FlagOption = WithBasic<'flag'> &
+export type FlagOption = WithType<'flag'> &
+  WithBasic &
   WithMisc &
   WithFlag &
   WithValue<boolean> &
@@ -491,7 +501,8 @@ export type FlagOption = WithBasic<'flag'> &
 /**
  * An option that has a boolean value (accepts a single boolean parameter).
  */
-export type BooleanOption = WithBasic<'boolean'> &
+export type BooleanOption = WithType<'boolean'> &
+  WithBasic &
   WithMisc &
   WithValue<boolean> &
   WithParam<boolean> &
@@ -501,7 +512,8 @@ export type BooleanOption = WithBasic<'boolean'> &
 /**
  * An option that has a string value (accepts a single string parameter).
  */
-export type StringOption = WithBasic<'string'> &
+export type StringOption = WithType<'string'> &
+  WithBasic &
   WithMisc &
   WithString &
   WithValue<string> &
@@ -513,7 +525,8 @@ export type StringOption = WithBasic<'string'> &
 /**
  * An option that has a number value (accepts a single number parameter).
  */
-export type NumberOption = WithBasic<'number'> &
+export type NumberOption = WithType<'number'> &
+  WithBasic &
   WithMisc &
   WithNumber &
   WithValue<number> &
@@ -525,7 +538,8 @@ export type NumberOption = WithBasic<'number'> &
 /**
  * An option that has a string array value (may accept single or multiple parameters).
  */
-export type StringsOption = WithBasic<'strings'> &
+export type StringsOption = WithType<'strings'> &
+  WithBasic &
   WithMisc &
   WithString &
   WithArray &
@@ -538,7 +552,8 @@ export type StringsOption = WithBasic<'strings'> &
 /**
  * An option that has a number array value (may accept single or multiple parameters).
  */
-export type NumbersOption = WithBasic<'numbers'> &
+export type NumbersOption = WithType<'numbers'> &
+  WithBasic &
   WithMisc &
   WithNumber &
   WithArray &
@@ -601,7 +616,8 @@ type OptionTypes =
  * An internal option definition.
  * @internal
  */
-export type OpaqueOption = WithBasic<OptionTypes> &
+export type OpaqueOption = WithType<OptionTypes> &
+  WithBasic &
   WithValue<unknown> &
   WithParam<unknown> &
   WithHelp &
@@ -790,21 +806,21 @@ type ArrayDataType<T extends Option, D> = ParamDataType<T, D, Array<EnumsDataTyp
  * @template T The option definition type
  */
 type OptionDataType<T extends Option> =
-  T extends WithBasic<'function'>
+  T extends WithType<'function'>
     ? ReturnType<T['exec']> | DefaultDataType<T>
-    : T extends WithBasic<'command'>
+    : T extends WithType<'command'>
       ? ReturnType<T['cmd']> | DefaultDataType<T>
-      : T extends WithBasic<'flag'>
+      : T extends WithType<'flag'>
         ? boolean | DefaultDataType<T>
-        : T extends WithBasic<'boolean'>
+        : T extends WithType<'boolean'>
           ? SingleDataType<T, boolean> | DefaultDataType<T>
-          : T extends WithBasic<'string'>
+          : T extends WithType<'string'>
             ? SingleDataType<T, string> | DefaultDataType<T>
-            : T extends WithBasic<'number'>
+            : T extends WithType<'number'>
               ? SingleDataType<T, number> | DefaultDataType<T>
-              : T extends WithBasic<'strings'>
+              : T extends WithType<'strings'>
                 ? ArrayDataType<T, string> | DelimitedDataType<T> | DefaultDataType<T>
-                : T extends WithBasic<'numbers'>
+                : T extends WithType<'numbers'>
                   ? ArrayDataType<T, number> | DelimitedDataType<T> | DefaultDataType<T>
                   : never;
 
@@ -818,7 +834,7 @@ type OptionDataType<T extends Option> =
  * @internal
  */
 export function isNiladic(option: OpaqueOption): boolean {
-  return ['help', 'function', 'version', 'command', 'flag'].includes(option.type);
+  return ['help', 'version', 'function', 'command', 'flag'].includes(option.type);
 }
 
 /**

--- a/packages/tsargp/lib/options.ts
+++ b/packages/tsargp/lib/options.ts
@@ -1,9 +1,9 @@
 //--------------------------------------------------------------------------------------------------
 // Imports
 //--------------------------------------------------------------------------------------------------
-import type { HelpConfig, HelpSections } from './formatter';
+import type { FormatterConfig, HelpSections } from './formatter';
 import type { Style } from './styles';
-import type { Resolve, Writable, URL } from './utils';
+import type { Resolve, URL, Flatten, KeyHaving, Range } from './utils';
 
 //--------------------------------------------------------------------------------------------------
 // Constants
@@ -88,11 +88,16 @@ export class RequiresNot {
 export type RequiresExp = RequiresNot | RequiresAll | RequiresOne;
 
 /**
+ * The type of an option value.
+ */
+export type OptionValue = boolean | string | number | Array<string> | Array<number>;
+
+/**
  * An object that maps option keys to required values.
  *
  * Values can be `undefined` to indicate presence, or `null` to indicate absence.
  */
-export type RequiresVal = { [key: string]: ParamOption['example'] | null };
+export type RequiresVal = { [key: string]: OptionValue | undefined | null };
 
 /**
  * An option requirement can be either:
@@ -109,7 +114,7 @@ export type Requires = string | RequiresVal | RequiresExp | RequiresCallback;
  * @param values The option values
  * @returns True if the requirements were satisfied
  */
-export type RequiresCallback = (values: OptionValues) => boolean;
+export type RequiresCallback = (values: InternalOptionValues) => boolean;
 
 /**
  * A callback to parse the value of option parameters. Any specified normalization or constraint
@@ -120,11 +125,17 @@ export type RequiresCallback = (values: OptionValues) => boolean;
  * @param value The parameter value
  * @returns The parsed value
  */
-export type ParseCallback<T> = (values: OptionValues, name: string, value: string) => T;
+export type ParseCallback<T> = (
+  values: InternalOptionValues,
+  name: string,
+  value: string,
+) => T | Promise<T>;
 
 /**
- * A module-relative resolution function (i.e., scoped to a module). To be used in non-browser
- * environments only.
+ * A module-relative resolution function (i.e., scoped to a module).
+ * To be used in non-browser environments only.
+ * @param specifier The path specifier
+ * @returns The resolved path
  */
 export type ResolveCallback = (specifier: string) => string;
 
@@ -134,7 +145,7 @@ export type ResolveCallback = (specifier: string) => string;
  * @param values The values parsed so far
  * @returns The default value
  */
-export type DefaultCallback<T> = (values: OptionValues) => T | Promise<T>;
+export type DefaultCallback<T> = (values: InternalOptionValues) => T | Promise<T>;
 
 /**
  * A callback for function options.
@@ -143,15 +154,19 @@ export type DefaultCallback<T> = (values: OptionValues) => T | Promise<T>;
  * @param rest The remaining command-line arguments
  * @returns The option value
  */
-export type ExecuteCallback = (values: OptionValues, comp: boolean, rest: Array<string>) => unknown;
+export type ExecuteCallback = (
+  values: InternalOptionValues,
+  comp: boolean,
+  rest: Array<string>,
+) => unknown;
 
 /**
  * A callback for command options.
- * @param values The values parsed before the command
- * @param cmdValues The values parsed after the command
+ * @param prev The values parsed for the parent command
+ * @param values The values parsed for the command
  * @returns The option value
  */
-export type CommandCallback = (values: OptionValues, cmdValues: OptionValues) => unknown;
+export type CommandCallback = (prev: InternalOptionValues, values: InternalOptionValues) => unknown;
 
 /**
  * A callback for option completion.
@@ -161,16 +176,19 @@ export type CommandCallback = (values: OptionValues, cmdValues: OptionValues) =>
  * @returns The list of completion words
  */
 export type CompleteCallback = (
-  values: OptionValues,
+  values: InternalOptionValues,
   comp: string,
   rest: Array<string>,
 ) => Array<string> | Promise<Array<string>>;
 
+//--------------------------------------------------------------------------------------------------
+// Internal types
+//--------------------------------------------------------------------------------------------------
 /**
  * Defines attributes common to all options.
  * @template T The option type
  */
-export type WithType<T extends string> = {
+export type WithBasic<T extends string> = {
   /**
    * The option type.
    */
@@ -178,7 +196,7 @@ export type WithType<T extends string> = {
   /**
    * The option names, as they appear on the command-line (e.g. `-h` or `--help`).
    *
-   * Names cannot contain whitespace or the equals sign `=` (since it may act as option-value
+   * Names cannot contain whitespace or the equals sign `=` (since it may act as option-parameter
    * separator). Empty names or `null`s can be specified in order to skip the respective "slot" in
    * the help message names column.
    */
@@ -188,13 +206,17 @@ export type WithType<T extends string> = {
    * when evaluating option requirements or processing positional arguments). It is not validated
    * and can be anything.
    *
-   * If not specified, the first name in the {@link WithType.names} array will be used.
+   * If not specified, the first name in the {@link WithBasic.names} array will be used.
    */
   preferredName?: string;
   /**
    * The option synopsis. It may contain inline styles.
    */
   readonly desc?: string;
+  /**
+   * The option deprecation reason. It may contain inline styles.
+   */
+  readonly deprecated?: string;
   /**
    * The option group in the help message.
    */
@@ -208,38 +230,20 @@ export type WithType<T extends string> = {
    */
   readonly styles?: OptionStyles;
   /**
-   * The option deprecation reason. It may contain inline styles.
-   */
-  readonly deprecated?: string;
-  /**
    * A reference to an external resource.
    */
   readonly link?: URL;
 };
 
 /**
- * Defines attributes for a required option.
+ * Defines attributes common to options with values.
+ * @template T The data type
  */
-export type WithRequired = {
+export type WithValue<T> = {
   /**
    * True if the option is always required.
    */
   readonly required?: true;
-  /**
-   * @deprecated mutually exclusive with {@link WithRequired.required}
-   */
-  readonly default?: never;
-  /**
-   * @deprecated mutually exclusive with {@link WithRequired.required}
-   */
-  readonly requiredIf?: never;
-};
-
-/**
- * Defines attributes for a default value.
- * @template T The default data type
- */
-export type WithDefault<T> = {
   /**
    * The option default value or a callback that returns the default value.
    *
@@ -247,245 +251,15 @@ export type WithDefault<T> = {
    * command-line. You may use a callback to inspect parsed values and determine the default value
    * based on those values.
    */
-  readonly default?: T | DefaultCallback<T>;
-  /**
-   * The conditional requirements.
-   */
-  readonly requiredIf?: Requires;
-  // TODO: change link to WithDefault.default once this is resolved:
-  // https://github.com/TypeStrong/typedoc/issues/2524
-  /**
-   * @deprecated mutually exclusive with {@link WithDefault['default']} and
-   * {@link WithDefault['requiredIf']}
-   */
-  readonly required?: never;
-};
-
-/**
- * Defines attributes common to all options that accept parameters.
- */
-export type WithParam = {
-  /**
-   * Allows positional arguments. There may be at most one option with this setting.
-   *
-   * If set, then any argument not recognized as an option name will be considered positional.
-   * Additionally, if a string is specified as positional marker, then all arguments beyond this
-   * marker will be considered positional.
-   *
-   * We recommend also setting {@link WithType.preferredName} to some explanatory name.
-   */
-  readonly positional?: true | string;
-  /**
-   * A custom completion callback. It should not throw. If asynchronous, you should call
-   * `ArgumentParser.parseAsync` and await its result.
-   */
-  readonly complete?: CompleteCallback;
-};
-
-/**
- * Defines attributes for an example value.
- * @template T The example data type
- */
-export type WithExample<T> = {
-  /**
-   * The option example value. Replaces the option type in the help message parameter column.
-   */
-  readonly example?: T;
-  /**
-   * @deprecated mutually exclusive with {@link WithExample.example}
-   */
-  readonly paramName?: never;
-};
-
-/**
- * Defines attributes for a parameter name.
- */
-export type WithParamName = {
-  /**
-   * The option parameter name. Replaces the option type in the help message parameter column.
-   */
-  readonly paramName?: string;
-  /**
-   * @deprecated mutually exclusive with {@link WithParamName.paramName}
-   */
-  readonly example?: never;
-};
-
-/**
- * Defines attributes for a custom callback that parses single-value parameters.
- */
-export type WithParse<T> = {
-  /**
-   * A custom function to parse the value of the option parameter.
-   */
-  readonly parse?: ParseCallback<T | Promise<T>>;
-  /**
-   * @deprecated mutually exclusive with {@link WithParse.parse}
-   */
-  readonly parseDelimited?: never;
-};
-
-/**
- * Defines attributes for a custom callback that parses delimited-value parameters.
- */
-export type WithParseDelimited<T> = {
-  /**
-   * A custom function to parse the delimited values of the option parameter. If specified, the
-   * option accepts a single parameter.
-   */
-  readonly parseDelimited?: ParseCallback<Array<T> | Promise<Array<T>>>;
-  /**
-   * @deprecated mutually exclusive with {@link WithParseDelimited.parseDelimited}
-   */
-  readonly parse?: never;
-  /**
-   * @deprecated mutually exclusive with {@link WithParseDelimited.parseDelimited}
-   */
-  readonly separator?: never;
-};
-
-/**
- * Defines attributes for an option that accepts delimited-value parameters.
- */
-export type WithSeparator = {
-  /**
-   * The parameter value separator. If specified, the option accepts a single parameter.
-   */
-  readonly separator?: string | RegExp;
-  /**
-   * @deprecated mutually exclusive with {@link WithSeparator.separator}
-   */
-  readonly parseDelimited?: never;
-};
-
-/**
- * Defines attributes common to all options that have array values.
- */
-export type WithArray = {
-  /**
-   * True if duplicate elements should be removed.
-   */
-  readonly unique?: true;
-  /**
-   * Allows appending elements if specified multiple times.
-   */
-  readonly append?: true;
-  /**
-   * The maximum allowed number of elements.
-   */
-  readonly limit?: number;
-};
-
-/**
- * Defines attributes for an enumeration constraint.
- * @template T The enumeration data type
- */
-export type WithEnums<T> = {
-  /**
-   * The enumerated values.
-   */
-  readonly enums?: ReadonlyArray<T>;
-  /**
-   * @deprecated mutually exclusive with {@link WithEnums.enums}
-   */
-  readonly regex?: never;
-  /**
-   * @deprecated mutually exclusive with {@link WithEnums.enums}
-   */
-  readonly range?: never;
-};
-
-/**
- * Defines attributes for a regex constraint.
- */
-export type WithRegex = {
-  /**
-   * The regular expression.
-   */
-  readonly regex?: RegExp;
-  /**
-   * @deprecated mutually exclusive with {@link WithRegex.regex}
-   */
-  readonly enums?: never;
-};
-
-/**
- * Defines attributes for a range constraint.
- */
-export type WithRange = {
-  /**
-   * The (closed) numeric range. You may want to use `[-Infinity, Infinity]` to disallow `NaN`.
-   */
-  readonly range?: [floor: number, ceiling: number];
-  /**
-   * @deprecated mutually exclusive with {@link WithRange.range}
-   */
-  readonly enums?: never;
-};
-
-/**
- * Defines the version attribute of a version option.
- */
-export type WithVersion = {
-  /**
-   * The semantic version (e.g., 0.1.0) or version information. It is not validated, but cannot be
-   * empty. It may contain inline styles.
-   */
-  readonly version: string;
-  /**
-   * @deprecated mutually exclusive with {@link WithVersion.version}
-   */
-  readonly resolve?: never;
-};
-
-/**
- * Defines the resolve attribute of a version option.
- */
-export type WithResolve = {
-  /**
-   * A resolution function scoped to the module where a `package.json` file should be searched. Use
-   * `import.meta.resolve`. Use in non-browser environments only. This results in an asynchronous
-   * operation, so you should call `ArgumentParser.parseAsync` and await its result.
-   */
-  readonly resolve: ResolveCallback;
-  /**
-   * @deprecated mutually exclusive with {@link WithResolve.resolve}
-   */
-  readonly version?: never;
-};
-
-/**
- * Defines attributes common to all options that accept string parameters.
- */
-export type WithString = (WithEnums<string> | WithRegex) & {
-  /**
-   * True if the values should be trimmed (remove leading and trailing whitespace).
-   */
-  readonly trim?: true;
-  /**
-   * The kind of case conversion to apply.
-   */
-  readonly case?: 'lower' | 'upper';
-};
-
-/**
- * Defines attributes common to all options that accept number parameters.
- */
-export type WithNumber = (WithEnums<number> | WithRange) & {
-  /**
-   * The kind of rounding to apply.
-   */
-  readonly round?: 'trunc' | 'floor' | 'ceil' | 'round';
-};
-
-/**
- * Defines attributes common to all options that have values.
- */
-export type WithValue<T> = (WithDefault<T> | WithRequired) & {
+  readonly default?: Readonly<T> | DefaultCallback<T>;
   /**
    * The option requirements.
    */
   readonly requires?: Requires;
+  /**
+   * The conditional requirements.
+   */
+  readonly requiredIf?: Requires;
   /**
    * The letters used for clustering in short-option style (e.g., 'fF').
    */
@@ -493,7 +267,99 @@ export type WithValue<T> = (WithDefault<T> | WithRequired) & {
 };
 
 /**
- * Defines attributes common to all valued options except function and command options.
+ * Defines attributes common to options with parameters.
+ * @template T The option value data type
+ */
+export type WithParam<T> = {
+  /**
+   * The option example value. Replaces the option type in the help message parameter column.
+   */
+  readonly example?: Readonly<T>;
+  /**
+   * The option parameter name. Replaces the option type in the help message parameter column.
+   */
+  readonly paramName?: string;
+  /**
+   * Allows positional arguments. There may be at most one option with this setting.
+   *
+   * If set, then any argument not recognized as an option name will be considered positional.
+   * Additionally, if a string is specified as positional marker, then all arguments beyond this
+   * marker will be considered positional.
+   *
+   * We recommend also setting {@link WithBasic.preferredName} to some explanatory name.
+   */
+  readonly positional?: true | string;
+  /**
+   * A custom completion callback. It should not throw. If asynchronous, you should call
+   * `ArgumentParser.parseAsync` and await its result.
+   */
+  readonly complete?: CompleteCallback;
+  /**
+   * A custom function to parse the value of the option parameter.
+   */
+  readonly parse?: ParseCallback<Flatten<T>>;
+  /**
+   * The enumerated values.
+   */
+  readonly enums?: ReadonlyArray<Flatten<T>>;
+};
+
+/**
+ * Defines attributes common to string-valued options.
+ */
+export type WithString = {
+  /**
+   * The regular expression.
+   */
+  readonly regex?: RegExp;
+  /**
+   * True if the values should be trimmed (remove leading and trailing whitespace).
+   */
+  readonly trim?: true;
+  /**
+   * The kind of case-conversion to apply.
+   */
+  readonly case?: 'lower' | 'upper';
+};
+
+/**
+ * Defines attributes common to number-valued options.
+ */
+export type WithNumber = {
+  /**
+   * The numeric range. You may want to use `[-Infinity, Infinity]` to disallow `NaN`.
+   */
+  readonly range?: Range;
+  /**
+   * The kind of math conversion to apply.
+   */
+  readonly conv?: KeyHaving<Math, (x: number) => number>;
+};
+
+/**
+ * Defines attributes common to array-valued options.
+ */
+export type WithArray = {
+  /**
+   * Allows appending elements if specified multiple times.
+   */
+  readonly append?: true;
+  /**
+   * The parameter value separator. If specified, the option accepts a single parameter.
+   */
+  readonly separator?: string | RegExp;
+  /**
+   * True if duplicate elements should be removed.
+   */
+  readonly unique?: true;
+  /**
+   * The maximum allowed number of elements.
+   */
+  readonly limit?: number;
+};
+
+/**
+ * Defines miscellaneous attributes.
  */
 export type WithMisc = {
   /**
@@ -504,123 +370,13 @@ export type WithMisc = {
 };
 
 /**
- * An option that has a boolean value (accepts a single boolean parameter).
+ * Defines attributes for the help option.
  */
-export type BooleanOption = WithType<'boolean'> &
-  WithParam &
-  WithMisc &
-  WithValue<boolean> &
-  (WithExample<boolean> | WithParamName) &
-  WithParse<boolean>;
-
-/**
- * An option that has a string value (accepts a single string parameter).
- */
-export type StringOption = WithType<'string'> &
-  WithParam &
-  WithMisc &
-  WithValue<string> &
-  (WithExample<string> | WithParamName) &
-  WithString &
-  WithParse<string>;
-
-/**
- * An option that has a number value (accepts a single number parameter).
- */
-export type NumberOption = WithType<'number'> &
-  WithParam &
-  WithMisc &
-  WithValue<number> &
-  (WithExample<number> | WithParamName) &
-  WithNumber &
-  WithParse<number>;
-
-/**
- * An option that has a string array value (may accept single or multiple parameters).
- */
-export type StringsOption = WithType<'strings'> &
-  WithParam &
-  WithMisc &
-  WithValue<ReadonlyArray<string>> &
-  (WithExample<ReadonlyArray<string>> | WithParamName) &
-  WithString &
-  WithArray &
-  ((WithParse<string> & WithSeparator) | WithParseDelimited<string>);
-
-/**
- * An option that has a number array value (may accept single or multiple parameters).
- */
-export type NumbersOption = WithType<'numbers'> &
-  WithParam &
-  WithMisc &
-  WithValue<ReadonlyArray<number>> &
-  (WithExample<ReadonlyArray<number>> | WithParamName) &
-  WithNumber &
-  WithArray &
-  ((WithParse<number> & WithSeparator) | WithParseDelimited<number>);
-
-/**
- * An option that has a boolean value and is enabled if specified (or disabled if negated).
- */
-export type FlagOption = WithType<'flag'> &
-  WithMisc &
-  WithValue<boolean> & {
-    /**
-     * The names used for negation (e.g., '--no-flag').
-     */
-    readonly negationNames?: ReadonlyArray<string>;
-  };
-
-/**
- * An option that executes a callback function.
- */
-export type FunctionOption = WithType<'function'> &
-  WithValue<unknown> & {
-    /**
-     * The callback function. If asynchronous, you should call `ArgumentParser.parseAsync` and await
-     * its result.
-     */
-    readonly exec: ExecuteCallback;
-    /**
-     * True to break the parsing loop.
-     */
-    readonly break?: true;
-    /**
-     * The number of remaining arguments to skip. You may change this value inside a synchronous
-     * callback. Otherwise, you should leave it unchanged. The parser does not alter this value.
-     * During bash completion, it is ignored.
-     */
-    skipCount?: number;
-  };
-
-/**
- * An option that executes a command.
- */
-export type CommandOption = WithType<'command'> &
-  WithValue<unknown> & {
-    /**
-     * The callback function. If asynchronous, you should call `ArgumentParser.parseAsync` and await
-     * its result.
-     */
-    readonly cmd: CommandCallback;
-    /**
-     * The command options or a callback that returns the options (for use with recursive commands).
-     */
-    readonly options: Options | (() => Options);
-    /**
-     * True if the first argument is expected to be an option cluster (i.e., short-option style).
-     */
-    readonly shortStyle?: true;
-  };
-
-/**
- * An option that throws a help message.
- */
-export type HelpOption = WithType<'help'> & {
+export type WithHelp = {
   /**
-   * The help format configuration.
+   * The formatter configuration.
    */
-  readonly format?: HelpConfig;
+  readonly format?: FormatterConfig;
   /**
    * The help sections to be rendered.
    */
@@ -632,157 +388,427 @@ export type HelpOption = WithType<'help'> & {
 };
 
 /**
- * An option that throws a semantic version.
+ * Defines attributes for the version option.
  */
-export type VersionOption = WithType<'version'> & (WithVersion | WithResolve);
+export type WithVersion = {
+  /**
+   * The semantic version (e.g., 0.1.0) or version information. It is not validated, but cannot be
+   * empty. It may contain inline styles.
+   */
+  readonly version?: string;
+  /**
+   * A resolution function scoped to the module where a `package.json` file should be searched. Use
+   * `import.meta.resolve`. Use in non-browser environments only. This results in an asynchronous
+   * operation, so you should call `ArgumentParser.parseAsync` and await its result.
+   */
+  readonly resolve?: ResolveCallback;
+};
 
 /**
- * An option that performs some predefined action.
+ * Defines attributes for the function option.
  */
-export type SpecialOption = HelpOption | VersionOption;
+export type WithFunction = {
+  /**
+   * The callback function. If asynchronous, you should call `ArgumentParser.parseAsync` and await
+   * its result.
+   */
+  readonly exec: ExecuteCallback;
+  /**
+   * True to break the parsing loop.
+   */
+  readonly break?: true;
+  /**
+   * The number of remaining arguments to skip. You may change this value inside a synchronous
+   * callback. Otherwise, you should leave it unchanged. The parser does not alter this value.
+   * During bash completion, it is ignored.
+   */
+  skipCount?: number;
+};
 
 /**
- * An option that performs a user-defined action.
+ * Defines attributes for the command option.
  */
-export type ExecutingOption = FunctionOption | CommandOption;
+export type WithCommand = {
+  /**
+   * The callback function. If asynchronous, you should call `ArgumentParser.parseAsync` and await
+   * its result.
+   */
+  readonly cmd: CommandCallback;
+  /**
+   * The command options or a callback that returns the options (for use with recursive commands).
+   */
+  readonly options: Options | (() => Options);
+  /**
+   * True if the first argument is expected to be an option cluster (i.e., short-option style).
+   */
+  readonly shortStyle?: true;
+};
 
 /**
- * An option that accepts no parameters.
+ * Defines attributes for the flag option.
  */
-export type NiladicOption = FlagOption | ExecutingOption | SpecialOption;
+export type WithFlag = {
+  /**
+   * The names used for negation (e.g., '--no-flag').
+   */
+  readonly negationNames?: ReadonlyArray<string>;
+};
 
 /**
- * A single-valued option that accepts a single parameter.
+ * The option types.
  */
-export type SingleOption = BooleanOption | StringOption | NumberOption;
+type OptionTypes =
+  | 'help'
+  | 'version'
+  | 'function'
+  | 'command'
+  | 'flag'
+  | 'boolean'
+  | 'string'
+  | 'number'
+  | 'strings'
+  | 'numbers';
 
 /**
- * An array-valued option that may accept multiple parameters.
+ * An internal option definition.
  */
-export type ArrayOption = StringsOption | NumbersOption;
+export type Option = WithBasic<OptionTypes> &
+  WithValue<unknown> &
+  WithParam<unknown> &
+  WithMisc &
+  WithHelp &
+  WithVersion &
+  WithFunction &
+  WithCommand &
+  WithFlag &
+  WithString &
+  WithNumber &
+  WithArray;
 
 /**
- * An option that accepts any kind of parameter.
+ * A collection of internal option definitions.
  */
-export type ParamOption = SingleOption | ArrayOption;
+export type InternalOptions = Readonly<Record<string, Option>>;
 
 /**
- * An option that has a default value.
+ * A collection of internal option values.
  */
-export type ValuedOption = FlagOption | ExecutingOption | ParamOption;
+export type InternalOptionValues = Record<string, unknown>;
+
+//--------------------------------------------------------------------------------------------------
+// Public types
+//--------------------------------------------------------------------------------------------------
+/**
+ * Defines attributes for a required option.
+ */
+type WithRequired = {
+  /**
+   * @deprecated mutually exclusive with {@link WithValue.required}
+   */
+  readonly default?: never;
+  /**
+   * @deprecated mutually exclusive with {@link WithValue.required}
+   */
+  readonly requiredIf?: never;
+};
 
 /**
- * An option definition. (finally)
+ * Defines attributes for a default value.
  */
-export type Option = NiladicOption | ParamOption;
+type WithDefault = {
+  /**
+   * @deprecated mutually exclusive with {@link WithValue.default} and {@link WithValue.requiredIf}
+   */
+  readonly required?: never;
+};
 
 /**
- * A collection of option definitions.
+ * Defines attributes for an example value.
  */
-export type Options = Readonly<Record<string, Option>>;
+type WithExample = {
+  /**
+   * @deprecated mutually exclusive with {@link WithParam.example}
+   */
+  readonly paramName?: never;
+};
 
 /**
- * The data type of an option with a default value.
+ * Defines attributes for a parameter name.
+ */
+type WithParamName = {
+  /**
+   * @deprecated mutually exclusive with {@link WithParam.paramName}
+   */
+  readonly example?: never;
+};
+
+/**
+ * Defines attributes for an enumeration constraint.
+ */
+type WithEnums = {
+  /**
+   * @deprecated mutually exclusive with {@link WithParam.enums}
+   */
+  readonly regex?: never;
+  /**
+   * @deprecated mutually exclusive with {@link WithParam.enums}
+   */
+  readonly range?: never;
+};
+
+/**
+ * Defines attributes for a regex constraint.
+ */
+type WithRegex = {
+  /**
+   * @deprecated mutually exclusive with {@link WithString.regex}
+   */
+  readonly enums?: never;
+};
+
+/**
+ * Defines attributes for a range constraint.
+ */
+type WithRange = {
+  /**
+   * @deprecated mutually exclusive with {@link WithNumber.range}
+   */
+  readonly enums?: never;
+};
+
+/**
+ * Defines the version attribute of a version option.
+ */
+type WithVerInfo = {
+  /**
+   * @deprecated mutually exclusive with {@link WithVersion.version}
+   */
+  readonly resolve?: never;
+};
+
+/**
+ * Defines the resolve attribute of a version option.
+ */
+type WithResolve = {
+  /**
+   * @deprecated mutually exclusive with {@link WithVersion.resolve}
+   */
+  readonly version?: never;
+};
+
+/**
+ * An option that throws a help message.
+ */
+type HelpOption = WithBasic<'help'> & WithHelp;
+
+/**
+ * An option that throws a version information.
+ */
+type VersionOption = WithBasic<'version'> & WithVersion & (WithVerInfo | WithResolve);
+
+/**
+ * An option that executes a callback function.
+ */
+type FunctionOption = WithBasic<'function'> &
+  WithFunction &
+  WithValue<unknown> &
+  WithParam<unknown> &
+  (WithDefault | WithRequired) &
+  (WithExample | WithParamName);
+
+/**
+ * An option that executes a command.
+ */
+type CommandOption = WithBasic<'command'> &
+  WithCommand &
+  WithValue<unknown> &
+  (WithDefault | WithRequired);
+
+/**
+ * An option that has a boolean value and is enabled if specified (or disabled if negated).
+ */
+type FlagOption = WithBasic<'flag'> &
+  WithMisc &
+  WithFlag &
+  WithValue<boolean> &
+  (WithDefault | WithRequired);
+
+/**
+ * An option that has a boolean value (accepts a single boolean parameter).
+ */
+type BooleanOption = WithBasic<'boolean'> &
+  WithMisc &
+  WithValue<boolean> &
+  WithParam<boolean> &
+  (WithDefault | WithRequired) &
+  (WithExample | WithParamName);
+
+/**
+ * An option that has a string value (accepts a single string parameter).
+ */
+type StringOption = WithBasic<'string'> &
+  WithMisc &
+  WithString &
+  WithValue<string> &
+  WithParam<string> &
+  (WithDefault | WithRequired) &
+  (WithExample | WithParamName) &
+  (WithEnums | WithRegex);
+
+/**
+ * An option that has a number value (accepts a single number parameter).
+ */
+type NumberOption = WithBasic<'number'> &
+  WithMisc &
+  WithNumber &
+  WithValue<number> &
+  WithParam<number> &
+  (WithDefault | WithRequired) &
+  (WithExample | WithParamName) &
+  (WithEnums | WithRange);
+
+/**
+ * An option that has a string array value (may accept single or multiple parameters).
+ */
+type StringsOption = WithBasic<'strings'> &
+  WithMisc &
+  WithString &
+  WithArray &
+  WithValue<Array<string>> &
+  WithParam<Array<string>> &
+  (WithDefault | WithRequired) &
+  (WithExample | WithParamName) &
+  (WithEnums | WithRegex);
+
+/**
+ * An option that has a number array value (may accept single or multiple parameters).
+ */
+type NumbersOption = WithBasic<'numbers'> &
+  WithMisc &
+  WithNumber &
+  WithArray &
+  WithValue<Array<number>> &
+  WithParam<Array<number>> &
+  (WithDefault | WithRequired) &
+  (WithExample | WithParamName) &
+  (WithEnums | WithRange);
+
+/**
+ * The public option types.
+ */
+type PublicOption =
+  | HelpOption
+  | VersionOption
+  | FunctionOption
+  | CommandOption
+  | FlagOption
+  | BooleanOption
+  | StringOption
+  | NumberOption
+  | StringsOption
+  | NumbersOption;
+
+/**
+ * A collection of public option definitions.
+ */
+export type Options = Readonly<Record<string, PublicOption>>;
+
+/**
+ * The data type of an option that may have a default value.
  * @template T The option definition type
  */
-type DefaultDataType<T extends ValuedOption> =
+type DefaultDataType<T extends PublicOption> =
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   T extends { default: (...args: any) => infer R }
-    ? Writable<R>
+    ? R
     : T extends { default: infer D }
       ? D extends undefined
         ? never
-        : Writable<D>
+        : D
       : T extends { required: true }
         ? never
         : undefined;
 
 /**
- * The data type of a non-niladic option.
+ * The data type of an option that has parameters.
  * @template T The option definition type
  * @template D The option value data type
  * @template E The effective data type
  */
-type ParamDataType<T extends ParamOption, D, E> = T extends
-  | { parse: ParseCallback<D> }
-  | { parseDelimited: ParseCallback<Array<D>> }
-  ? E
-  : T extends
-        | { parse: ParseCallback<Promise<D>> }
-        | { parseDelimited: ParseCallback<Promise<Array<D>>> }
-    ? Promise<E>
-    : T extends
-          | { parse: ParseCallback<D | Promise<D>> }
-          | { parseDelimited: ParseCallback<Array<D> | Promise<Array<D>>> }
-      ? E | Promise<E>
-      : E;
+type ParamDataType<T extends PublicOption, D, E> =
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  T extends { parse: (...args: any) => infer R }
+    ? R extends D
+      ? E
+      : R extends Promise<D>
+        ? Promise<E>
+        : R extends D | Promise<D>
+          ? E | Promise<E>
+          : E
+    : E;
 
 /**
  * The data type of an option with enumerated values.
  * @template T The option definition type
  * @template D The option value data type
  */
-type EnumsDataType<T extends ParamOption, D> = T extends { enums: ReadonlyArray<infer E> } ? E : D;
+type EnumsDataType<T extends PublicOption, D> = T extends { enums: ReadonlyArray<infer E> } ? E : D;
 
 /**
  * The data type of a (possibly) delimited array-valued option.
  * @template T The option definition type
  */
-type DelimitedDataType<T extends ArrayOption> = T extends
-  | { separator: string }
-  | { parseDelimited: NonNullable<unknown> }
-  ? never
-  : [];
+type DelimitedDataType<T extends PublicOption> = T extends { separator: string } ? never : [];
 
 /**
  * The data type of a single-valued option.
  * @template T The option definition type
  * @template D The option value data type
  */
-type SingleDataType<T extends SingleOption, D> = ParamDataType<T, D, EnumsDataType<T, D>>;
+type SingleDataType<T extends PublicOption, D> = ParamDataType<T, D, EnumsDataType<T, D>>;
 
 /**
  * The data type of an array-valued option.
  * @template T The option definition type
  * @template D The option value data type
  */
-type ArrayDataType<T extends ArrayOption, D> = ParamDataType<T, D, Array<EnumsDataType<T, D>>>;
+type ArrayDataType<T extends PublicOption, D> = ParamDataType<T, D, Array<EnumsDataType<T, D>>>;
 
 /**
  * The data type of an option value.
  * @template T The option definition type
  */
-type OptionDataType<T extends Option> = T extends FunctionOption
-  ? ReturnType<T['exec']> | DefaultDataType<T>
-  : T extends CommandOption
-    ? ReturnType<T['cmd']> | DefaultDataType<T>
-    : T extends FlagOption
-      ? boolean | DefaultDataType<T>
-      : T extends BooleanOption
-        ? SingleDataType<T, boolean> | DefaultDataType<T>
-        : T extends StringOption
-          ? SingleDataType<T, string> | DefaultDataType<T>
-          : T extends NumberOption
-            ? SingleDataType<T, number> | DefaultDataType<T>
-            : T extends StringsOption
-              ? ArrayDataType<T, string> | DelimitedDataType<T> | DefaultDataType<T>
-              : T extends NumbersOption
-                ? ArrayDataType<T, number> | DelimitedDataType<T> | DefaultDataType<T>
-                : never;
+type OptionDataType<T extends PublicOption> =
+  T extends WithBasic<'function'>
+    ? ReturnType<T['exec']> | DefaultDataType<T>
+    : T extends WithBasic<'command'>
+      ? ReturnType<T['cmd']> | DefaultDataType<T>
+      : T extends WithBasic<'flag'>
+        ? boolean | DefaultDataType<T>
+        : T extends WithBasic<'boolean'>
+          ? SingleDataType<T, boolean> | DefaultDataType<T>
+          : T extends WithBasic<'string'>
+            ? SingleDataType<T, string> | DefaultDataType<T>
+            : T extends WithBasic<'number'>
+              ? SingleDataType<T, number> | DefaultDataType<T>
+              : T extends WithBasic<'strings'>
+                ? ArrayDataType<T, string> | DelimitedDataType<T> | DefaultDataType<T>
+                : T extends WithBasic<'numbers'>
+                  ? ArrayDataType<T, number> | DelimitedDataType<T> | DefaultDataType<T>
+                  : never;
+
+/**
+ * The non-valued option types.
+ */
+type NonValued = WithBasic<'help' | 'version'>;
 
 /**
  * A generic collection of option values.
  * @template T The type of the option definitions
  */
 export type OptionValues<T extends Options = Options> = Resolve<{
-  -readonly [key in keyof T as T[key] extends SpecialOption ? never : key]: OptionDataType<T[key]>;
+  -readonly [key in keyof T as T[key] extends NonValued ? never : key]: OptionDataType<T[key]>;
 }>;
-
-/**
- * The concrete data type of the option value of a non-niladic option.
- * @internal
- */
-export type ParamValue = Writable<Exclude<ParamOption['example'], undefined>>;
 
 //--------------------------------------------------------------------------------------------------
 // Functions
@@ -793,8 +819,18 @@ export type ParamValue = Writable<Exclude<ParamOption['example'], undefined>>;
  * @returns True if the option is niladic
  * @internal
  */
-export function isNiladic(option: Option): option is NiladicOption {
-  return ['flag', 'function', 'help', 'version', 'command'].includes(option.type);
+export function isNiladic(option: Option): boolean {
+  return ['help', 'function', 'version', 'command', 'flag'].includes(option.type);
+}
+
+/**
+ * Tests if an option is variadic (i.e., it accepts a variable number of parameters).
+ * @param option The option definition
+ * @returns True if the option is variadic
+ * @internal
+ */
+export function isVariadic(option: Option): boolean {
+  return isArray(option) && !option.separator;
 }
 
 /**
@@ -803,7 +839,7 @@ export function isNiladic(option: Option): option is NiladicOption {
  * @returns True if the option is an array option
  * @internal
  */
-export function isArray(option: Option): option is ArrayOption {
+export function isArray(option: Option): boolean {
   return option.type === 'strings' || option.type === 'numbers';
 }
 
@@ -813,19 +849,46 @@ export function isArray(option: Option): option is ArrayOption {
  * @returns True if the option is a valued option
  * @internal
  */
-export function isValued(option: Option): option is ValuedOption {
+export function isValued(option: Option): boolean {
   return option.type !== 'help' && option.type !== 'version';
 }
 
 /**
- * Tests if an array option is variadic (i.e., accepts multiple parameters).
+ * Tests if an option has a boolean value.
  * @param option The option definition
- * @returns True if the option is variadic
+ * @returns True if the option is boolean-valued
  * @internal
  */
-export function isVariadic(option: ArrayOption): boolean {
-  return (
-    !('separator' in option && option.separator) &&
-    !('parseDelimited' in option && option.parseDelimited)
-  );
+export function isBoolean(option: Option): boolean {
+  return option.type === 'flag' || option.type === 'boolean';
+}
+
+/**
+ * Tests if an option has string values.
+ * @param option The option definition
+ * @returns True if the option is string-valued
+ * @internal
+ */
+export function isString(option: Option): boolean {
+  return option.type === 'string' || option.type === 'strings';
+}
+
+/**
+ * Tests if an option has number values.
+ * @param option The option definition
+ * @returns True if the option is number-valued
+ * @internal
+ */
+export function isNumber(option: Option): boolean {
+  return option.type === 'number' || option.type === 'numbers';
+}
+
+/**
+ * Tests if an option has unknown values.
+ * @param option The option definition
+ * @returns True if the option is unknown-valued
+ * @internal
+ */
+export function isUnknown(option: Option): boolean {
+  return option.type === 'function' || option.type === 'command';
 }

--- a/packages/tsargp/lib/options.ts
+++ b/packages/tsargp/lib/options.ts
@@ -849,8 +849,18 @@ export function isArray(option: Option): boolean {
  * @returns True if the option is a valued option
  * @internal
  */
-export function isValued(option: Option): boolean {
-  return option.type !== 'help' && option.type !== 'version';
+export function isSpecial(option: Option): boolean {
+  return option.type === 'help' || option.type === 'version';
+}
+
+/**
+ * Tests if an option has unknown values.
+ * @param option The option definition
+ * @returns True if the option is unknown-valued
+ * @internal
+ */
+export function isUnknown(option: Option): boolean {
+  return option.type === 'function' || option.type === 'command';
 }
 
 /**
@@ -881,14 +891,4 @@ export function isString(option: Option): boolean {
  */
 export function isNumber(option: Option): boolean {
   return option.type === 'number' || option.type === 'numbers';
-}
-
-/**
- * Tests if an option has unknown values.
- * @param option The option definition
- * @returns True if the option is unknown-valued
- * @internal
- */
-export function isUnknown(option: Option): boolean {
-  return option.type === 'function' || option.type === 'command';
 }

--- a/packages/tsargp/lib/parser.ts
+++ b/packages/tsargp/lib/parser.ts
@@ -371,7 +371,7 @@ function parseCluster(validator: OptionValidator, args: Array<string>) {
     }
     const key = validator.letters.get(letter);
     if (!key) {
-      throw validator.error(ErrorItem.unknownOption, { o1: letter }, { alt: 0 });
+      throw validator.error(ErrorItem.unknownOption, { o: letter }, { alt: 0 });
     }
     const option = validator.options[key];
     if (
@@ -547,7 +547,7 @@ function handleCompletion(option: Option, param?: string) {
  */
 function handleUnknown(validator: OptionValidator, name: string, err?: ErrorMessage): never {
   const similar = findSimilarNames(name, [...validator.names.keys()], 0.6);
-  const [args, alt] = similar.length ? [{ o1: name, o2: similar }, 1] : [{ o1: name }, 0];
+  const [args, alt] = similar.length ? [{ o1: name, o2: similar }, 1] : [{ o: name }, 0];
   const config: FormatConfig = { alt, sep: ',' };
   if (err) {
     err.msg.push(validator.format(ErrorItem.parseError, args, config));

--- a/packages/tsargp/lib/parser.ts
+++ b/packages/tsargp/lib/parser.ts
@@ -38,7 +38,7 @@ import {
 } from './styles';
 import { OptionValidator, defaultConfig } from './validator';
 import { format } from './styles';
-import { checkRequiredArray, getArgs, isTrue } from './utils';
+import { checkRequiredArray, findSimilarNames, getArgs, isTrue } from './utils';
 
 //--------------------------------------------------------------------------------------------------
 // Constants
@@ -546,7 +546,7 @@ function handleCompletion(option: Option, param?: string) {
  * @param err The previous error message, if any
  */
 function handleUnknown(validator: OptionValidator, name: string, err?: ErrorMessage): never {
-  const similar = validator.findSimilarNames(name, 0.6);
+  const similar = findSimilarNames(name, [...validator.names.keys()], 0.6);
   const [args, alt] = similar.length ? [{ o1: name, o2: similar }, 1] : [{ o1: name }, 0];
   const config: FormatConfig = { alt, sep: ',' };
   if (err) {

--- a/packages/tsargp/lib/parser.ts
+++ b/packages/tsargp/lib/parser.ts
@@ -22,7 +22,7 @@ import {
   isArray,
   isVariadic,
   isNiladic,
-  isValued,
+  isSpecial,
   isString,
   isBoolean,
   isUnknown,
@@ -38,7 +38,7 @@ import {
 } from './styles';
 import { OptionValidator, defaultConfig } from './validator';
 import { format } from './styles';
-import { assert, checkRequiredArray, getArgs, isTrue } from './utils';
+import { checkRequiredArray, getArgs, isTrue } from './utils';
 
 //--------------------------------------------------------------------------------------------------
 // Constants
@@ -231,7 +231,7 @@ class ParserLoop {
     for (const key in validator.options) {
       if (!(key in values)) {
         const option = validator.options[key];
-        if (isValued(option)) {
+        if (!isSpecial(option)) {
           values[key] = undefined;
         }
       }
@@ -246,6 +246,8 @@ class ParserLoop {
    * @returns The parser loop instance
    */
   loop(): this {
+    /** @ignore */
+    function assert(_condition: unknown): asserts _condition {}
     /** @ignore */
     function suggestName(option: Option): boolean {
       return (
@@ -591,7 +593,7 @@ class ParserLoop {
     const option = this.validator.options[key];
     const specified = this.specifiedKeys.has(key);
     const required = value !== null;
-    if (isUnknown(option) || !specified || !required || value === undefined) {
+    if (isSpecial(option) || isUnknown(option) || !specified || !required || value === undefined) {
       if ((specified == required) != negate) {
         return true;
       }
@@ -816,7 +818,7 @@ function handleCompletion(option: Option, param?: string) {
 function handleUnknown(validator: OptionValidator, name: string, err?: ErrorMessage): never {
   const similar = validator.findSimilarNames(name, 0.6);
   const [args, alt] = similar.length ? [{ o1: name, o2: similar }, 1] : [{ o1: name }, 0];
-  const config: FormatConfig = { alt, brackets: ['[', ']'], sep: ',' };
+  const config: FormatConfig = { alt, sep: ',' };
   if (err) {
     err.msg.push(validator.format(ErrorItem.parseError, args, config));
   } else {
@@ -1135,7 +1137,7 @@ function checkArray<T extends string | number>(
   const styles = validator.config.styles;
   format.o(name, styles, error);
   error.addWord(negate != invert ? '!=' : '=');
-  error.formatArgs(styles, `%${spec}`, { [spec]: expected });
+  error.formatArgs(styles, `[%${spec}]`, { [spec]: expected });
   return false;
 }
 

--- a/packages/tsargp/lib/parser.ts
+++ b/packages/tsargp/lib/parser.ts
@@ -4,12 +4,12 @@
 import type {
   Options,
   OptionValues,
-  InternalOptionValues,
+  OpaqueOptionValues,
   Requires,
   RequiresVal,
   CompleteCallback,
   ResolveCallback,
-  Option,
+  OpaqueOption,
 } from './options';
 import type { OptionInfo, ConcreteConfig, ValidatorConfig } from './validator';
 
@@ -202,6 +202,7 @@ export class ArgumentParser<T extends Options = Options> {
 
 /**
  * Implements the parsing loop.
+ * @internal
  */
 class ParserLoop {
   private readonly specifiedKeys = new Set<string>();
@@ -219,7 +220,7 @@ class ParserLoop {
    */
   constructor(
     private readonly validator: OptionValidator,
-    private readonly values: InternalOptionValues,
+    private readonly values: OpaqueOptionValues,
     private readonly args: Array<string>,
     private readonly completing: boolean,
     private readonly progName?: string,
@@ -249,7 +250,7 @@ class ParserLoop {
     /** @ignore */
     function assert(_condition: unknown): asserts _condition {}
     /** @ignore */
-    function suggestName(option: Option): boolean {
+    function suggestName(option: OpaqueOption): boolean {
       return (
         argKind === ArgKind.positional ||
         (argKind === ArgKind.param && isArray(option) && isVariadic(option))
@@ -399,8 +400,8 @@ function parseCluster(validator: OptionValidator, args: Array<string>) {
  */
 function checkEnvVar(
   validator: OptionValidator,
-  values: InternalOptionValues,
-  option: Option,
+  values: OpaqueOptionValues,
+  option: OpaqueOption,
   key: string,
 ): boolean {
   if (option.envVar) {
@@ -430,7 +431,7 @@ function checkEnvVar(
  */
 function createLoop(
   validator: OptionValidator,
-  values: InternalOptionValues,
+  values: OpaqueOptionValues,
   command = process?.env['COMP_LINE'] ?? process?.argv.slice(2) ?? [],
   config: ParseConfig = { compIndex: Number(process?.env['COMP_POINT']) },
 ): ParserLoop {
@@ -524,7 +525,7 @@ async function resolveVersion(
  * @param option The option definition
  * @param param The option parameter
  */
-function handleCompletion(option: Option, param?: string) {
+function handleCompletion(option: OpaqueOption, param?: string) {
   let words =
     option.type === 'boolean'
       ? ['true', 'false']
@@ -623,9 +624,9 @@ function checkRequireItems<T>(
  */
 function parseArray<T extends string | number>(
   validator: OptionValidator,
-  values: InternalOptionValues,
+  values: OpaqueOptionValues,
   key: string,
-  option: Option,
+  option: OpaqueOption,
   name: string,
   value: string,
   convertFn: (value: string) => T,
@@ -687,9 +688,9 @@ function parseArray<T extends string | number>(
  */
 function parseSingle<T extends boolean | string | number>(
   validator: OptionValidator,
-  values: InternalOptionValues,
+  values: OpaqueOptionValues,
   key: string,
-  option: Option,
+  option: OpaqueOption,
   name: string,
   value: string,
   convertFn: (value: string) => T,
@@ -711,9 +712,9 @@ function parseSingle<T extends boolean | string | number>(
  */
 function setSingle<T extends boolean | string | number>(
   validator: OptionValidator,
-  values: InternalOptionValues,
+  values: OpaqueOptionValues,
   key: string,
-  option: Option,
+  option: OpaqueOption,
   name: string,
   value: T | Promise<T>,
 ) {
@@ -735,9 +736,9 @@ function setSingle<T extends boolean | string | number>(
  */
 function setArray<T extends string | number>(
   validator: OptionValidator,
-  values: InternalOptionValues,
+  values: OpaqueOptionValues,
   key: string,
-  option: Option,
+  option: OpaqueOption,
   name: string,
   value: ReadonlyArray<T> | Promise<ReadonlyArray<T>>,
 ) {
@@ -760,9 +761,9 @@ function setArray<T extends string | number>(
  */
 function parseValue(
   validator: OptionValidator,
-  values: InternalOptionValues,
+  values: OpaqueOptionValues,
   key: string,
-  option: Option,
+  option: OpaqueOption,
   name: string,
   value: string,
 ) {
@@ -783,7 +784,7 @@ function parseValue(
  * @param key The option key
  * @param option The option definition
  */
-function resetValue(values: InternalOptionValues, key: string, option: Option) {
+function resetValue(values: OpaqueOptionValues, key: string, option: OpaqueOption) {
   if (!option.append || values[key] === undefined) {
     values[key] = [];
   }
@@ -805,8 +806,8 @@ function resetValue(values: InternalOptionValues, key: string, option: Option) {
  */
 function checkSingle<T extends boolean | string | number>(
   validator: OptionValidator,
-  values: InternalOptionValues,
-  option: Option,
+  values: OpaqueOptionValues,
+  option: OpaqueOption,
   negate: boolean,
   invert: boolean,
   key: string,
@@ -846,8 +847,8 @@ function checkSingle<T extends boolean | string | number>(
  */
 function checkArray<T extends string | number>(
   validator: OptionValidator,
-  values: InternalOptionValues,
-  option: Option,
+  values: OpaqueOptionValues,
+  option: OpaqueOption,
   negate: boolean,
   invert: boolean,
   key: string,
@@ -885,8 +886,8 @@ function checkArray<T extends string | number>(
  */
 function checkRequiredValue(
   validator: OptionValidator,
-  values: InternalOptionValues,
-  option: Option,
+  values: OpaqueOptionValues,
+  option: OpaqueOption,
   negate: boolean,
   invert: boolean,
   key: string,
@@ -908,9 +909,9 @@ function checkRequiredValue(
  */
 function setDefaultValue(
   validator: OptionValidator,
-  values: InternalOptionValues,
+  values: OpaqueOptionValues,
   key: string,
-  option: Option,
+  option: OpaqueOption,
 ) {
   if (option.default === undefined) {
     values[key] = undefined;
@@ -943,10 +944,10 @@ function setDefaultValue(
  */
 function handleNiladic(
   validator: OptionValidator,
-  values: InternalOptionValues,
+  values: OpaqueOptionValues,
   specifiedKeys: Set<string>,
   key: string,
-  option: Option,
+  option: OpaqueOption,
   name: string,
   index: number,
   completing: boolean,
@@ -1006,10 +1007,10 @@ function handleNiladic(
  */
 function handleFunction(
   validator: OptionValidator,
-  values: InternalOptionValues,
+  values: OpaqueOptionValues,
   specifiedKeys: Set<string>,
   key: string,
-  option: Option,
+  option: OpaqueOption,
   index: number,
   completing: boolean,
   args: Array<string>,
@@ -1066,10 +1067,10 @@ function handleFunction(
  */
 function handleCommand(
   validator: OptionValidator,
-  values: InternalOptionValues,
+  values: OpaqueOptionValues,
   specifiedKeys: Set<string>,
   key: string,
-  option: Option,
+  option: OpaqueOption,
   name: string,
   index: number,
   completing: boolean,
@@ -1079,7 +1080,7 @@ function handleCommand(
   if (!completing) {
     checkRequired(validator, values, specifiedKeys);
   }
-  const newValues: InternalOptionValues = {};
+  const newValues: OpaqueOptionValues = {};
   const options = typeof option.options === 'function' ? option.options() : option.options;
   const newValidator = new OptionValidator(options, validator.config);
   const loop = new ParserLoop(
@@ -1118,7 +1119,7 @@ function handleCommand(
  */
 function handleSpecial(
   validator: OptionValidator,
-  option: Option,
+  option: OpaqueOption,
   index: number,
   args: Array<string>,
   promises: Array<Promise<void>>,
@@ -1151,7 +1152,7 @@ function handleSpecial(
  * @param promises The list of promises
  */
 function handleComplete(
-  values: InternalOptionValues,
+  values: OpaqueOptionValues,
   complete: CompleteCallback,
   index: number,
   param: string,
@@ -1190,7 +1191,7 @@ function handleComplete(
  */
 function checkRequired(
   validator: OptionValidator,
-  values: InternalOptionValues,
+  values: OpaqueOptionValues,
   specifiedKeys: Set<string>,
 ) {
   for (const key in validator.options) {
@@ -1242,7 +1243,7 @@ function checkRequired(
  */
 function checkRequires(
   validator: OptionValidator,
-  values: InternalOptionValues,
+  values: OpaqueOptionValues,
   specifiedKeys: Set<string>,
   requires: Requires,
   error: TerminalString,
@@ -1312,7 +1313,7 @@ function checkRequires(
  */
 function checkRequirement(
   validator: OptionValidator,
-  values: InternalOptionValues,
+  values: OpaqueOptionValues,
   specifiedKeys: Set<string>,
   kvp: [key: string, value: RequiresVal[string]],
   error: TerminalString,

--- a/packages/tsargp/lib/styles.ts
+++ b/packages/tsargp/lib/styles.ts
@@ -3,7 +3,7 @@
 //--------------------------------------------------------------------------------------------------
 import type { Alias, Concrete, Enumerate, URL, ValuesOf } from './utils';
 import { cs, tf, fg, bg } from './enums';
-import { overrides, splitPhrase } from './utils';
+import { overrides, selectAlternative } from './utils';
 
 export { sequence as seq, sgr as style, foreground as fg8, background as bg8, underline as ul8 };
 export { underlineStyle as ul, formatFunctions as format };
@@ -202,7 +202,7 @@ export type MessageStyles = {
    */
   readonly option?: Style;
   /**
-   * A style for generic (or unknown) values.
+   * The style of generic (or unknown) values.
    */
   readonly value?: Style;
   /**
@@ -444,7 +444,7 @@ export class TerminalString {
    */
   formatArgs(styles: FormatStyles, phrase: string, args?: FormatArgs, config?: FormatConfig): this {
     const formatFn = args && formatArgs(styles, args, config);
-    const alternative = config?.alt !== undefined ? splitPhrase(phrase)[config.alt] : phrase;
+    const alternative = config?.alt !== undefined ? selectAlternative(phrase, config.alt) : phrase;
     return this.splitText(alternative, formatFn);
   }
 

--- a/packages/tsargp/lib/styles.ts
+++ b/packages/tsargp/lib/styles.ts
@@ -399,6 +399,14 @@ export class TerminalString {
   }
 
   /**
+   * Appends an SGR clear sequence to the list.
+   * @returns The terminal string instance
+   */
+  addClear(): this {
+    return this.addText(sgr(tf.clear), 0);
+  }
+
+  /**
    * Appends a text that may contain control characters or sequences to the list.
    * @param text The text to be appended
    * @param length The length of the text without control characters or sequences
@@ -439,7 +447,7 @@ export class TerminalString {
   /**
    * Formats a set of arguments.
    * @param styles The format styles
-   * @param phrase The format phrase
+   * @param phrase The custom phrase
    * @param args The format arguments
    * @param config The format config
    * @returns The terminal string instance

--- a/packages/tsargp/lib/styles.ts
+++ b/packages/tsargp/lib/styles.ts
@@ -199,21 +199,17 @@ export type FormatConfig = {
    */
   readonly alt?: number;
   /**
-   * A pair of brackets for array values.
-   */
-  readonly brackets?: [string, string];
-  /**
    * An element separator for array values.
    */
   readonly sep?: string;
   /**
    * Whether the separator should be merged with the previous value. (Defaults to true)
    */
-  readonly merge?: boolean;
+  readonly mergePrev?: boolean;
   /**
    * Whether the separator should be merged with the next value. (Defaults to false)
    */
-  readonly mergeAfter?: boolean;
+  readonly mergeNext?: boolean;
 };
 
 //--------------------------------------------------------------------------------------------------
@@ -702,7 +698,7 @@ function splitItem(result: TerminalString, item: string, format?: FormatCallback
 function formatArgs(
   styles: FormatStyles,
   args: FormatArgs,
-  config: FormatConfig = { brackets: ['[', ']'], sep: ',' },
+  config: FormatConfig = { sep: ',' },
 ): FormatCallback {
   return function (this: TerminalString, spec: string) {
     const arg = spec.slice(1);
@@ -711,20 +707,14 @@ function formatArgs(
       const value = args[arg];
       const formatFn = (format as FormatFunctions)[fmt];
       if (Array.isArray(value)) {
-        if (config?.brackets) {
-          this.addOpening(config.brackets[0]);
-        }
         value.forEach((val, i) => {
           formatFn(val, styles, this);
           if (config?.sep && i < value.length - 1) {
-            this.setMerge(config.merge)
+            this.setMerge(config.mergePrev)
               .addWord(config.sep)
-              .setMerge(config.mergeAfter ?? false);
+              .setMerge(config.mergeNext ?? false);
           }
         });
-        if (config?.brackets) {
-          this.addClosing(config.brackets[1]);
-        }
       } else {
         formatFn(value, styles, this);
       }

--- a/packages/tsargp/lib/styles.ts
+++ b/packages/tsargp/lib/styles.ts
@@ -98,7 +98,7 @@ const regex = {
 } as const satisfies Record<string, RegExp>;
 
 //--------------------------------------------------------------------------------------------------
-// Types
+// Public types
 //--------------------------------------------------------------------------------------------------
 /**
  * A control sequence introducer.
@@ -160,19 +160,6 @@ export type FormatCallback = (this: TerminalString, spec: string) => void;
 export type FormatArgs = Record<string, unknown>;
 
 /**
- * A formatting function.
- * @internal
- */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type FormatFunction = (value: any, styles: FormatStyles, result: TerminalString) => void;
-
-/**
- * A set of formatting functions.
- * @internal
- */
-export type FormatFunctions = Record<string, FormatFunction>;
-
-/**
  * A message that can be printed on a terminal.
  */
 export type Message = ErrorMessage | HelpMessage | WarnMessage | VersionMessage | CompletionMessage;
@@ -217,7 +204,6 @@ export type MessageStyles = {
 
 /**
  * A concrete version of the format styles.
- * @internal
  */
 export type FormatStyles = Concrete<MessageStyles> & {
   /**
@@ -247,6 +233,22 @@ export type FormatConfig = {
    */
   readonly mergeNext?: boolean;
 };
+
+//--------------------------------------------------------------------------------------------------
+// Internal types
+//--------------------------------------------------------------------------------------------------
+/**
+ * A formatting function.
+ * @internal
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type FormatFunction = (value: any, styles: FormatStyles, result: TerminalString) => void;
+
+/**
+ * A set of formatting functions.
+ * @internal
+ */
+export type FormatFunctions = Record<string, FormatFunction>;
 
 //--------------------------------------------------------------------------------------------------
 // Classes

--- a/packages/tsargp/lib/utils.ts
+++ b/packages/tsargp/lib/utils.ts
@@ -70,6 +70,12 @@ export type KeyHaving<T, V> = keyof { [K in keyof T as T[K] extends V ? K : neve
 export type Flatten<T> = T extends Array<infer E> ? E : T;
 
 /**
+ * A helper type to get a union of the values of all properties from a type.
+ * @template T The source type
+ */
+export type ValuesOf<T> = T[keyof T];
+
+/**
  * For some reason the global definition of `URL` has issues with static methods.
  */
 export interface URL extends _URL {}

--- a/packages/tsargp/lib/utils.ts
+++ b/packages/tsargp/lib/utils.ts
@@ -110,7 +110,7 @@ export type NamingMatch<T extends NamingRules> = Resolve<{
 
 /**
  * A (closed) numeric range.
- * 
+ *
  * In a valid range, the minimum should be strictly less than the maximum.
  */
 export type Range = [min: number, max: number];
@@ -278,16 +278,33 @@ export function gestaltSimilarity(S: string, T: string): number {
  * @internal
  */
 export function splitPhrase(phrase: string): Array<string> {
-  const [l, c, r] = phrase.split(/\(([^()|]*\|[^()]*)\)/, 3);
-  return c ? c.split('|').map((alt) => l + alt + r) : [l];
+  let a = [];
+  let b = -1;
+  let i = 0;
+  for (; i < phrase.length; ++i) {
+    const c = phrase[i];
+    if (c === '(') {
+      a.push(i);
+    } else if (c === '|') {
+      if (b < 0 && a.length) {
+        b = a.length;
+      }
+    } else if (c === ')') {
+      if (b == a.length) {
+        break;
+      }
+      a.pop();
+    }
+  }
+  if (i < phrase.length) {
+    const s = a[a.length - 1];
+    const l = phrase.slice(0, s);
+    const c = phrase.slice(s + 1, i);
+    const r = phrase.slice(i + 1);
+    return c.split('|').map((alt) => l + alt + r);
+  }
+  return [phrase];
 }
-
-/**
- * Asserts that a condition is true. This is a no-op.
- * @param _condition The condition
- * @internal
- */
-export function assert(_condition: unknown): asserts _condition {}
 
 /**
  * Converts a string to boolean.

--- a/packages/tsargp/lib/utils.ts
+++ b/packages/tsargp/lib/utils.ts
@@ -278,6 +278,38 @@ export function gestaltSimilarity(S: string, T: string): number {
 }
 
 /**
+ * Gets a list of option names that are similar to a given name.
+ * @param name The name to be searched
+ * @param names The names to be searched
+ * @param threshold The similarity threshold
+ * @returns The list of similar names in decreasing order of similarity
+ */
+export function findSimilarNames(
+  name: string,
+  names: Array<string>,
+  threshold: number,
+): Array<string> {
+  /** @ignore */
+  function norm(name: string) {
+    return name.replace(/\p{P}/gu, '').toLowerCase();
+  }
+  const searchName = norm(name);
+  return names
+    .reduce((acc, name2) => {
+      // skip the original name
+      if (name2 != name) {
+        const sim = gestaltSimilarity(searchName, norm(name2));
+        if (sim >= threshold) {
+          acc.push([name2, sim]);
+        }
+      }
+      return acc;
+    }, new Array<[string, number]>())
+    .sort(([, as], [, bs]) => bs - as)
+    .map(([str]) => str);
+}
+
+/**
  * Split a phrase into multiple alternatives
  * @param phrase The phrase string
  * @returns The phrase alternatives

--- a/packages/tsargp/lib/utils.ts
+++ b/packages/tsargp/lib/utils.ts
@@ -181,6 +181,7 @@ export function getArgs(line: string, compIndex: number = NaN): Array<string> {
 
 /**
  * Checks the specified value of an array option against a required value.
+ * @template T The type of the array element
  * @param actual The specified value
  * @param expected The required value
  * @param negate True if the requirement should be negated
@@ -188,7 +189,7 @@ export function getArgs(line: string, compIndex: number = NaN): Array<string> {
  * @returns True if the requirement was satisfied
  * @internal
  */
-export function checkRequiredArray<T extends string | number>(
+export function checkRequiredArray<T>(
   actual: ReadonlyArray<T>,
   expected: ReadonlyArray<T>,
   negate: boolean,

--- a/packages/tsargp/lib/utils.ts
+++ b/packages/tsargp/lib/utils.ts
@@ -57,6 +57,19 @@ export type Concrete<T> = { [K in keyof T]-?: Concrete<T[K]> };
 export type Writable<T> = { -readonly [P in keyof T]: Writable<T[P]> };
 
 /**
+ * A helper type to get the keys of a type depending on a value constraint.
+ * @template T The source type
+ * @template V The value type
+ */
+export type KeyHaving<T, V> = keyof { [K in keyof T as T[K] extends V ? K : never]: never };
+
+/**
+ * A helper type to get the type of the array element from a type.
+ * @template T The source type
+ */
+export type Flatten<T> = T extends Array<infer E> ? E : T;
+
+/**
  * For some reason the global definition of `URL` has issues with static methods.
  */
 export interface URL extends _URL {}
@@ -94,6 +107,13 @@ export type NamingMatch<T extends NamingRules> = Resolve<{
     -readonly [key2 in keyof T[key1]]: string;
   };
 }>;
+
+/**
+ * A (closed) numeric range.
+ * 
+ * In a valid range, the minimum should be strictly less than the maximum.
+ */
+export type Range = [min: number, max: number];
 
 //--------------------------------------------------------------------------------------------------
 // Functions

--- a/packages/tsargp/lib/validator.ts
+++ b/packages/tsargp/lib/validator.ts
@@ -548,8 +548,8 @@ function validateConstraints(config: ConcreteConfig, key: string, option: Opaque
   }
   if (option.range) {
     const [min, max] = option.range;
+    // handles NaN as well
     if (!(min < max)) {
-      // handles NaN as well
       throw error(config, ErrorItem.invalidNumericRange, { o: key, n: option.range });
     }
   }

--- a/packages/tsargp/test/formatter/formatter.formatting.spec.ts
+++ b/packages/tsargp/test/formatter/formatter.formatting.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import type { Options, HelpConfig } from '../../lib';
+import type { Options, FormatterConfig } from '../../lib';
 import { HelpFormatter, OptionValidator, style, tf, fg8 } from '../../lib';
 import '../utils.spec'; // initialize globals
 
@@ -118,7 +118,7 @@ describe('HelpFormatter', () => {
           desc: 'A boolean option',
         },
       } as const satisfies Options;
-      const config: HelpConfig = {
+      const config: FormatterConfig = {
         names: { breaks: -1 },
         param: { breaks: -1 },
         descr: { breaks: -1 },
@@ -135,7 +135,7 @@ describe('HelpFormatter', () => {
           desc: 'A boolean option',
         },
       } as const satisfies Options;
-      const config: HelpConfig = {
+      const config: FormatterConfig = {
         names: { breaks: 1 },
         param: { breaks: 1 },
         descr: { breaks: 1 },
@@ -154,7 +154,7 @@ describe('HelpFormatter', () => {
           desc: 'A boolean option',
         },
       } as const satisfies Options;
-      const config: HelpConfig = {
+      const config: FormatterConfig = {
         names: { breaks: 1 },
         param: { breaks: 1, absolute: true },
         descr: { breaks: 1, absolute: true },
@@ -173,7 +173,7 @@ describe('HelpFormatter', () => {
           desc: 'A boolean option',
         },
       } as const satisfies Options;
-      const config: HelpConfig = {
+      const config: FormatterConfig = {
         names: { breaks: 1, indent: -1 },
         param: { breaks: 1, indent: -1 },
         descr: { breaks: 1, indent: -1 },
@@ -190,7 +190,7 @@ describe('HelpFormatter', () => {
           desc: 'A boolean option',
         },
       } as const satisfies Options;
-      const config: HelpConfig = { names: { hidden: true } };
+      const config: FormatterConfig = { names: { hidden: true } };
       const message = new HelpFormatter(new OptionValidator(options), config).formatHelp();
       expect(message.wrap()).toEqual('    <boolean>  A boolean option\n');
     });
@@ -203,7 +203,7 @@ describe('HelpFormatter', () => {
           desc: 'A boolean option',
         },
       } as const satisfies Options;
-      const config: HelpConfig = { param: { hidden: true } };
+      const config: FormatterConfig = { param: { hidden: true } };
       const message = new HelpFormatter(new OptionValidator(options), config).formatHelp();
       expect(message.wrap()).toEqual('  -b, --boolean    A boolean option\n');
     });
@@ -216,7 +216,7 @@ describe('HelpFormatter', () => {
           desc: 'A boolean option',
         },
       } as const satisfies Options;
-      const config: HelpConfig = { descr: { hidden: true } };
+      const config: FormatterConfig = { descr: { hidden: true } };
       const message = new HelpFormatter(new OptionValidator(options), config).formatHelp();
       expect(message.wrap()).toEqual('  -b, --boolean  <boolean>\n');
     });
@@ -232,7 +232,7 @@ describe('HelpFormatter', () => {
           names: [null, '--flag2', null],
         },
       } as const satisfies Options;
-      const config: HelpConfig = { names: { align: 'left' } };
+      const config: FormatterConfig = { names: { align: 'left' } };
       const message = new HelpFormatter(new OptionValidator(options), config).formatHelp();
       expect(message.wrap()).toEqual('  -f, --flag\n  --flag2\n');
     });
@@ -248,7 +248,7 @@ describe('HelpFormatter', () => {
           names: [null, '--flag2', null],
         },
       } as const satisfies Options;
-      const config: HelpConfig = { names: { align: 'right' } };
+      const config: FormatterConfig = { names: { align: 'right' } };
       const message = new HelpFormatter(new OptionValidator(options), config).formatHelp();
       expect(message.wrap()).toEqual('  -f, --flag\n     --flag2\n');
     });
@@ -264,7 +264,7 @@ describe('HelpFormatter', () => {
           names: [null, '--flag2', null],
         },
       } as const satisfies Options;
-      const config: HelpConfig = { names: { align: 'slot' } };
+      const config: FormatterConfig = { names: { align: 'slot' } };
       const message = new HelpFormatter(new OptionValidator(options), config).formatHelp();
       expect(message.wrap()).toEqual('  -f           --flag\n      --flag2\n');
     });
@@ -282,7 +282,7 @@ describe('HelpFormatter', () => {
           example: [1],
         },
       } as const satisfies Options;
-      const config: HelpConfig = { param: { align: 'right' }, items: [] };
+      const config: FormatterConfig = { param: { align: 'right' }, items: [] };
       const message = new HelpFormatter(new OptionValidator(options), config).formatHelp();
       expect(message.wrap()).toEqual('  -ns1  1 2\n  -ns2    1\n');
     });
@@ -295,7 +295,7 @@ describe('HelpFormatter', () => {
           desc: 'A flag option',
         },
       } as const satisfies Options;
-      const config: HelpConfig = { descr: { align: 'right' } };
+      const config: FormatterConfig = { descr: { align: 'right' } };
       const message = new HelpFormatter(new OptionValidator(options), config).formatHelp();
       expect(message.wrap(14, false)).toEqual('  -f    A flag\n        option\n');
     });

--- a/packages/tsargp/test/formatter/formatter.normalization.spec.ts
+++ b/packages/tsargp/test/formatter/formatter.normalization.spec.ts
@@ -49,63 +49,18 @@ describe('HelpFormatter', () => {
       );
     });
 
-    it('should handle a number option with truncation', () => {
+    it('should handle a number option with math conversion', () => {
       const options = {
         number: {
           type: 'number',
           names: ['-n', '--number'],
           desc: 'A number option.',
-          round: 'trunc',
+          conv: 'trunc',
         },
       } as const satisfies Options;
       const message = new HelpFormatter(new OptionValidator(options)).formatHelp();
       expect(message.wrap()).toEqual(
-        `  -n, --number  <number>  A number option. Values will be rounded towards zero.\n`,
-      );
-    });
-
-    it('should handle a number option with ceil rounding', () => {
-      const options = {
-        number: {
-          type: 'number',
-          names: ['-n', '--number'],
-          desc: 'A number option.',
-          round: 'ceil',
-        },
-      } as const satisfies Options;
-      const message = new HelpFormatter(new OptionValidator(options)).formatHelp();
-      expect(message.wrap()).toEqual(
-        `  -n, --number  <number>  A number option. Values will be rounded up.\n`,
-      );
-    });
-
-    it('should handle a number option with floor rounding', () => {
-      const options = {
-        number: {
-          type: 'number',
-          names: ['-n', '--number'],
-          desc: 'A number option.',
-          round: 'floor',
-        },
-      } as const satisfies Options;
-      const message = new HelpFormatter(new OptionValidator(options)).formatHelp();
-      expect(message.wrap()).toEqual(
-        `  -n, --number  <number>  A number option. Values will be rounded down.\n`,
-      );
-    });
-
-    it('should handle a number option with nearest rounding', () => {
-      const options = {
-        number: {
-          type: 'number',
-          names: ['-n', '--number'],
-          desc: 'A number option.',
-          round: 'round',
-        },
-      } as const satisfies Options;
-      const message = new HelpFormatter(new OptionValidator(options)).formatHelp();
-      expect(message.wrap()).toEqual(
-        `  -n, --number  <number>  A number option. Values will be rounded to the nearest integer.\n`,
+        `  -n, --number  <number>  A number option. Values will be converted with Math.trunc.\n`,
       );
     });
 
@@ -189,67 +144,19 @@ describe('HelpFormatter', () => {
       );
     });
 
-    it('should handle a delimited numbers option with truncation', () => {
+    it('should handle a delimited numbers option with math conversion', () => {
       const options = {
         numbers: {
           type: 'numbers',
           names: ['-ns', '--numbers'],
           desc: 'A numbers option.',
           separator: ',',
-          round: 'trunc',
+          conv: 'trunc',
         },
       } as const satisfies Options;
       const message = new HelpFormatter(new OptionValidator(options)).formatHelp();
       expect(message.wrap()).toEqual(
-        `  -ns, --numbers  <numbers>  A numbers option. Values are delimited by ','. Values will be rounded towards zero.\n`,
-      );
-    });
-
-    it('should handle a delimited numbers option with ceil rounding', () => {
-      const options = {
-        numbers: {
-          type: 'numbers',
-          names: ['-ns', '--numbers'],
-          desc: 'A numbers option.',
-          separator: ',',
-          round: 'ceil',
-        },
-      } as const satisfies Options;
-      const message = new HelpFormatter(new OptionValidator(options)).formatHelp();
-      expect(message.wrap()).toEqual(
-        `  -ns, --numbers  <numbers>  A numbers option. Values are delimited by ','. Values will be rounded up.\n`,
-      );
-    });
-
-    it('should handle a delimited numbers option with floor rounding', () => {
-      const options = {
-        numbers: {
-          type: 'numbers',
-          names: ['-ns', '--numbers'],
-          desc: 'A numbers option.',
-          separator: ',',
-          round: 'floor',
-        },
-      } as const satisfies Options;
-      const message = new HelpFormatter(new OptionValidator(options)).formatHelp();
-      expect(message.wrap()).toEqual(
-        `  -ns, --numbers  <numbers>  A numbers option. Values are delimited by ','. Values will be rounded down.\n`,
-      );
-    });
-
-    it('should handle a delimited numbers option with nearest rounding', () => {
-      const options = {
-        numbers: {
-          type: 'numbers',
-          names: ['-ns', '--numbers'],
-          desc: 'A numbers option.',
-          separator: ',',
-          round: 'round',
-        },
-      } as const satisfies Options;
-      const message = new HelpFormatter(new OptionValidator(options)).formatHelp();
-      expect(message.wrap()).toEqual(
-        `  -ns, --numbers  <numbers>  A numbers option. Values are delimited by ','. Values will be rounded to the nearest integer.\n`,
+        `  -ns, --numbers  <numbers>  A numbers option. Values are delimited by ','. Values will be converted with Math.trunc.\n`,
       );
     });
   });

--- a/packages/tsargp/test/formatter/formatter.spec.ts
+++ b/packages/tsargp/test/formatter/formatter.spec.ts
@@ -88,7 +88,7 @@ describe('HelpFormatter', () => {
       } as const satisfies Options;
       const message = new HelpFormatter(new OptionValidator(options)).formatHelp();
       expect(message.wrap()).toEqual(
-        `  -f, --flag    A flag option. Can be negated with [-no-f, --no-flag].\n`,
+        `  -f, --flag    A flag option. Can be negated with -no-f, --no-flag.\n`,
       );
     });
 

--- a/packages/tsargp/test/formatter/formatter.spec.ts
+++ b/packages/tsargp/test/formatter/formatter.spec.ts
@@ -88,7 +88,7 @@ describe('HelpFormatter', () => {
       } as const satisfies Options;
       const message = new HelpFormatter(new OptionValidator(options)).formatHelp();
       expect(message.wrap()).toEqual(
-        `  -f, --flag    A flag option. Can be negated with -no-f or --no-flag.\n`,
+        `  -f, --flag    A flag option. Can be negated with [-no-f, --no-flag].\n`,
       );
     });
 

--- a/packages/tsargp/test/parser/parser.completion.spec.ts
+++ b/packages/tsargp/test/parser/parser.completion.spec.ts
@@ -166,6 +166,25 @@ describe('ArgumentParser', () => {
       expect(() => parser.parse('cmd -s ', { compIndex: 7 })).toThrow(/^$/);
     });
 
+    it('should handle the completion of a positional marker with enums', () => {
+      const options = {
+        string: {
+          type: 'string',
+          names: ['-s'],
+          enums: ['one', 'two'],
+          positional: '--',
+        },
+      } as const satisfies Options;
+      const parser = new ArgumentParser(options);
+      expect(() => parser.parse('cmd ', { compIndex: 4 })).toThrow(/^one\ntwo$/);
+      expect(() => parser.parse('cmd -', { compIndex: 5 })).toThrow(/^-s\n--$/);
+      expect(() => parser.parse('cmd --', { compIndex: 6 })).toThrow(/^--$/);
+      expect(() => parser.parse('cmd -- ', { compIndex: 7 })).toThrow(/^one\ntwo$/);
+      expect(() => parser.parse('cmd -- o', { compIndex: 8 })).toThrow(/^one$/);
+      expect(() => parser.parse('cmd --=', { compIndex: 7 })).toThrow(/^$/);
+      expect(() => parser.parse('cmd -s ', { compIndex: 7 })).toThrow(/^one\ntwo$/);
+    });
+
     it('should handle the completion of a positional boolean option', () => {
       const options = {
         boolean: {

--- a/packages/tsargp/test/parser/parser.constraints.spec.ts
+++ b/packages/tsargp/test/parser/parser.constraints.spec.ts
@@ -32,7 +32,7 @@ describe('ArgumentParser', () => {
       expect(parser.parse([])).toEqual({ string: undefined });
       expect(parser.parse(['-s', 'one'])).toEqual({ string: 'one' });
       expect(() => parser.parse(['-s', 'abc'])).toThrow(
-        `Invalid parameter to -s: 'abc'. Possible values are ['one', 'two'].`,
+        `Invalid parameter to -s: 'abc'. Possible values are {'one', 'two'}.`,
       );
     });
 
@@ -67,7 +67,7 @@ describe('ArgumentParser', () => {
       expect(parser.parse([])).toEqual({ number: undefined });
       expect(parser.parse(['-n', '1'])).toEqual({ number: 1 });
       expect(() => parser.parse(['-n', '3'])).toThrow(
-        `Invalid parameter to -n: 3. Possible values are [1, 2].`,
+        `Invalid parameter to -n: 3. Possible values are {1, 2}.`,
       );
     });
 
@@ -103,7 +103,7 @@ describe('ArgumentParser', () => {
       expect(parser.parse(['-ss', ' one , one '])).toEqual({ strings: ['one', 'one'] });
       expect(parser.parse(['-ss', ' two '])).toEqual({ strings: ['two'] });
       expect(() => parser.parse(['-ss', 'abc'])).toThrow(
-        `Invalid parameter to -ss: 'abc'. Possible values are ['one', 'two'].`,
+        `Invalid parameter to -ss: 'abc'. Possible values are {'one', 'two'}.`,
       );
     });
 
@@ -141,7 +141,7 @@ describe('ArgumentParser', () => {
       expect(parser.parse(['-ns', ' 1 , 1 '])).toEqual({ numbers: [1, 1] });
       expect(parser.parse(['-ns', ' 2 '])).toEqual({ numbers: [2] });
       expect(() => parser.parse(['-ns', '1,3'])).toThrow(
-        `Invalid parameter to -ns: 3. Possible values are [1, 2].`,
+        `Invalid parameter to -ns: 3. Possible values are {1, 2}.`,
       );
     });
 

--- a/packages/tsargp/test/parser/parser.custom.spec.ts
+++ b/packages/tsargp/test/parser/parser.custom.spec.ts
@@ -61,7 +61,7 @@ describe('ArgumentParser', () => {
         number: {
           type: 'number',
           names: ['-n'],
-          round: 'ceil',
+          conv: 'ceil',
           parse: vi.fn().mockImplementation((_0, _1, value) => Number(value) + 2),
         },
       } as const satisfies Options;
@@ -75,7 +75,7 @@ describe('ArgumentParser', () => {
         number: {
           type: 'number',
           names: ['-n'],
-          round: 'ceil',
+          conv: 'ceil',
           parse: async (_0, _1, value) => Number(value) + 2,
         },
       } as const satisfies Options;
@@ -159,40 +159,12 @@ describe('ArgumentParser', () => {
       ]);
     });
 
-    it('should handle a strings option with mixed-async custom delimited parsing', async () => {
-      const options = {
-        strings: {
-          type: 'strings',
-          names: ['-ss'],
-          case: 'upper',
-          append: true,
-          unique: true,
-          parseDelimited: (_0, _1, value: string) => {
-            const res = value.split(',');
-            return value.startsWith('sync') ? res : Promise.resolve(res);
-          },
-        },
-      } as const satisfies Options;
-      const parser = new ArgumentParser(options);
-      expect(() => parser.parse(['-ss'])).toThrow(`Missing parameter to -ss.`);
-      expect(parser.parse(['-ss', 'sync,sync', '-ss', 'sync,sync'])).toEqual({ strings: ['SYNC'] });
-      await expect(
-        parser.parse(['-ss', 'sync,sync', '-ss', 'async,async']).strings,
-      ).resolves.toEqual(['SYNC', 'ASYNC']);
-      await expect(
-        parser.parse(['-ss', 'async,async', '-ss', 'sync,sync']).strings,
-      ).resolves.toEqual(['ASYNC', 'SYNC']);
-      await expect(
-        parser.parse(['-ss', 'async,async', '-ss', 'async,async']).strings,
-      ).resolves.toEqual(['ASYNC']);
-    });
-
     it('should handle a numbers option with mixed-async custom parsing', async () => {
       const options = {
         numbers: {
           type: 'numbers',
           names: ['-ns'],
-          round: 'ceil',
+          conv: 'ceil',
           unique: true,
           parse: vi.fn().mockImplementation((_0, _1, value) => {
             const res = Number(value);
@@ -220,7 +192,7 @@ describe('ArgumentParser', () => {
         numbers: {
           type: 'numbers',
           names: ['-ns'],
-          round: 'ceil',
+          conv: 'ceil',
           append: true,
           unique: true,
           separator: ',',
@@ -247,34 +219,6 @@ describe('ArgumentParser', () => {
         3,
         2,
         4, // order is preserved
-      ]);
-    });
-
-    it('should handle a numbers option with mixed-async custom delimited parsing', async () => {
-      const options = {
-        numbers: {
-          type: 'numbers',
-          names: ['-ns'],
-          round: 'ceil',
-          append: true,
-          unique: true,
-          parseDelimited: (_0, _1, value): Array<number> | Promise<Array<number>> => {
-            const res = value.split(',').map((val) => Number(val));
-            return value.startsWith('1') ? res : Promise.resolve(res);
-          },
-        },
-      } as const satisfies Options;
-      const parser = new ArgumentParser(options);
-      expect(() => parser.parse(['-ns'])).toThrow(`Missing parameter to -ns.`);
-      expect(parser.parse(['-ns', '1.1,1.2', '-ns', '1.1,1.2'])).toEqual({ numbers: [2] });
-      await expect(parser.parse(['-ns', '1.1,1.2', '-ns', '2.1,2.2']).numbers).resolves.toEqual([
-        2, 3,
-      ]);
-      await expect(parser.parse(['-ns', '2.1,2.2', '-ns', '1.1,1.2']).numbers).resolves.toEqual([
-        3, 2,
-      ]);
-      await expect(parser.parse(['-ns', '2.1,2.2', '-ns', '2.1,2.2']).numbers).resolves.toEqual([
-        3,
       ]);
     });
   });

--- a/packages/tsargp/test/parser/parser.default.spec.ts
+++ b/packages/tsargp/test/parser/parser.default.spec.ts
@@ -341,7 +341,7 @@ describe('ArgumentParser', () => {
           type: 'numbers',
           names: ['-ns'],
           default: [1.1, 2.2],
-          round: 'trunc',
+          conv: 'trunc',
         },
       } as const satisfies Options;
       const parser = new ArgumentParser(options);
@@ -354,7 +354,7 @@ describe('ArgumentParser', () => {
           type: 'numbers',
           names: ['-ns'],
           default: () => [1.1, 2.2],
-          round: 'trunc',
+          conv: 'trunc',
         },
       } as const satisfies Options;
       const parser = new ArgumentParser(options);
@@ -367,7 +367,7 @@ describe('ArgumentParser', () => {
           type: 'numbers',
           names: ['-ns'],
           default: async () => [1.1, 2.2],
-          round: 'trunc',
+          conv: 'trunc',
         },
       } as const satisfies Options;
       const parser = new ArgumentParser(options);

--- a/packages/tsargp/test/parser/parser.environment.spec.ts
+++ b/packages/tsargp/test/parser/parser.environment.spec.ts
@@ -114,7 +114,7 @@ describe('ArgumentParser', () => {
           names: ['-ns'],
           envVar: 'NUMBERS',
           separator: ',',
-          round: 'trunc',
+          conv: 'trunc',
           requires: 'required',
         },
         required: {

--- a/packages/tsargp/test/parser/parser.normalization.spec.ts
+++ b/packages/tsargp/test/parser/parser.normalization.spec.ts
@@ -40,12 +40,12 @@ describe('ArgumentParser', () => {
       expect(parser.parse(['-s', 'oNe'])).toEqual({ string: 'ONE' });
     });
 
-    it('should handle a number option with truncation', () => {
+    it('should handle a number option with math normalization', () => {
       const options = {
         number: {
           type: 'number',
           names: ['-n'],
-          round: 'trunc',
+          conv: 'trunc',
         },
       } as const satisfies Options;
       const parser = new ArgumentParser(options);
@@ -55,57 +55,6 @@ describe('ArgumentParser', () => {
       expect(parser.parse(['-n', '-.1'])).toEqual({ number: -0 });
       expect(parser.parse(['-n', '-.5'])).toEqual({ number: -0 });
       expect(parser.parse(['-n', '-.9'])).toEqual({ number: -0 });
-    });
-
-    it('should handle a number option with ceil rounding', () => {
-      const options = {
-        number: {
-          type: 'number',
-          names: ['-n'],
-          round: 'ceil',
-        },
-      } as const satisfies Options;
-      const parser = new ArgumentParser(options);
-      expect(parser.parse(['-n', '0.1'])).toEqual({ number: 1 });
-      expect(parser.parse(['-n', '0.5'])).toEqual({ number: 1 });
-      expect(parser.parse(['-n', '0.9'])).toEqual({ number: 1 });
-      expect(parser.parse(['-n', '-.1'])).toEqual({ number: -0 });
-      expect(parser.parse(['-n', '-.5'])).toEqual({ number: -0 });
-      expect(parser.parse(['-n', '-.9'])).toEqual({ number: -0 });
-    });
-
-    it('should handle a number option with floor rounding', () => {
-      const options = {
-        number: {
-          type: 'number',
-          names: ['-n'],
-          round: 'floor',
-        },
-      } as const satisfies Options;
-      const parser = new ArgumentParser(options);
-      expect(parser.parse(['-n', '0.1'])).toEqual({ number: 0 });
-      expect(parser.parse(['-n', '0.5'])).toEqual({ number: 0 });
-      expect(parser.parse(['-n', '0.9'])).toEqual({ number: 0 });
-      expect(parser.parse(['-n', '-.1'])).toEqual({ number: -1 });
-      expect(parser.parse(['-n', '-.5'])).toEqual({ number: -1 });
-      expect(parser.parse(['-n', '-.9'])).toEqual({ number: -1 });
-    });
-
-    it('should handle a number option with nearest rounding', () => {
-      const options = {
-        number: {
-          type: 'number',
-          names: ['-n'],
-          round: 'round',
-        },
-      } as const satisfies Options;
-      const parser = new ArgumentParser(options);
-      expect(parser.parse(['-n', '0.1'])).toEqual({ number: 0 });
-      expect(parser.parse(['-n', '0.5'])).toEqual({ number: 1 });
-      expect(parser.parse(['-n', '0.9'])).toEqual({ number: 1 });
-      expect(parser.parse(['-n', '-.1'])).toEqual({ number: -0 });
-      expect(parser.parse(['-n', '-.5'])).toEqual({ number: -0 });
-      expect(parser.parse(['-n', '-.9'])).toEqual({ number: -1 });
     });
 
     it('should handle a strings option with trimming normalization', () => {
@@ -147,60 +96,18 @@ describe('ArgumentParser', () => {
       expect(parser.parse(['-ss', 'o?Ne,2ki'])).toEqual({ strings: ['O?NE', '2KI'] });
     });
 
-    it('should handle a numbers option with truncation', () => {
+    it('should handle a numbers option math normalization', () => {
       const options = {
         numbers: {
           type: 'numbers',
           names: ['-ns'],
-          round: 'trunc',
+          conv: 'trunc',
         },
       } as const satisfies Options;
       const parser = new ArgumentParser(options);
       expect(parser.parse(['-ns', '0.1', '-.1'])).toEqual({ numbers: [0, -0] });
       expect(parser.parse(['-ns', '0.5', '-.5'])).toEqual({ numbers: [0, -0] });
       expect(parser.parse(['-ns', '0.9', '-.9'])).toEqual({ numbers: [0, -0] });
-    });
-
-    it('should handle a numbers option with ceil rounding', () => {
-      const options = {
-        numbers: {
-          type: 'numbers',
-          names: ['-ns'],
-          round: 'ceil',
-        },
-      } as const satisfies Options;
-      const parser = new ArgumentParser(options);
-      expect(parser.parse(['-ns', '0.1', '-.1'])).toEqual({ numbers: [1, -0] });
-      expect(parser.parse(['-ns', '0.5', '-.5'])).toEqual({ numbers: [1, -0] });
-      expect(parser.parse(['-ns', '0.9', '-.9'])).toEqual({ numbers: [1, -0] });
-    });
-
-    it('should handle a numbers option with floor rounding', () => {
-      const options = {
-        numbers: {
-          type: 'numbers',
-          names: ['-ns'],
-          round: 'floor',
-        },
-      } as const satisfies Options;
-      const parser = new ArgumentParser(options);
-      expect(parser.parse(['-ns', '0.1', '-.1'])).toEqual({ numbers: [0, -1] });
-      expect(parser.parse(['-ns', '0.5', '-.5'])).toEqual({ numbers: [0, -1] });
-      expect(parser.parse(['-ns', '0.9', '-.9'])).toEqual({ numbers: [0, -1] });
-    });
-
-    it('should handle a numbers option with nearest rounding', () => {
-      const options = {
-        numbers: {
-          type: 'numbers',
-          names: ['-ns'],
-          round: 'round',
-        },
-      } as const satisfies Options;
-      const parser = new ArgumentParser(options);
-      expect(parser.parse(['-ns', '0.1', '-.1'])).toEqual({ numbers: [0, -0] });
-      expect(parser.parse(['-ns', '0.5', '-.5'])).toEqual({ numbers: [1, -0] });
-      expect(parser.parse(['-ns', '0.9', '-.9'])).toEqual({ numbers: [1, -1] });
     });
   });
 });

--- a/packages/tsargp/test/parser/parser.positional.spec.ts
+++ b/packages/tsargp/test/parser/parser.positional.spec.ts
@@ -38,8 +38,8 @@ describe('ArgumentParser', () => {
         },
       } as const satisfies Options;
       const parser = new ArgumentParser(options);
-      expect(() => parser.parse(['--='])).toThrow(`Option -- does not accept inline values.`);
-      expect(() => parser.parse(['--=a'])).toThrow(`Option -- does not accept inline values.`);
+      expect(() => parser.parse(['--='])).toThrow(`Positional marker -- does not accept inline values.`);
+      expect(() => parser.parse(['--=a'])).toThrow(`Positional marker -- does not accept inline values.`);
     });
 
     it('should handle a boolean option with positional arguments', () => {

--- a/packages/tsargp/test/parser/parser.positional.spec.ts
+++ b/packages/tsargp/test/parser/parser.positional.spec.ts
@@ -38,8 +38,12 @@ describe('ArgumentParser', () => {
         },
       } as const satisfies Options;
       const parser = new ArgumentParser(options);
-      expect(() => parser.parse(['--='])).toThrow(`Positional marker -- does not accept inline values.`);
-      expect(() => parser.parse(['--=a'])).toThrow(`Positional marker -- does not accept inline values.`);
+      expect(() => parser.parse(['--='])).toThrow(
+        `Positional marker -- does not accept inline values.`,
+      );
+      expect(() => parser.parse(['--=a'])).toThrow(
+        `Positional marker -- does not accept inline values.`,
+      );
     });
 
     it('should handle a boolean option with positional arguments', () => {
@@ -91,7 +95,7 @@ describe('ArgumentParser', () => {
       } as const satisfies Options;
       const parser = new ArgumentParser(options);
       expect(() => parser.parse(['s'])).toThrow(
-        `Invalid parameter to -s: 's'. Possible values are ['abc'].\n` +
+        `Invalid parameter to -s: 's'. Possible values are {'abc'}.\n` +
           `Did you mean to specify an option name instead of s? Similar names are [-s].\n`,
       );
     });
@@ -158,7 +162,7 @@ describe('ArgumentParser', () => {
       } as const satisfies Options;
       const parser = new ArgumentParser(options);
       expect(() => parser.parse(['1'])).toThrow(
-        `Invalid parameter to -n: 1. Possible values are [123].\n` +
+        `Invalid parameter to -n: 1. Possible values are {123}.\n` +
           `Did you mean to specify an option name instead of 1?\n`,
       );
     });

--- a/packages/tsargp/test/styles/styles.spec.ts
+++ b/packages/tsargp/test/styles/styles.spec.ts
@@ -161,7 +161,7 @@ describe('TerminalString', () => {
       ]);
     });
 
-    it('should format array-valued arguments with brackets', () => {
+    it('should format array-valued arguments with separator', () => {
       const str1 = new TerminalString().splitText('type script');
       const str2 = new TerminalString().formatArgs(styles, '%b %s %n %r %o %v %u %t %p', {
         b: [true, false],
@@ -176,32 +176,32 @@ describe('TerminalString', () => {
       });
       expect(str2.count).toEqual(22);
       expect(str2.strings).toEqual([
-        '[true,',
-        'false]',
-        `['abc',`,
-        `'def']`,
-        '[123,',
-        '456]',
-        '[/def/g,',
-        '/123/i]',
-        '[some name,',
-        'other name]',
-        '[<() => 1>,',
-        '<[object Object]>]',
-        '[https://abc/,',
-        'ftp://def/]',
-        '[some',
+        'true,',
+        'false',
+        `'abc',`,
+        `'def'`,
+        '123,',
+        '456',
+        '/def/g,',
+        '/123/i',
+        'some name,',
+        'other name',
+        '<() => 1>,',
+        '<[object Object]>',
+        'https://abc/,',
+        'ftp://def/',
+        'some',
         'text,',
         'other',
-        'text]',
-        '[type',
+        'text',
+        'type',
         'script,',
         'type',
-        'script]',
+        'script',
       ]);
     });
 
-    it('should format array-valued arguments with separator', () => {
+    it('should format array-valued arguments without merging the separator', () => {
       const str1 = new TerminalString().splitText('type script');
       const str2 = new TerminalString().formatArgs(
         styles,
@@ -217,7 +217,7 @@ describe('TerminalString', () => {
           t: ['some text', 'other text'],
           p: [str1, str1],
         },
-        { sep: '-', merge: false },
+        { sep: '-', mergePrev: false },
       );
       expect(str2.count).toEqual(31);
       expect(str2.strings).toEqual([

--- a/packages/tsargp/test/styles/styles.spec.ts
+++ b/packages/tsargp/test/styles/styles.spec.ts
@@ -99,12 +99,12 @@ describe('TerminalString', () => {
     it('should add closing words to the last word', () => {
       const str = new TerminalString()
         .addWord('type')
-        .addSequence(style(fg.default, bg.default, ul.default))
+        .addSequence(style(fg.default, bg.default, ul.curly))
         .addClosing(']')
         .addClosing('.');
       expect(str).toHaveLength(6);
       expect(str.count).toEqual(2);
-      expect(str.strings).toEqual(['type', '\x9b39;49;59m].']);
+      expect(str.strings).toEqual(['type', '\x9b39;49;4;3m].']);
     });
 
     it('should not merge next words if the closing is empty', () => {

--- a/packages/tsargp/test/utils.spec.ts
+++ b/packages/tsargp/test/utils.spec.ts
@@ -162,16 +162,27 @@ describe('splitPhrase', () => {
     expect(splitPhrase('')).toEqual(['']);
   });
 
-  it('should handle a phrase with just words', () => {
-    expect(splitPhrase('type (script) is fun')).toEqual(['type (script) is fun']);
+  it('should handle a phrase with no groups', () => {
+    expect(splitPhrase('type|script (is fun)')).toEqual(['type|script (is fun)']);
   });
 
-  it('should handle a phrase with words and groups', () => {
+  it('should handle a phrase with unmatched parentheses', () => {
+    expect(splitPhrase('type (script')).toEqual(['type (script']);
+    expect(splitPhrase('type )script')).toEqual(['type )script']);
+  });
+
+  it('should handle a phrase with empty groups', () => {
+    expect(splitPhrase('(|) type')).toEqual([' type', ' type']);
+    expect(splitPhrase('script (|)')).toEqual(['script ', 'script ']);
+    expect(splitPhrase('is (|)fun')).toEqual(['is fun', 'is fun']);
+  });
+
+  it('should handle a phrase with non-empty groups', () => {
     expect(splitPhrase('(type|script) is fun')).toEqual(['type is fun', 'script is fun']);
   });
 
-  it('should handle a phrase with groups with empty alternatives', () => {
-    expect(splitPhrase('(|) is fun')).toEqual([' is fun', ' is fun']);
+  it('should handle a phrase with parentheses inside groups', () => {
+    expect(splitPhrase('((type)|(script)) is fun')).toEqual(['(type) is fun', '(script) is fun']);
   });
 });
 

--- a/packages/tsargp/test/validator/validator.constraints.spec.ts
+++ b/packages/tsargp/test/validator/validator.constraints.spec.ts
@@ -64,7 +64,7 @@ describe('OptionValidator', () => {
       } as const satisfies Options;
       const validator = new OptionValidator(options);
       expect(() => validator.validate()).toThrow(
-        `Invalid parameter to string: 'abc'. Possible values are ['one', 'two'].`,
+        `Invalid parameter to string: 'abc'. Possible values are {'one', 'two'}.`,
       );
     });
 
@@ -79,7 +79,7 @@ describe('OptionValidator', () => {
       } as const satisfies Options;
       const validator = new OptionValidator(options);
       expect(() => validator.validate()).toThrow(
-        `Invalid parameter to string: 'abc'. Possible values are ['one', 'two'].`,
+        `Invalid parameter to string: 'abc'. Possible values are {'one', 'two'}.`,
       );
     });
 
@@ -98,7 +98,7 @@ describe('OptionValidator', () => {
       } as const satisfies Options;
       const validator = new OptionValidator(options);
       expect(() => validator.validate()).toThrow(
-        `Invalid parameter to required: 'abc'. Possible values are ['one', 'two'].`,
+        `Invalid parameter to required: 'abc'. Possible values are {'one', 'two'}.`,
       );
     });
 
@@ -188,7 +188,7 @@ describe('OptionValidator', () => {
       } as const satisfies Options;
       const validator = new OptionValidator(options);
       expect(() => validator.validate()).toThrow(
-        `Invalid parameter to number: 3. Possible values are [1, 2].`,
+        `Invalid parameter to number: 3. Possible values are {1, 2}.`,
       );
     });
 
@@ -203,7 +203,7 @@ describe('OptionValidator', () => {
       } as const satisfies Options;
       const validator = new OptionValidator(options);
       expect(() => validator.validate()).toThrow(
-        `Invalid parameter to number: 3. Possible values are [1, 2].`,
+        `Invalid parameter to number: 3. Possible values are {1, 2}.`,
       );
     });
 
@@ -222,7 +222,7 @@ describe('OptionValidator', () => {
       } as const satisfies Options;
       const validator = new OptionValidator(options);
       expect(() => validator.validate()).toThrow(
-        `Invalid parameter to required: 3. Possible values are [1, 2].`,
+        `Invalid parameter to required: 3. Possible values are {1, 2}.`,
       );
     });
 
@@ -290,7 +290,7 @@ describe('OptionValidator', () => {
       } as const satisfies Options;
       const validator = new OptionValidator(options);
       expect(() => validator.validate()).toThrow(
-        `Invalid parameter to strings: 'abc'. Possible values are ['one', 'two'].`,
+        `Invalid parameter to strings: 'abc'. Possible values are {'one', 'two'}.`,
       );
     });
 
@@ -306,7 +306,7 @@ describe('OptionValidator', () => {
       } as const satisfies Options;
       const validator = new OptionValidator(options);
       expect(() => validator.validate()).toThrow(
-        `Invalid parameter to strings: 'abc'. Possible values are ['one', 'two'].`,
+        `Invalid parameter to strings: 'abc'. Possible values are {'one', 'two'}.`,
       );
     });
 
@@ -326,7 +326,7 @@ describe('OptionValidator', () => {
       } as const satisfies Options;
       const validator = new OptionValidator(options);
       expect(() => validator.validate()).toThrow(
-        `Invalid parameter to required: 'abc'. Possible values are ['one', 'two'].`,
+        `Invalid parameter to required: 'abc'. Possible values are {'one', 'two'}.`,
       );
     });
 
@@ -443,7 +443,7 @@ describe('OptionValidator', () => {
       } as const satisfies Options;
       const validator = new OptionValidator(options);
       expect(() => validator.validate()).toThrow(
-        `Invalid parameter to numbers: 3. Possible values are [1, 2].`,
+        `Invalid parameter to numbers: 3. Possible values are {1, 2}.`,
       );
     });
 
@@ -459,7 +459,7 @@ describe('OptionValidator', () => {
       } as const satisfies Options;
       const validator = new OptionValidator(options);
       expect(() => validator.validate()).toThrow(
-        `Invalid parameter to numbers: 3. Possible values are [1, 2].`,
+        `Invalid parameter to numbers: 3. Possible values are {1, 2}.`,
       );
     });
 
@@ -479,7 +479,7 @@ describe('OptionValidator', () => {
       } as const satisfies Options;
       const validator = new OptionValidator(options);
       expect(() => validator.validate()).toThrow(
-        `Invalid parameter to required: 3. Possible values are [1, 2].`,
+        `Invalid parameter to required: 3. Possible values are {1, 2}.`,
       );
     });
 

--- a/packages/tsargp/test/validator/validator.constraints.spec.ts
+++ b/packages/tsargp/test/validator/validator.constraints.spec.ts
@@ -102,6 +102,32 @@ describe('OptionValidator', () => {
       );
     });
 
+    it('should throw an error on number option with invalid range', () => {
+      const options = {
+        number: {
+          type: 'number',
+          names: ['-n'],
+          range: [0, 0],
+        },
+      } as const satisfies Options;
+      const validator = new OptionValidator(options);
+      expect(() => validator.validate()).toThrow(`Option number has invalid numeric range [0, 0].`);
+    });
+
+    it('should throw an error on number option with invalid range with NaN', () => {
+      const options = {
+        number: {
+          type: 'number',
+          names: ['-n'],
+          range: [0, NaN],
+        },
+      } as const satisfies Options;
+      const validator = new OptionValidator(options);
+      expect(() => validator.validate()).toThrow(
+        `Option number has invalid numeric range [0, NaN].`,
+      );
+    });
+
     it('should throw an error on number example value not in range', () => {
       const options = {
         number: {


### PR DESCRIPTION
Removed the `parseDelimited` attribute in anticipation for a new and better feature yet to be implemented. This parsing callback was not really important, whereas the same effect can be achieved with the `parse` callback by modifying the previous option value.

Improved the formatting of custom phrases for both error and help messages. Now they can contain multiple groups referencing the same phrase alternatives across groups. This also allowed the help item phrases to use specifiers for different value data types.

Added a new kind of validation, `invalidNumericRange`, for the option's numeric range definition. Some other enumerators were merged into one that uses a phrase containing different format specifiers for each alternative.

Refactored the `ul` enumeration into a constant that holds underline styles instead of underline colors (since it had just one color that was not strictly necessary).

The documentation was updated in many places to reflect the above changes.