### PR TITLE
Issues/85

### DIFF
--- a/.changeset/breezy-yaks-bathe.md
+++ b/.changeset/breezy-yaks-bathe.md
@@ -1,0 +1,5 @@
+---
+'tsargp': minor
+---
+
+Added the `ConnectiveWords` enumeration to be used together with the `connectives` property of the validator configuration, in order to customize the formatting of option requirements.

--- a/.changeset/cuddly-seals-march.md
+++ b/.changeset/cuddly-seals-march.md
@@ -1,0 +1,5 @@
+---
+'@trulysimple/tsargp-docs': minor
+---
+
+Added a sub-section called "Connective words" in the Validator page, to document the new `ConnectiveWords` enumeration.

--- a/packages/docs/pages/docs/library/validator.mdx
+++ b/packages/docs/pages/docs/library/validator.mdx
@@ -352,10 +352,11 @@ requirements, in both error and help messages. It has the following optional pro
 the enumerators from `ConnectiveWords`:
 
 - `and` - the word used to connect two logical expressions in conjunction
-- `or` - the word to connect two logical expressions in disjunction
-- `not` - the word to connect a logical expression in negation
-- `equals` - the word to connect two expressions in equality comparison
-- `notEquals` - the word to connect two expressions in non-equality comparison
+- `or` - the word used to connect two logical expressions in disjunction
+- `not` - the word used to connect a logical expression in negation
+- `no` - the word used to connect a logical expression in non-existence
+- `equals` - the word used to connect two expressions in equality comparison
+- `notEquals` - the word used to connect two expressions in non-equality comparison
 
 [value validation]: #value-validation
 [negation names]: options#negation-names

--- a/packages/docs/pages/docs/library/validator.mdx
+++ b/packages/docs/pages/docs/library/validator.mdx
@@ -267,7 +267,8 @@ The `ErrorItem` enumeration lists the kinds of error messages that may be raised
 
 ### Error phrases
 
-The `phrases` property specifies the phrases to be used for each kind of error message:
+The `phrases` property specifies the phrases to be used for each kind of error message. It has the
+following optional properties, which are the enumerators from `ErrorItem`:
 
 - `parseError` - `'Did you mean to specify an option name instead of (%o|%o1)?(| Similar names are [%o2].)'{:ts}`
 - `unknownOption` - `'Unknown option (%o|%o1).(| Similar names are [%o2].)'{:ts}`
@@ -343,6 +344,18 @@ with a description of the corresponding value:
 | invalidClusterLetter       | `%o` = the option's key; `%s` = the invalid letter                                          |
 | tooSimilarOptionNames      | `%o` = the command prefix[^1]; `%s1` = the option name; `%s2` = the similar names           |
 | mixedNamingConvention      | `%o` = the command prefix[^1]; `%n` = the slot index; `%s` = the naming conventions         |
+
+### Connective words
+
+The `connectives` property specifies the connective words to be used in the formatting of option
+requirements, in both error and help messages. It has the following optional properties, which are
+the enumerators from `ConnectiveWords`:
+
+- `and` - the word used to connect two logical expressions in conjunction
+- `or` - the word to connect two logical expressions in disjunction
+- `not` - the word to connect a logical expression in negation
+- `equals` - the word to connect two expressions in equality comparison
+- `notEquals` - the word to connect two expressions in non-equality comparison
 
 [value validation]: #value-validation
 [negation names]: options#negation-names

--- a/packages/tsargp/lib/enums.ts
+++ b/packages/tsargp/lib/enums.ts
@@ -246,6 +246,36 @@ export const enum HelpItem {
 }
 
 /**
+ * The kind of connective words used in option requirements.
+ */
+export const enum ConnectiveWords {
+  /**
+   * The word used to connect two logical expressions in conjunction.
+   */
+  and,
+  /**
+   * The word used to connect two logical expressions in disjunction.
+   */
+  or,
+  /**
+   * The word used to connect a logical expression in negation.
+   */
+  not,
+  /**
+   * The word used to connect a logical expression in non-existence.
+   */
+  no,
+  /**
+   * The word used to connect two expressions in equality comparison.
+   */
+  equals,
+  /**
+   * The word used to connect two expressions in non-equality comparison.
+   */
+  notEquals,
+}
+
+/**
  * A control sequence introducer command.
  * @see https://xtermjs.org/docs/api/vtfeatures/#csi
  */

--- a/packages/tsargp/lib/validator.ts
+++ b/packages/tsargp/lib/validator.ts
@@ -5,7 +5,7 @@ import type { OpaqueOption, Options, Requires, RequiresVal, OpaqueOptions } from
 import type { FormatArgs, FormattingFlags, FormatStyles, MessageStyles } from './styles';
 import type { Concrete, NamingRules } from './utils';
 
-import { tf, fg, ErrorItem } from './enums';
+import { tf, fg, ErrorItem, ConnectiveWords } from './enums';
 import {
   RequiresAll,
   RequiresOne,
@@ -78,6 +78,14 @@ export const defaultConfig: ConcreteConfig = {
     [ErrorItem.mixedNamingConvention]: '%o: Name slot %n has mixed naming conventions [%s].',
     [ErrorItem.invalidNumericRange]: 'Option %o has invalid numeric range [%n].',
   },
+  connectives: {
+    [ConnectiveWords.and]: 'and',
+    [ConnectiveWords.or]: 'or',
+    [ConnectiveWords.not]: 'not',
+    [ConnectiveWords.no]: 'no',
+    [ConnectiveWords.equals]: '==',
+    [ConnectiveWords.notEquals]: '!=',
+  },
 };
 
 /**
@@ -110,13 +118,17 @@ const namingConventions: NamingRules = {
  */
 export type ValidatorConfig = {
   /**
-   * The message styles
+   * The message styles.
    */
   readonly styles?: MessageStyles;
   /**
-   * The message phrases
+   * The message phrases.
    */
   readonly phrases?: Readonly<Partial<Record<ErrorItem, string>>>;
+  /**
+   * The connective words.
+   */
+  readonly connectives?: Readonly<Partial<Record<ConnectiveWords, string>>>;
 };
 
 /**

--- a/packages/tsargp/test/formatter/formatter.requirements.spec.ts
+++ b/packages/tsargp/test/formatter/formatter.requirements.spec.ts
@@ -91,7 +91,7 @@ describe('HelpFormatter', () => {
         },
       } as const satisfies Options;
       const message = new HelpFormatter(new OptionValidator(options)).formatHelp();
-      expect(message.wrap()).toEqual(`  -f, --flag    A flag option. Requires -req = 'abc'.\n`);
+      expect(message.wrap()).toEqual(`  -f, --flag    A flag option. Requires -req == 'abc'.\n`);
     });
 
     it('should handle an option with a forward requirement expression', () => {
@@ -120,7 +120,7 @@ describe('HelpFormatter', () => {
       } as const satisfies Options;
       const message = new HelpFormatter(new OptionValidator(options)).formatHelp();
       expect(message.wrap()).toEqual(
-        `  -f, --flag    A flag option. Requires (-req1 and (-req2 = 1 or -req3 != '2')).\n`,
+        `  -f, --flag    A flag option. Requires (-req1 and (-req2 == 1 or -req3 != '2')).\n`,
       );
     });
 
@@ -239,7 +239,7 @@ describe('HelpFormatter', () => {
         },
       } as const satisfies Options;
       const message = new HelpFormatter(new OptionValidator(options)).formatHelp();
-      expect(message.wrap()).toEqual(`  -f, --flag    A flag option. Required if -req = 'abc'.\n`);
+      expect(message.wrap()).toEqual(`  -f, --flag    A flag option. Required if -req == 'abc'.\n`);
     });
 
     it('should handle an option with a conditional requirement expression', () => {
@@ -268,7 +268,7 @@ describe('HelpFormatter', () => {
       } as const satisfies Options;
       const message = new HelpFormatter(new OptionValidator(options)).formatHelp();
       expect(message.wrap()).toEqual(
-        `  -f, --flag    A flag option. Required if (-req1 and (-req2 = 1 or -req3 != '2')).\n`,
+        `  -f, --flag    A flag option. Required if (-req1 and (-req2 == 1 or -req3 != '2')).\n`,
       );
     });
 

--- a/packages/tsargp/test/parser/parser.requirements.spec.ts
+++ b/packages/tsargp/test/parser/parser.requirements.spec.ts
@@ -348,10 +348,10 @@ describe('ArgumentParser', () => {
       const parser = new ArgumentParser(options);
       await expect(parser.parse([])).resolves.toMatchObject({});
       await expect(parser.parse(['-f'])).rejects.toThrow(`Option -f requires -f2.`);
-      await expect(parser.parse(['-f', '-f2'])).rejects.toThrow(`Option -f requires -f2 = false.`);
+      await expect(parser.parse(['-f', '-f2'])).rejects.toThrow(`Option -f requires -f2 == false.`);
       await expect(parser.parse(['-f', '--no-f2'])).rejects.toThrow(`Option -f requires -b.`);
       await expect(parser.parse(['-f', '--no-f2', '-b', '0'])).rejects.toThrow(
-        `Option -f requires -b = true.`,
+        `Option -f requires -b == true.`,
       );
       await expect(parser.parse(['-f', '--no-f2', '-b', '1'])).resolves.toMatchObject({});
     });
@@ -379,11 +379,11 @@ describe('ArgumentParser', () => {
       await expect(parser.parse([])).resolves.toMatchObject({});
       await expect(parser.parse(['-f'])).rejects.toThrow(`Option -f requires -s.`);
       await expect(parser.parse(['-f', '-s', 'x'])).rejects.toThrow(
-        `Option -f requires -s = 'abc'.`,
+        `Option -f requires -s == 'abc'.`,
       );
       await expect(parser.parse(['-f', '-s', 'abc'])).rejects.toThrow(`Option -f requires -ss.`);
       await expect(parser.parse(['-f', '-s', 'abc', '-ss', ''])).rejects.toThrow(
-        `Option -f requires -ss = ['a'].`,
+        `Option -f requires -ss == ['a'].`,
       );
       await expect(parser.parse(['-f', '-s', 'abc', '-ss', 'a'])).resolves.toMatchObject({});
     });
@@ -410,10 +410,12 @@ describe('ArgumentParser', () => {
       const parser = new ArgumentParser(options);
       await expect(parser.parse([])).resolves.toMatchObject({});
       await expect(parser.parse(['-f'])).rejects.toThrow(`Option -f requires -n.`);
-      await expect(parser.parse(['-f', '-n', '1'])).rejects.toThrow(`Option -f requires -n = 123.`);
+      await expect(parser.parse(['-f', '-n', '1'])).rejects.toThrow(
+        `Option -f requires -n == 123.`,
+      );
       await expect(parser.parse(['-f', '-n', '123'])).rejects.toThrow(`Option -f requires -ns.`);
       await expect(parser.parse(['-f', '-n', '123', '-ns', ''])).rejects.toThrow(
-        `Option -f requires -ns = [1].`,
+        `Option -f requires -ns == [1].`,
       );
       await expect(parser.parse(['-f', '-n', '123', '-ns', '1'])).resolves.toMatchObject({});
     });
@@ -793,7 +795,7 @@ describe('ArgumentParser', () => {
     await expect(parser.parse(['--no-f2'])).resolves.toMatchObject({});
     await expect(parser.parse(['--no-f2', '-b', '0'])).resolves.toMatchObject({});
     await expect(parser.parse(['--no-f2', '-b', '1'])).rejects.toThrow(
-      `Option -f is required if (-f2 = false and -b = true).`,
+      `Option -f is required if (-f2 == false and -b == true).`,
     );
   });
 
@@ -822,7 +824,7 @@ describe('ArgumentParser', () => {
     await expect(parser.parse(['-s', 'abc'])).resolves.toMatchObject({});
     await expect(parser.parse(['-s', 'abc', '-ss', ''])).resolves.toMatchObject({});
     await expect(parser.parse(['-s', 'abc', '-ss', 'a'])).rejects.toThrow(
-      `Option -f is required if (-s = 'abc' and -ss = ['a']).`,
+      `Option -f is required if (-s == 'abc' and -ss == ['a']).`,
     );
   });
 
@@ -851,7 +853,7 @@ describe('ArgumentParser', () => {
     await expect(parser.parse(['-n', '123'])).resolves.toMatchObject({});
     await expect(parser.parse(['-n', '123', '-ns', ''])).resolves.toMatchObject({});
     await expect(parser.parse(['-n', '123', '-ns', '1'])).rejects.toThrow(
-      `Option -f is required if (-n = 123 and -ns = [1]).`,
+      `Option -f is required if (-n == 123 and -ns == [1]).`,
     );
   });
 


### PR DESCRIPTION
Added the `ConnectiveWords` enumeration to be used together with the `connectives` property of the validator configuration, in order to customize the formatting of option requirements.

Added a sub-section called "Connective words" in the Validator page, to document the new enumeration.

Closes #85 
