### PR TITLE
Issues/90

### DIFF
--- a/.changeset/cold-rice-shop.md
+++ b/.changeset/cold-rice-shop.md
@@ -1,0 +1,5 @@
+---
+'@trulysimple/tsargp-docs': minor
+---
+
+The Parser page was updated to document the new `ParseInfo` type, along with information regarding the parsing callbacks. The Options page was updated to document changes made to the parsing callbacks. The `parseError` enumerator was removed from the Validator page, since it is no longer supported.

--- a/.changeset/slimy-falcons-press.md
+++ b/.changeset/slimy-falcons-press.md
@@ -1,0 +1,5 @@
+---
+'tsargp': minor
+---
+
+The parsing callbacks were refactored to accept a single parameter of type `ParseInfo`, which contains information about the current argument sequence in the parsing loop. The loop itself was refactored to accumulate a sequence of arguments that will be passed to the parsing callbacks as the option parameter(s). The `parseError` enumerator was removed from the `ErrorItem`, since it is no longer supported.

--- a/packages/docs/pages/docs/library/options.mdx
+++ b/packages/docs/pages/docs/library/options.mdx
@@ -282,7 +282,7 @@ Notes about this callback:
 
 #### Parse callback
 
-The `parse` attribute, if present, specifies a custom callback to parse the value of the option
+The `parse` attribute, if present, specifies a [custom callback] to parse the value of the option
 parameter(s).
 
 It accepts a single parameter that contains the current [argument information], in which `param`
@@ -472,7 +472,7 @@ In addition to the set of [value attributes], it has the following attributes.
 
 #### Execute callback
 
-The `exec` attribute specifies the callback function that should be executed.
+The `exec` attribute specifies the [custom callback] function that should be executed.
 
 It accepts a single parameter that contains the current [argument information], in which `param`
 holds the remaining command-line arguments. The `comp` property indicates whether word completion is
@@ -535,11 +535,11 @@ In addition to the set of [value attributes], it has the following attributes.
 
 #### Command callback
 
-The `exec` attribute specifies the callback function that should be executed.
+The `exec` attribute specifies the [custom callback] function that should be executed.
 
 It accepts a single parameter that contains the current [argument information], in which `param`
 holds the values parsed for the command. The `comp` property will always be `false{:ts}` in the case
-of a nested command, since word completion.
+of a nested command, since word completion is handled during the parsing of the remaining arguments.
 
 Notes about this callback:
 

--- a/packages/docs/pages/docs/library/options.mdx
+++ b/packages/docs/pages/docs/library/options.mdx
@@ -267,13 +267,12 @@ When using this attribute, we recommend also setting [preferred name] to some ex
 
 #### Complete callback
 
-The `complete` attribute, if present, specifies a custom completion callback. This can be used to
-make better suggestions for bash completion than the [default algorithm] would do for the option. It
-accepts three parameters:
+The `complete` attribute, if present, specifies a [custom callback] for word completion. This can be
+used to make better suggestions than the [default algorithm] would do for the option.
 
-- `values` - the values parsed up to the current iteration
-- `comp` - the word being completed (it may be an empty string)
-- `rest` - the remaining command-line arguments
+It accepts a single parameter that contains the current [argument information], in which `comp` is
+the word being completed. In the case of array-valued options, the `param` property holds the option
+parameters preceding `comp`, if any.
 
 Notes about this callback:
 
@@ -284,16 +283,16 @@ Notes about this callback:
 #### Parse callback
 
 The `parse` attribute, if present, specifies a custom callback to parse the value of the option
-parameter. It accepts three parameters:
+parameter(s).
 
-- `values` - the values parsed up to the current iteration
-- `name` - the option name, as was specified on the command-line
-- `value` - the parameter string value
+It accepts a single parameter that contains the current [argument information], in which `param`
+holds the option parameter(s). The `comp` property indicates whether word completion is in effect
+(but not in the current iteration).
 
 Notes about this callback:
 
 - it can be asynchronous
-- it should return a value compatible with the option type (this should not be an array)
+- it should return the new option value
 
 #### Enumeration
 
@@ -473,18 +472,17 @@ In addition to the set of [value attributes], it has the following attributes.
 
 #### Execute callback
 
-The `exec` attribute specifies the callback function that should be executed. It is required and
-accepts three parameters:
+The `exec` attribute specifies the callback function that should be executed.
 
-- `values` - the values parsed up to the current iteration
-- `comp` - whether bash completion is in effect (but not in the current iteration)
-- `rest` - the remaining command-line arguments
+It accepts a single parameter that contains the current [argument information], in which `param`
+holds the remaining command-line arguments. The `comp` property indicates whether word completion is
+in effect (but not in the current iteration).
 
 Notes about this callback:
 
 - it can be asynchronous
 - the returned value, if any, will be saved as the option value
-- altering the `rest` parameter will have _no_ effect on the original command-line arguments
+- altering the `param` property will have _no_ effect on the original command-line arguments
 
 <Callout type="default">
   Inside this callback, you may check whether an option has been specified before it by comparing
@@ -537,11 +535,11 @@ In addition to the set of [value attributes], it has the following attributes.
 
 #### Command callback
 
-The `cmd` attribute specifies the callback function that should be executed. It is required and
-accepts two parameters:
+The `exec` attribute specifies the callback function that should be executed.
 
-- `values` - the values parsed for the parent command
-- `cmdValues` - the values parsed for the command
+It accepts a single parameter that contains the current [argument information], in which `param`
+holds the values parsed for the command. The `comp` property will always be `false{:ts}` in the case
+of a nested command, since word completion.
 
 Notes about this callback:
 
@@ -712,6 +710,7 @@ attributes:
 [help sections]: formatter#help-sections
 [option filters]: formatter#option-filters
 [custom callback]: parser#custom-callbacks
+[argument information]: parser#argument-information
 [`parseInto`]: parser#using-your-own-object
 [`shortStyle`]: parser#short-option-style
 [formatter configuration]: formatter#help-format

--- a/packages/docs/pages/docs/library/parser.mdx
+++ b/packages/docs/pages/docs/library/parser.mdx
@@ -117,8 +117,8 @@ applications, since argument parsing is usually done at the top-level of a modul
 
 #### Argument information
 
-The `ParseInfo` object is passed as parameter to some of the aforementioned callbacks, and contains
-information about the current argument sequence in the parsing loop:
+The `ParseInfo` object is passed as the parameter of some of the aforementioned callbacks, and
+contains information about the current argument sequence in the parsing loop:
 
 - `values` -
   The previously parsed values. It is an opaque type that should be cast to

--- a/packages/docs/pages/docs/library/parser.mdx
+++ b/packages/docs/pages/docs/library/parser.mdx
@@ -115,6 +115,25 @@ Besides, the asynchronous version has the benefit of allowing us to perform some
 concurrently, such as the requirements verification. This should not be a drawback for most CLI
 applications, since argument parsing is usually done at the top-level of a module or script.
 
+#### Argument information
+
+The `ParseInfo` object is passed as parameter to some of the aforementioned callbacks, and contains
+information about the current argument sequence in the parsing loop:
+
+- `values` -
+  The previously parsed values. It is an opaque type that should be cast to
+  `OptionValues<typeof your_options>{:ts}`.
+- `index` -
+  The index of the occurrence of the option name, or of the first option parameter. It will be
+  `NaN{:ts}` if the sequence comes from an environment variable.
+- `name` -
+  The option name as specified on the command-line, or the environment variable name.
+  It will be the option's [preferred name] if the sequence comes from positional arguments.
+- `param` -
+  The option parameter(s), or the parameters preceding the word being completed, if any.
+- `comp` -
+  True if performing word completion, or the word being completed.
+
 ### Word completion
 
 Quoting the [Bash docs]:
@@ -245,6 +264,7 @@ they would pollute the output of process management utilities such as `ps`.
 [execute callback]: options#execute-callback
 [command callback]: options#command-callback
 [warning messages]: styles#warning-message
+[preferred name]: options#names--preferred-name
 [`break`]: options#break-loop
 [Set]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set
 [Bash docs]: https://www.gnu.org/software/bash/manual/html_node/Programmable-Completion.html

--- a/packages/docs/pages/docs/library/parser.mdx
+++ b/packages/docs/pages/docs/library/parser.mdx
@@ -205,16 +205,9 @@ any errors that occur during parsing and it does not make sense to verify requir
 
 ### Name suggestions
 
-During parsing, there are two situations in which the parser might suggest option names:
-
-- when it expects an option name and the current argument is not a valid name (and there is no
-  positional option)
-- when it expects an option parameter and the current argument fails to be parsed, and the affected
-  option is a variadic array option (but only if the argument was specified neither with a
-  positional marker nor as an [inline parameter])
-
-In these cases, the parser selects option names that are similar to the current argument using the
-[Gestalt algorithm], and includes them in the error message.
+When the parser expects an option name and the current argument is not a valid one (and there is no
+positional option), it may select option names that are similar to the current argument using the
+[Gestalt algorithm], and include them in the error message.
 
 ### Error messages
 

--- a/packages/docs/pages/docs/library/validator.mdx
+++ b/packages/docs/pages/docs/library/validator.mdx
@@ -193,9 +193,6 @@ optional properties:
 
 The `ErrorItem` enumeration lists the kinds of error messages that may be raised by the library:
 
-- `parseError` -
-  raised by the parser when an option parameter fails to be parsed, with possible option name
-  suggestions
 - `unknownOption` -
   raised by the parser when an option name is not found, with possible option name suggestions
 - `unsatisfiedRequirement` -
@@ -270,7 +267,6 @@ The `ErrorItem` enumeration lists the kinds of error messages that may be raised
 The `phrases` property specifies the phrases to be used for each kind of error message. It has the
 following optional properties, which are the enumerators from `ErrorItem`:
 
-- `parseError` - `'Did you mean to specify an option name instead of (%o|%o1)?(| Similar names are [%o2].)'{:ts}`
 - `unknownOption` - `'Unknown option (%o|%o1).(| Similar names are [%o2].)'{:ts}`
 - `unsatisfiedRequirement` - `'Option %o requires %p.'{:ts}`
 - `missingRequiredOption` - `'Option %o is required.'{:ts}`
@@ -313,7 +309,6 @@ with a description of the corresponding value:
 
 | Error                      | Specifiers                                                                                  |
 | -------------------------- | ------------------------------------------------------------------------------------------- |
-| parseError                 | `%o`/`%o1` = the unknown option name; `%o2` = similar option names                          |
 | unknownOption              | `%o`/`%o1` = the unknown option name; `%o2` = similar option names                          |
 | unsatisfiedRequirement     | `%o` = the specified option name; `%p` = the option's requirements                          |
 | missingRequiredOption      | `%o` = the option's preferred name                                                          |

--- a/packages/docs/typedoc.json
+++ b/packages/docs/typedoc.json
@@ -21,6 +21,8 @@
     "WithRegex",
     "WithRange",
     "WithVerInfo",
-    "WithResolve"
+    "WithResolve",
+    "WithAppend",
+    "WithParse"
   ]
 }

--- a/packages/tsargp/examples/calc.options.ts
+++ b/packages/tsargp/examples/calc.options.ts
@@ -44,8 +44,8 @@ const addOpts = {
     names: ['add'],
     desc: 'A command that sums multiple numbers.',
     options: (): Options => ({ ...multiOpts, ...mainOpts }),
-    cmd(_, cmdValues): number {
-      const vals = cmdValues as OptionValues<typeof multiOpts & typeof mainOpts>;
+    exec({ param }): number {
+      const vals = param as OptionValues<typeof multiOpts & typeof mainOpts>;
       const other = vals.add ?? vals.sub ?? vals.mult ?? vals.div ?? 0;
       return vals.numbers.reduce((acc, val) => acc + val, other);
     },
@@ -64,8 +64,8 @@ const subOpts = {
     names: ['sub'],
     desc: 'A command that subtracts two numbers.',
     options: (): Options => ({ ...binaryOpts, ...mainOpts }),
-    cmd(_, cmdValues): number {
-      const vals = cmdValues as OptionValues<typeof binaryOpts & typeof mainOpts>;
+    exec({ param }): number {
+      const vals = param as OptionValues<typeof binaryOpts & typeof mainOpts>;
       const other = vals.add ?? vals.sub ?? vals.mult ?? vals.div ?? NaN;
       const [a, b] = vals.numbers;
       return a === undefined ? NaN : b === undefined ? a - other : a - b;
@@ -85,8 +85,8 @@ const multOpts = {
     names: ['mult'],
     desc: 'A command that multiplies multiple numbers.',
     options: (): Options => ({ ...multiOpts, ...mainOpts }),
-    cmd(_, cmdValues): number {
-      const vals = cmdValues as OptionValues<typeof multiOpts & typeof mainOpts>;
+    exec({ param }): number {
+      const vals = param as OptionValues<typeof multiOpts & typeof mainOpts>;
       const other = vals.add ?? vals.sub ?? vals.mult ?? vals.div ?? 1;
       return vals.numbers.reduce((acc, val) => acc * val, other);
     },
@@ -105,8 +105,8 @@ const divOpts = {
     names: ['div'],
     desc: 'A command that divides two numbers.',
     options: (): Options => ({ ...binaryOpts, ...mainOpts }),
-    cmd(_, cmdValues): number {
-      const vals = cmdValues as OptionValues<typeof binaryOpts & typeof mainOpts>;
+    exec({ param }): number {
+      const vals = param as OptionValues<typeof binaryOpts & typeof mainOpts>;
       const other = vals.add ?? vals.sub ?? vals.mult ?? vals.div ?? NaN;
       const [a, b] = vals.numbers;
       return a === undefined ? NaN : b === undefined ? a / other : a / b;

--- a/packages/tsargp/examples/demo.options.ts
+++ b/packages/tsargp/examples/demo.options.ts
@@ -29,8 +29,8 @@ const helloOpts = {
     names: ['hello'],
     desc: 'A recursive command option. Logs the arguments passed after it.',
     options: (): Options => helloOpts,
-    cmd(_, cmdValues): number {
-      const vals = cmdValues as OptionValues<typeof helloOpts>;
+    exec({ param }): number {
+      const vals = param as OptionValues<typeof helloOpts>;
       const calls = vals.command ?? 0;
       console.log(`[tail call #${calls}]`, ...vals.strings);
       return calls + 1;
@@ -64,7 +64,7 @@ export default {
     names: ['help'],
     desc: 'Prints the help of a nested command.',
     options: helpOpts,
-    cmd() {
+    exec() {
       new ArgumentParser(helloOpts).parse(['-h'], { progName: 'hello' });
     },
   },

--- a/packages/tsargp/lib/enums.ts
+++ b/packages/tsargp/lib/enums.ts
@@ -11,11 +11,6 @@ export { ControlSequence as cs, TypeFace as tf, Foreground as fg, Background as 
  */
 export const enum ErrorItem {
   /**
-   * Raised by the parser when an option parameter fails to be parsed, with possible option name
-   * suggestions.
-   */
-  parseError,
-  /**
    * Raised by the parser when an option name is not found, with possible option name suggestions.
    */
   unknownOption,

--- a/packages/tsargp/lib/options.ts
+++ b/packages/tsargp/lib/options.ts
@@ -122,19 +122,15 @@ export type Requires = string | RequiresVal | RequiresExp | RequiresCallback;
 export type RequiresCallback = (values: OpaqueOptionValues) => boolean | Promise<boolean>;
 
 /**
- * A callback to parse the value of option parameters. Any specified normalization or constraint
- * will be applied to the returned value.
+ * A callback to parse the value of option parameters or to perform word completion.
+ * In case of parsing, normalization and constraints will be applied to the returned value.
+ * @template P The parameter data type
  * @template T The return data type
- * @param values The values parsed so far
- * @param name The option name (as specified on the command-line)
- * @param value The parameter value
- * @returns The parsed value
+ * @template C The completion data type
+ * @param info The argument sequence information
+ * @returns The new option value or the completion words
  */
-export type ParseCallback<T> = (
-  values: OpaqueOptionValues,
-  name: string,
-  value: string,
-) => T | Promise<T>;
+export type CustomCallback<P, T, C = boolean> = (info: ParseInfo<P, C>) => T | Promise<T>;
 
 /**
  * A module-relative resolution function (i.e., scoped to a module).
@@ -153,38 +149,35 @@ export type ResolveCallback = (specifier: string) => string;
 export type DefaultCallback<T> = (values: OpaqueOptionValues) => T | Promise<T>;
 
 /**
- * A callback for function options.
- * @param values The values parsed so far
- * @param comp True if performing completion (but not in the current iteration)
- * @param rest The remaining command-line arguments
- * @returns The option value
+ * Information about the current argument sequence in the parsing loop.
+ * @template P The parameter data type
+ * @template C The completion data type
  */
-export type ExecuteCallback = (
-  values: OpaqueOptionValues,
-  comp: boolean,
-  rest: Array<string>,
-) => unknown;
-
-/**
- * A callback for command options.
- * @param prev The values parsed for the parent command
- * @param values The values parsed for the command
- * @returns The option value
- */
-export type CommandCallback = (prev: OpaqueOptionValues, values: OpaqueOptionValues) => unknown;
-
-/**
- * A callback for option completion.
- * @param values The values parsed so far
- * @param comp The word being completed (it may be an empty string)
- * @param rest The remaining command-line arguments
- * @returns The list of completion words
- */
-export type CompleteCallback = (
-  values: OpaqueOptionValues,
-  comp: string,
-  rest: Array<string>,
-) => Array<string> | Promise<Array<string>>;
+export type ParseInfo<P, C> = {
+  /**
+   * The previously parsed values.
+   * It is an opaque type that should be cast to {@link OptionValues}`<typeof your_options>`.
+   */
+  values: OpaqueOptionValues;
+  /**
+   * The index of the occurrence of the option name, or of the first option parameter.
+   * It will be NaN if the sequence comes from an environment variable.
+   */
+  index: number;
+  /**
+   * The option name as specified on the command-line, or the environment variable name.
+   * It will be the option's preferred name if the sequence comes from positional arguments.
+   */
+  name: string;
+  /**
+   * The option parameter(s), or the parameters preceding the word being completed, if any.
+   */
+  param: P;
+  /**
+   * True if performing word completion, or the word being completed.
+   */
+  comp: C;
+};
 
 /**
  * Defines the type of an option.
@@ -276,9 +269,10 @@ export type WithValue<T> = {
 
 /**
  * Defines attributes common to options with parameters.
+ * @template P The parameter data type
  * @template T The option value data type
  */
-export type WithParam<T> = {
+export type WithParam<P, T> = {
   /**
    * The option example value. Replaces the option type in the help message parameter column.
    */
@@ -303,11 +297,12 @@ export type WithParam<T> = {
    * It should return the list of completion words.
    * If it throws an error, it is ignored, and the default completion message is thrown instead.
    */
-  readonly complete?: CompleteCallback;
+  readonly complete?: CustomCallback<Array<string>, Array<string>, string>;
   /**
-   * A custom callback to parse the value of the option parameter.
+   * A custom callback to parse the value of the option parameter(s).
+   * It should return the new option value.
    */
-  readonly parse?: ParseCallback<Flatten<T>>;
+  readonly parse?: CustomCallback<P, T>;
   /**
    * The enumerated values.
    */
@@ -425,7 +420,7 @@ export type WithFunction = {
   /**
    * The function callback.
    */
-  readonly exec: ExecuteCallback;
+  readonly exec: CustomCallback<Array<string>, unknown>;
   /**
    * True to break the parsing loop.
    */
@@ -445,7 +440,7 @@ export type WithCommand = {
   /**
    * The command callback.
    */
-  readonly cmd: CommandCallback;
+  readonly exec: CustomCallback<OpaqueOptionValues, unknown>;
   /**
    * The command options or a callback that returns the options (for use with recursive commands).
    */
@@ -514,7 +509,7 @@ export type BooleanOption = WithType<'boolean'> &
   WithBasic &
   WithMisc &
   WithValue<boolean> &
-  WithParam<boolean> &
+  WithParam<string, boolean> &
   (WithDefault | WithRequired) &
   (WithExample | WithParamName);
 
@@ -526,7 +521,7 @@ export type StringOption = WithType<'string'> &
   WithMisc &
   WithString &
   WithValue<string> &
-  WithParam<string> &
+  WithParam<string, string> &
   (WithDefault | WithRequired) &
   (WithExample | WithParamName) &
   (WithEnums | WithRegex);
@@ -539,7 +534,7 @@ export type NumberOption = WithType<'number'> &
   WithMisc &
   WithNumber &
   WithValue<number> &
-  WithParam<number> &
+  WithParam<string, number> &
   (WithDefault | WithRequired) &
   (WithExample | WithParamName) &
   (WithEnums | WithRange);
@@ -553,9 +548,10 @@ export type StringsOption = WithType<'strings'> &
   WithString &
   WithArray &
   WithValue<Array<string>> &
-  WithParam<Array<string>> &
+  WithParam<Array<string>, Array<string>> &
   (WithDefault | WithRequired) &
   (WithExample | WithParamName) &
+  (WithAppend | WithParse) &
   (WithEnums | WithRegex);
 
 /**
@@ -567,9 +563,10 @@ export type NumbersOption = WithType<'numbers'> &
   WithNumber &
   WithArray &
   WithValue<Array<number>> &
-  WithParam<Array<number>> &
+  WithParam<Array<string>, Array<number>> &
   (WithDefault | WithRequired) &
   (WithExample | WithParamName) &
+  (WithAppend | WithParse) &
   (WithEnums | WithRange);
 
 /**
@@ -628,7 +625,7 @@ type OptionTypes =
 export type OpaqueOption = WithType<OptionTypes> &
   WithBasic &
   WithValue<unknown> &
-  WithParam<unknown> &
+  WithParam<unknown, unknown> &
   WithHelp &
   WithVersion &
   WithFunction &
@@ -750,6 +747,26 @@ type WithResolve = {
 };
 
 /**
+ * Removes mutually exclusive attributes from an option with an `append` attribute.
+ */
+type WithAppend = {
+  /**
+   * @deprecated mutually exclusive with {@link WithVersion.append}
+   */
+  readonly parse?: never;
+};
+
+/**
+ * Removes mutually exclusive attributes from an option with a custom `parse` callback.
+ */
+type WithParse = {
+  /**
+   * @deprecated mutually exclusive with {@link WithVersion.parse}
+   */
+  readonly append?: never;
+};
+
+/**
  * The data type of an option that may have a default value.
  * @template T The option definition type
  */
@@ -762,20 +779,12 @@ type DefaultDataType<T extends Option> = T extends { required: true }
     : undefined;
 
 /**
- * The data type of a function option.
+ * The data type of an option with an executing callback.
  * @template T The option definition type
  */
-type FunctionDataType<T extends Option> =
+type ExecDataType<T extends Option> =
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   T extends { exec: (...args: any) => infer R } ? (R extends Promise<infer D> ? D : R) : never;
-
-/**
- * The data type of a command option.
- * @template T The option definition type
- */
-type CommandDataType<T extends Option> =
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  T extends { cmd: (...args: any) => infer R } ? (R extends Promise<infer D> ? D : R) : never;
 
 /**
  * The data type of an option with enumerated values.
@@ -789,23 +798,21 @@ type EnumsDataType<T extends Option, D> = T extends { enums: ReadonlyArray<infer
  * @template T The option definition type
  */
 type OptionDataType<T extends Option> =
-  T extends WithType<'function'>
-    ? FunctionDataType<T> | DefaultDataType<T>
-    : T extends WithType<'command'>
-      ? CommandDataType<T> | DefaultDataType<T>
-      : T extends WithType<'flag'>
-        ? boolean | DefaultDataType<T>
-        : T extends WithType<'boolean'>
-          ? EnumsDataType<T, boolean> | DefaultDataType<T>
-          : T extends WithType<'string'>
-            ? EnumsDataType<T, string> | DefaultDataType<T>
-            : T extends WithType<'number'>
-              ? EnumsDataType<T, number> | DefaultDataType<T>
-              : T extends WithType<'strings'>
-                ? Array<EnumsDataType<T, string>> | DefaultDataType<T>
-                : T extends WithType<'numbers'>
-                  ? Array<EnumsDataType<T, number>> | DefaultDataType<T>
-                  : never;
+  T extends WithType<'function' | 'command'>
+    ? ExecDataType<T> | DefaultDataType<T>
+    : T extends WithType<'flag'>
+      ? boolean | DefaultDataType<T>
+      : T extends WithType<'boolean'>
+        ? EnumsDataType<T, boolean> | DefaultDataType<T>
+        : T extends WithType<'string'>
+          ? EnumsDataType<T, string> | DefaultDataType<T>
+          : T extends WithType<'number'>
+            ? EnumsDataType<T, number> | DefaultDataType<T>
+            : T extends WithType<'strings'>
+              ? Array<EnumsDataType<T, string>> | DefaultDataType<T>
+              : T extends WithType<'numbers'>
+                ? Array<EnumsDataType<T, number>> | DefaultDataType<T>
+                : never;
 
 //--------------------------------------------------------------------------------------------------
 // Functions

--- a/packages/tsargp/lib/options.ts
+++ b/packages/tsargp/lib/options.ts
@@ -751,7 +751,7 @@ type WithResolve = {
  */
 type WithAppend = {
   /**
-   * @deprecated mutually exclusive with {@link WithVersion.append}
+   * @deprecated mutually exclusive with {@link WithArray.append}
    */
   readonly parse?: never;
 };
@@ -761,7 +761,7 @@ type WithAppend = {
  */
 type WithParse = {
   /**
-   * @deprecated mutually exclusive with {@link WithVersion.parse}
+   * @deprecated mutually exclusive with {@link WithParam.parse}
    */
   readonly append?: never;
 };

--- a/packages/tsargp/lib/parser.ts
+++ b/packages/tsargp/lib/parser.ts
@@ -34,7 +34,6 @@ import {
   isUnknown,
 } from './options';
 import {
-  ErrorMessage,
   WarnMessage,
   VersionMessage,
   CompletionMessage,
@@ -471,9 +470,6 @@ async function handleNonNiladic(
     } catch (err) {
       // do not propagate errors during completion
       if (!comp) {
-        // if (err instanceof ErrorMessage && suggestNames) {
-        //   handleUnknown(validator, param, err);
-        // }
         throw err;
       }
     }
@@ -567,18 +563,12 @@ function handleCompletion(option: OpaqueOption, comp = '') {
  * Handles an unknown option name.
  * @param validator The option validator
  * @param name The unknown option name
- * @param err The previous error message, if any
  */
-function handleUnknownName(validator: OptionValidator, name: string, err?: ErrorMessage): never {
+function handleUnknownName(validator: OptionValidator, name: string): never {
   const similar = findSimilarNames(name, [...validator.names.keys()], 0.6);
   const [args, alt] = similar.length ? [{ o1: name, o2: similar }, 1] : [{ o: name }, 0];
   const flags: FormattingFlags = { alt, sep: ',' };
-  if (err) {
-    err.msg.push(validator.format(ErrorItem.parseError, args, flags));
-  } else {
-    err = validator.error(ErrorItem.unknownOption, args, flags);
-  }
-  throw err;
+  throw validator.error(ErrorItem.unknownOption, args, flags);
 }
 
 /**

--- a/packages/tsargp/lib/parser.ts
+++ b/packages/tsargp/lib/parser.ts
@@ -512,34 +512,6 @@ async function resolveVersion(
 }
 
 /**
- * Handles the completion of an option with a custom completion callback.
- * @param values The option values
- * @param info The option information
- * @param index The starting index of the argument sequence
- * @param param The preceding parameters, if any
- * @param comp The word being completed
- */
-async function handleComplete(
-  values: OpaqueOptionValues,
-  info: OptionInfo,
-  index: number,
-  param: Array<string>,
-  comp = '',
-) {
-  const { name, option } = info;
-  if (option.complete) {
-    let words;
-    try {
-      words = await option.complete({ values, index, name, param, comp });
-    } catch (err) {
-      // do not propagate errors during completion
-      throw new CompletionMessage();
-    }
-    throw new CompletionMessage(...words);
-  }
-}
-
-/**
  * Handles the completion of an option with a parameter.
  * @param option The option definition
  * @param comp The word being completed
@@ -852,6 +824,34 @@ function handleSpecial(
     throw new VersionMessage(option.version);
   } else if (option.resolve) {
     return resolveVersion(validator, option.resolve);
+  }
+}
+
+/**
+ * Handles the completion of an option with a custom completion callback.
+ * @param values The option values
+ * @param info The option information
+ * @param index The starting index of the argument sequence
+ * @param param The preceding parameters, if any
+ * @param comp The word being completed
+ */
+async function handleComplete(
+  values: OpaqueOptionValues,
+  info: OptionInfo,
+  index: number,
+  param: Array<string>,
+  comp = '',
+) {
+  const { name, option } = info;
+  if (option.complete) {
+    let words;
+    try {
+      words = await option.complete({ values, index, name, param, comp });
+    } catch (err) {
+      // do not propagate errors during completion
+      throw new CompletionMessage();
+    }
+    throw new CompletionMessage(...words);
   }
 }
 

--- a/packages/tsargp/lib/validator.ts
+++ b/packages/tsargp/lib/validator.ts
@@ -37,8 +37,6 @@ export const defaultConfig: ConcreteConfig = {
     text: style(tf.clear),
   },
   phrases: {
-    [ErrorItem.parseError]:
-      'Did you mean to specify an option name instead of (%o|%o1)?(| Similar names are [%o2].)',
     [ErrorItem.unknownOption]: 'Unknown option (%o|%o1).(| Similar names are [%o2].)',
     [ErrorItem.unsatisfiedRequirement]: 'Option %o requires %p.',
     [ErrorItem.missingRequiredOption]: 'Option %o is required.',

--- a/packages/tsargp/test/formatter/formatter.default.spec.ts
+++ b/packages/tsargp/test/formatter/formatter.default.spec.ts
@@ -41,7 +41,7 @@ describe('HelpFormatter', () => {
           names: ['-f', '--command'],
           desc: 'A command option.',
           options: {},
-          cmd() {},
+          exec() {},
           default: true,
         },
       } as const satisfies Options;
@@ -56,7 +56,7 @@ describe('HelpFormatter', () => {
           names: ['-f', '--command'],
           desc: 'A command option.',
           options: {},
-          cmd() {},
+          exec() {},
           default: () => 0,
         },
       } as const satisfies Options;

--- a/packages/tsargp/test/formatter/formatter.spec.ts
+++ b/packages/tsargp/test/formatter/formatter.spec.ts
@@ -72,7 +72,7 @@ describe('HelpFormatter', () => {
           names: ['-f', '--command'],
           desc: 'A command option',
           options: {},
-          cmd() {},
+          exec() {},
         },
       } as const satisfies Options;
       const message = new HelpFormatter(new OptionValidator(options)).formatHelp();

--- a/packages/tsargp/test/parser/parser.cluster.spec.ts
+++ b/packages/tsargp/test/parser/parser.cluster.spec.ts
@@ -169,7 +169,7 @@ describe('ArgumentParser', () => {
           type: 'command',
           names: ['-c'],
           options: {},
-          cmd() {},
+          exec() {},
           clusterLetters: 'c',
         },
       } as const satisfies Options;
@@ -201,7 +201,7 @@ describe('ArgumentParser', () => {
               clusterLetters: 'n',
             },
           },
-          cmd: (_, values) => values,
+          exec: ({ param }) => param,
           shortStyle: true,
           clusterLetters: 'c',
         },

--- a/packages/tsargp/test/parser/parser.completion.spec.ts
+++ b/packages/tsargp/test/parser/parser.completion.spec.ts
@@ -29,8 +29,13 @@ describe('ArgumentParser', () => {
       } as const satisfies Options;
       const parser = new ArgumentParser(options);
       await expect(parser.parse('cmd -f ', { compIndex: 7 })).rejects.toThrow(/^-f$/);
-      const anything = expect.anything();
-      expect(options.function.exec).toHaveBeenCalledWith(anything, true, anything);
+      expect(options.function.exec).toHaveBeenCalledWith({
+        values: { function: undefined },
+        index: 0,
+        name: '-f',
+        param: ['\0'],
+        comp: true,
+      });
     });
 
     it('should ignore the skip count of a function option during completion', async () => {
@@ -94,10 +99,16 @@ describe('ArgumentParser', () => {
       await expect(parser.parse('cmd -f', { compIndex: 6 })).rejects.toThrow(/^-f$/);
       expect(options.function.exec).not.toHaveBeenCalled();
       await expect(parser.parse('cmd -f ', { compIndex: 7 })).rejects.toThrow(/^-f$/);
-      const anything = expect.anything();
-      expect(options.function.exec).toHaveBeenCalledWith(anything, true, anything);
+      expect(options.function.exec).toHaveBeenCalledWith({
+        values: { function: undefined },
+        index: 0,
+        name: '-f',
+        param: ['\0'],
+        comp: true,
+      });
       options.function.exec.mockClear();
       await expect(parser.parse('cmd -f=', { compIndex: 7 })).rejects.toThrow(/^$/);
+      expect(options.function.exec).not.toHaveBeenCalled();
       await expect(parser.parse('cmd -f= ', { compIndex: 8 })).rejects.toThrow(/^-f$/);
       expect(options.function.exec).not.toHaveBeenCalled(); // option was ignored
     });
@@ -113,8 +124,13 @@ describe('ArgumentParser', () => {
       } as const satisfies Options;
       const parser = new ArgumentParser(options);
       await expect(parser.parse('cmd -f ', { compIndex: 7 })).rejects.toThrow(/^-f$/);
-      const anything = expect.anything();
-      expect(options.function.exec).toHaveBeenCalledWith(anything, true, anything);
+      expect(options.function.exec).toHaveBeenCalledWith({
+        values: { function: undefined },
+        index: 0,
+        name: '-f',
+        param: ['\0'],
+        comp: true,
+      });
     });
 
     it('should handle the completion of a command option', async () => {
@@ -128,7 +144,7 @@ describe('ArgumentParser', () => {
               names: ['-f'],
             },
           },
-          cmd: vi.fn(),
+          exec: vi.fn(),
         },
       } as const satisfies Options;
       const parser = new ArgumentParser(options);
@@ -138,7 +154,7 @@ describe('ArgumentParser', () => {
       await expect(parser.parse('cmd -c ', { compIndex: 7 })).rejects.toThrow(/^-f$/);
       await expect(parser.parse('cmd -c=', { compIndex: 7 })).rejects.toThrow(/^$/);
       await expect(parser.parse('cmd -c= ', { compIndex: 8 })).rejects.toThrow(/^-c$/);
-      expect(options.command.cmd).not.toHaveBeenCalled();
+      expect(options.command.exec).not.toHaveBeenCalled();
     });
 
     it('should handle the completion of a flag option', async () => {
@@ -255,18 +271,41 @@ describe('ArgumentParser', () => {
         },
       } as const satisfies Options;
       const parser = new ArgumentParser(options);
-      const anything = expect.anything();
       await expect(parser.parse('cmd -b ', { compIndex: 7 })).rejects.toThrow(/^abc$/);
-      expect(options.boolean.complete).toHaveBeenCalledWith(anything, '', anything);
+      expect(options.boolean.complete).toHaveBeenCalledWith({
+        values: { boolean: undefined },
+        index: 0,
+        name: '-b',
+        param: [],
+        comp: '',
+      });
       options.boolean.complete.mockClear();
       await expect(parser.parse('cmd -b 123', { compIndex: 7 })).rejects.toThrow(/^abc$/);
-      expect(options.boolean.complete).toHaveBeenCalledWith(anything, '', anything);
+      expect(options.boolean.complete).toHaveBeenCalledWith({
+        values: { boolean: undefined },
+        index: 0,
+        name: '-b',
+        param: [],
+        comp: '',
+      });
       options.boolean.complete.mockClear();
       await expect(parser.parse('cmd -b 123', { compIndex: 9 })).rejects.toThrow(/^abc$/);
-      expect(options.boolean.complete).toHaveBeenCalledWith(anything, '12', anything);
+      expect(options.boolean.complete).toHaveBeenCalledWith({
+        values: { boolean: undefined },
+        index: 0,
+        name: '-b',
+        param: [],
+        comp: '12',
+      });
       options.boolean.complete.mockClear();
       await expect(parser.parse('cmd 0 1 ', { compIndex: 8 })).rejects.toThrow(/^abc$/);
-      expect(options.boolean.complete).toHaveBeenCalledWith(anything, '', anything);
+      expect(options.boolean.complete).toHaveBeenCalledWith({
+        values: { boolean: undefined },
+        index: 0,
+        name: '-b',
+        param: ['0', '1'],
+        comp: '',
+      });
     });
 
     it('should handle the completion of a boolean option with custom completion that throws', async () => {
@@ -402,7 +441,22 @@ describe('ArgumentParser', () => {
       } as const satisfies Options;
       const parser = new ArgumentParser(options);
       await expect(parser.parse('cmd -ss ', { compIndex: 8 })).rejects.toThrow(/^$/);
+      expect(options.strings.complete).toHaveBeenCalledWith({
+        values: { strings: undefined },
+        index: 0,
+        name: '-ss',
+        param: [],
+        comp: '',
+      });
+      options.strings.complete.mockClear();
       await expect(parser.parse('cmd -ss 1 ', { compIndex: 10 })).rejects.toThrow(/^$/);
+      expect(options.strings.complete).toHaveBeenCalledWith({
+        values: { strings: undefined },
+        index: 0,
+        name: '-ss',
+        param: ['1'],
+        comp: '',
+      });
     });
 
     it('should handle the completion of a variadic strings option', async () => {
@@ -449,7 +503,22 @@ describe('ArgumentParser', () => {
       } as const satisfies Options;
       const parser = new ArgumentParser(options);
       await expect(parser.parse('cmd -ns ', { compIndex: 8 })).rejects.toThrow(/^$/);
+      expect(options.numbers.complete).toHaveBeenCalledWith({
+        values: { numbers: undefined },
+        index: 0,
+        name: '-ns',
+        param: [],
+        comp: '',
+      });
+      options.numbers.complete.mockClear();
       await expect(parser.parse('cmd -ns 1 ', { compIndex: 10 })).rejects.toThrow(/^$/);
+      expect(options.numbers.complete).toHaveBeenCalledWith({
+        values: { numbers: undefined },
+        index: 0,
+        name: '-ns',
+        param: ['1'],
+        comp: '',
+      });
     });
 
     it('should handle the completion of a variadic numbers option', async () => {

--- a/packages/tsargp/test/parser/parser.custom.spec.ts
+++ b/packages/tsargp/test/parser/parser.custom.spec.ts
@@ -10,12 +10,18 @@ describe('ArgumentParser', () => {
           type: 'boolean',
           positional: true,
           preferredName: 'bool',
-          parse: vi.fn().mockImplementation((_0, _1, value) => value.includes('123')),
+          parse: vi.fn().mockImplementation(({ param }) => param.includes('123')),
         },
       } as const satisfies Options;
       const parser = new ArgumentParser(options);
       await expect(parser.parse(['0123'])).resolves.toEqual({ boolean: true });
-      expect(options.boolean.parse).toHaveBeenCalledWith(expect.anything(), 'bool', '0123');
+      expect(options.boolean.parse).toHaveBeenCalledWith({
+        values: { boolean: true }, // should be { boolean: undefined } at the time of call
+        index: 0,
+        name: 'bool',
+        param: '0123',
+        comp: false,
+      });
     });
 
     it('should handle a boolean option with custom parsing from environment variable', async () => {
@@ -30,7 +36,13 @@ describe('ArgumentParser', () => {
       const parser = new ArgumentParser(options);
       process.env['BOOLEAN'] = '1';
       await expect(parser.parse([])).resolves.toEqual({ boolean: true });
-      expect(options.boolean.parse).toHaveBeenCalledWith(expect.anything(), 'BOOLEAN', '1');
+      expect(options.boolean.parse).toHaveBeenCalledWith({
+        values: { boolean: true }, // should be { boolean: undefined } at the time of call
+        index: NaN,
+        name: 'BOOLEAN',
+        param: '1',
+        comp: false,
+      });
     });
 
     it('should handle a boolean option with async custom parsing', async () => {
@@ -38,7 +50,7 @@ describe('ArgumentParser', () => {
         boolean: {
           type: 'boolean',
           names: ['-b'],
-          parse: async (_0, _1, value) => value.includes('123'),
+          parse: async ({ param }) => param.includes('123'),
         },
       } as const satisfies Options;
       const parser = new ArgumentParser(options);
@@ -52,12 +64,18 @@ describe('ArgumentParser', () => {
           type: 'string',
           names: ['-s'],
           case: 'upper',
-          parse: vi.fn().mockImplementation((_0, _1, value) => value.slice(2)),
+          parse: vi.fn().mockImplementation(({ param }) => param.slice(2)),
         },
       } as const satisfies Options;
       const parser = new ArgumentParser(options);
       await expect(parser.parse(['-s', 'abcde'])).resolves.toEqual({ string: 'CDE' });
-      expect(options.string.parse).toHaveBeenCalledWith(expect.anything(), '-s', 'abcde');
+      expect(options.string.parse).toHaveBeenCalledWith({
+        values: { string: 'CDE' }, // should be { string: undefined } at the time of call
+        index: 0,
+        name: '-s',
+        param: 'abcde',
+        comp: false,
+      });
     });
 
     it('should handle a string option with async custom parsing', async () => {
@@ -66,7 +84,7 @@ describe('ArgumentParser', () => {
           type: 'string',
           names: ['-s'],
           case: 'upper',
-          parse: async (_0, _1, value) => value.slice(2),
+          parse: async ({ param }) => param.slice(2),
         },
       } as const satisfies Options;
       const parser = new ArgumentParser(options);
@@ -79,12 +97,18 @@ describe('ArgumentParser', () => {
           type: 'number',
           names: ['-n'],
           conv: 'ceil',
-          parse: vi.fn().mockImplementation((_0, _1, value) => Number(value)),
+          parse: vi.fn().mockImplementation(({ param }) => Number(param)),
         },
       } as const satisfies Options;
       const parser = new ArgumentParser(options);
       await expect(parser.parse(['-n', '1.2'])).resolves.toEqual({ number: 2 });
-      expect(options.number.parse).toHaveBeenCalledWith(expect.anything(), '-n', '1.2');
+      expect(options.number.parse).toHaveBeenCalledWith({
+        values: { number: 2 }, // should be { number: undefined } at the time of call
+        index: 0,
+        name: '-n',
+        param: '1.2',
+        comp: false,
+      });
     });
 
     it('should handle a number option with async custom parsing', async () => {
@@ -93,7 +117,7 @@ describe('ArgumentParser', () => {
           type: 'number',
           names: ['-n'],
           conv: 'ceil',
-          parse: async (_0, _1, value) => Number(value),
+          parse: async ({ param }) => Number(param),
         },
       } as const satisfies Options;
       const parser = new ArgumentParser(options);
@@ -106,14 +130,19 @@ describe('ArgumentParser', () => {
           type: 'strings',
           names: ['-ss'],
           case: 'upper',
-          parse: vi.fn().mockImplementation((_0, _1, value) => value),
+          parse: vi.fn().mockImplementation(({ param }) => param),
         },
       } as const satisfies Options;
       const parser = new ArgumentParser(options);
       await expect(parser.parse(['-ss', 'a', 'b'])).resolves.toEqual({ strings: ['A', 'B'] });
-      expect(options.strings.parse).toHaveBeenCalledWith(expect.anything(), '-ss', 'a');
-      expect(options.strings.parse).toHaveBeenCalledWith(expect.anything(), '-ss', 'b');
-      expect(options.strings.parse).toHaveBeenCalledTimes(2);
+      expect(options.strings.parse).toHaveBeenCalledWith({
+        values: { strings: ['A', 'B'] }, // should be { strings: undefined } at the time of call
+        index: 0,
+        name: '-ss',
+        param: ['a', 'b'],
+        comp: false,
+      });
+      expect(options.strings.parse).toHaveBeenCalledTimes(1);
     });
 
     it('should handle a strings option with async custom parsing', async () => {
@@ -122,7 +151,7 @@ describe('ArgumentParser', () => {
           type: 'strings',
           names: ['-ss'],
           unique: true,
-          parse: async (_0, _1, value) => value,
+          parse: async ({ param }) => param,
         },
       } as const satisfies Options;
       const parser = new ArgumentParser(options);
@@ -136,14 +165,19 @@ describe('ArgumentParser', () => {
           type: 'numbers',
           names: ['-ns'],
           conv: 'ceil',
-          parse: vi.fn().mockImplementation((_0, _1, value) => Number(value)),
+          parse: vi.fn().mockImplementation(({ param }) => param.map(Number)),
         },
       } as const satisfies Options;
       const parser = new ArgumentParser(options);
       await expect(parser.parse(['-ns', '1.2', '1.7'])).resolves.toEqual({ numbers: [2, 2] });
-      expect(options.numbers.parse).toHaveBeenCalledWith(expect.anything(), '-ns', '1.2');
-      expect(options.numbers.parse).toHaveBeenCalledWith(expect.anything(), '-ns', '1.7');
-      expect(options.numbers.parse).toHaveBeenCalledTimes(2);
+      expect(options.numbers.parse).toHaveBeenCalledWith({
+        values: { numbers: [2, 2] }, // should be { numbers: undefined } at the time of call
+        index: 0,
+        name: '-ns',
+        param: ['1.2', '1.7'],
+        comp: false,
+      });
+      expect(options.numbers.parse).toHaveBeenCalledTimes(1);
     });
 
     it('should handle a numbers option with async custom parsing', async () => {
@@ -152,7 +186,7 @@ describe('ArgumentParser', () => {
           type: 'numbers',
           names: ['-ns'],
           unique: true,
-          parse: async (_0, _1, value) => Number(value),
+          parse: async ({ param }) => param.map(Number),
         },
       } as const satisfies Options;
       const parser = new ArgumentParser(options);

--- a/packages/tsargp/test/parser/parser.custom.spec.ts
+++ b/packages/tsargp/test/parser/parser.custom.spec.ts
@@ -16,7 +16,8 @@ describe('ArgumentParser', () => {
       const parser = new ArgumentParser(options);
       await expect(parser.parse(['0123'])).resolves.toEqual({ boolean: true });
       expect(options.boolean.parse).toHaveBeenCalledWith({
-        values: { boolean: true }, // should be { boolean: undefined } at the time of call
+        // should have been { boolean: undefined } at the time of call
+        values: { boolean: true },
         index: 0,
         name: 'bool',
         param: '0123',
@@ -37,7 +38,8 @@ describe('ArgumentParser', () => {
       process.env['BOOLEAN'] = '1';
       await expect(parser.parse([])).resolves.toEqual({ boolean: true });
       expect(options.boolean.parse).toHaveBeenCalledWith({
-        values: { boolean: true }, // should be { boolean: undefined } at the time of call
+        // should have been { boolean: undefined } at the time of call
+        values: { boolean: true },
         index: NaN,
         name: 'BOOLEAN',
         param: '1',
@@ -70,7 +72,8 @@ describe('ArgumentParser', () => {
       const parser = new ArgumentParser(options);
       await expect(parser.parse(['-s', 'abcde'])).resolves.toEqual({ string: 'CDE' });
       expect(options.string.parse).toHaveBeenCalledWith({
-        values: { string: 'CDE' }, // should be { string: undefined } at the time of call
+        // should have been { string: undefined } at the time of call
+        values: { string: 'CDE' },
         index: 0,
         name: '-s',
         param: 'abcde',
@@ -103,7 +106,8 @@ describe('ArgumentParser', () => {
       const parser = new ArgumentParser(options);
       await expect(parser.parse(['-n', '1.2'])).resolves.toEqual({ number: 2 });
       expect(options.number.parse).toHaveBeenCalledWith({
-        values: { number: 2 }, // should be { number: undefined } at the time of call
+        // should have been { number: undefined } at the time of call
+        values: { number: 2 },
         index: 0,
         name: '-n',
         param: '1.2',
@@ -136,7 +140,8 @@ describe('ArgumentParser', () => {
       const parser = new ArgumentParser(options);
       await expect(parser.parse(['-ss', 'a', 'b'])).resolves.toEqual({ strings: ['A', 'B'] });
       expect(options.strings.parse).toHaveBeenCalledWith({
-        values: { strings: ['A', 'B'] }, // should be { strings: undefined } at the time of call
+        // should have been { strings: undefined } at the time of call
+        values: { strings: ['A', 'B'] },
         index: 0,
         name: '-ss',
         param: ['a', 'b'],
@@ -171,7 +176,8 @@ describe('ArgumentParser', () => {
       const parser = new ArgumentParser(options);
       await expect(parser.parse(['-ns', '1.2', '1.7'])).resolves.toEqual({ numbers: [2, 2] });
       expect(options.numbers.parse).toHaveBeenCalledWith({
-        values: { numbers: [2, 2] }, // should be { numbers: undefined } at the time of call
+        // should have been { numbers: undefined } at the time of call
+        values: { numbers: [2, 2] },
         index: 0,
         name: '-ns',
         param: ['1.2', '1.7'],

--- a/packages/tsargp/test/parser/parser.default.spec.ts
+++ b/packages/tsargp/test/parser/parser.default.spec.ts
@@ -10,7 +10,7 @@ describe('ArgumentParser', () => {
           type: 'function',
           names: ['-f1'],
           break: true,
-          exec(values) {
+          exec({ values }) {
             expect((values as OptionValues<typeof options>).flag).toBeTruthy();
           },
         },
@@ -29,7 +29,7 @@ describe('ArgumentParser', () => {
         function: {
           type: 'function',
           names: ['-f1'],
-          exec(values) {
+          exec({ values }) {
             expect((values as OptionValues<typeof options>).flag).toBeUndefined();
           },
         },
@@ -91,7 +91,7 @@ describe('ArgumentParser', () => {
           type: 'command',
           names: ['-c'],
           options: {},
-          cmd(values) {
+          exec({ values }) {
             expect((values as OptionValues<typeof options>).flag).toBeTruthy();
           },
         },
@@ -112,12 +112,12 @@ describe('ArgumentParser', () => {
           names: ['-c'],
           default: false,
           options: {},
-          cmd: vi.fn(),
+          exec: vi.fn(),
         },
       } as const satisfies Options;
       const parser = new ArgumentParser(options);
       await expect(parser.parse([])).resolves.toEqual({ command: false });
-      expect(options.command.cmd).not.toHaveBeenCalled();
+      expect(options.command.exec).not.toHaveBeenCalled();
     });
 
     it('should handle a command option with a default value callback', async () => {
@@ -127,12 +127,12 @@ describe('ArgumentParser', () => {
           names: ['-c'],
           default: () => false,
           options: {},
-          cmd: vi.fn(),
+          exec: vi.fn(),
         },
       } as const satisfies Options;
       const parser = new ArgumentParser(options);
       await expect(parser.parse([])).resolves.toEqual({ command: false });
-      expect(options.command.cmd).not.toHaveBeenCalled();
+      expect(options.command.exec).not.toHaveBeenCalled();
     });
 
     it('should handle a command option with an async default value callback', async () => {
@@ -142,12 +142,12 @@ describe('ArgumentParser', () => {
           names: ['-c'],
           default: async () => false,
           options: {},
-          cmd: vi.fn(),
+          exec: vi.fn(),
         },
       } as const satisfies Options;
       const parser = new ArgumentParser(options);
       await expect(parser.parse([])).resolves.toEqual({ command: false });
-      expect(options.command.cmd).not.toHaveBeenCalled();
+      expect(options.command.exec).not.toHaveBeenCalled();
     });
 
     it('should handle a flag option with a default value', async () => {

--- a/packages/tsargp/test/parser/parser.default.spec.ts
+++ b/packages/tsargp/test/parser/parser.default.spec.ts
@@ -4,7 +4,7 @@ import '../utils.spec'; // initialize globals
 
 describe('ArgumentParser', () => {
   describe('parse', () => {
-    it('should set default values when breaking the parsing loop', async () => {
+    it('should set default values before calling a function callback that breaks the parsing loop', async () => {
       const options = {
         function: {
           type: 'function',
@@ -24,7 +24,7 @@ describe('ArgumentParser', () => {
       await expect(parser.parse(['-f1'])).resolves.toEqual({ function: undefined, flag: true });
     });
 
-    it('should not set default values during parsing', async () => {
+    it('should not set default values before calling a function callback that does not break the parsing loop', async () => {
       const options = {
         function: {
           type: 'function',

--- a/packages/tsargp/test/parser/parser.positional.spec.ts
+++ b/packages/tsargp/test/parser/parser.positional.spec.ts
@@ -105,7 +105,7 @@ describe('ArgumentParser', () => {
       await expect(parser.parse(['--'])).resolves.toEqual({ boolean: true });
     });
 
-    it('should throw a name suggestion on parse failure from positional string option', async () => {
+    it.skip('should throw a name suggestion on parse failure from positional string option', async () => {
       const options = {
         string: {
           type: 'string',
@@ -192,7 +192,7 @@ describe('ArgumentParser', () => {
       await expect(parser.parse(['--'])).resolves.toEqual({ string: '1' });
     });
 
-    it('should throw a name suggestion on parse failure from positional number option', async () => {
+    it.skip('should throw a name suggestion on parse failure from positional number option', async () => {
       const options = {
         number: {
           type: 'number',

--- a/packages/tsargp/test/parser/parser.positional.spec.ts
+++ b/packages/tsargp/test/parser/parser.positional.spec.ts
@@ -105,22 +105,6 @@ describe('ArgumentParser', () => {
       await expect(parser.parse(['--'])).resolves.toEqual({ boolean: true });
     });
 
-    it.skip('should throw a name suggestion on parse failure from positional string option', async () => {
-      const options = {
-        string: {
-          type: 'string',
-          names: ['-s'],
-          enums: ['abc'],
-          positional: true,
-        },
-      } as const satisfies Options;
-      const parser = new ArgumentParser(options);
-      await expect(parser.parse(['s'])).rejects.toThrow(
-        `Invalid parameter to -s: 's'. Possible values are {'abc'}.\n` +
-          `Did you mean to specify an option name instead of s? Similar names are [-s].\n`,
-      );
-    });
-
     it('should throw an error on string option with missing parameter after positional marker', async () => {
       const options = {
         string: {
@@ -190,22 +174,6 @@ describe('ArgumentParser', () => {
       } as const satisfies Options;
       const parser = new ArgumentParser(options);
       await expect(parser.parse(['--'])).resolves.toEqual({ string: '1' });
-    });
-
-    it.skip('should throw a name suggestion on parse failure from positional number option', async () => {
-      const options = {
-        number: {
-          type: 'number',
-          names: ['-n'],
-          enums: [123],
-          positional: true,
-        },
-      } as const satisfies Options;
-      const parser = new ArgumentParser(options);
-      await expect(parser.parse(['1'])).rejects.toThrow(
-        `Invalid parameter to -n: 1. Possible values are {123}.\n` +
-          `Did you mean to specify an option name instead of 1?\n`,
-      );
     });
 
     it('should throw an error on number option with missing parameter after positional marker', async () => {

--- a/packages/tsargp/test/parser/parser.requirements.spec.ts
+++ b/packages/tsargp/test/parser/parser.requirements.spec.ts
@@ -114,7 +114,7 @@ describe('ArgumentParser', () => {
         required: {
           type: 'strings',
           names: ['-ss'],
-          parse: async () => '1',
+          parse: async () => ['1'],
         },
       } as const satisfies Options;
       const parser = new ArgumentParser(options);
@@ -134,7 +134,7 @@ describe('ArgumentParser', () => {
         required: {
           type: 'numbers',
           names: ['-ns'],
-          parse: async () => 1,
+          parse: async () => [1],
         },
       } as const satisfies Options;
       const parser = new ArgumentParser(options);

--- a/packages/tsargp/test/parser/parser.spec.ts
+++ b/packages/tsargp/test/parser/parser.spec.ts
@@ -586,24 +586,6 @@ describe('ArgumentParser', () => {
         await expect(parser.parse(['--string', ''])).resolves.toEqual({ string: '' });
         await expect(parser.parse(['-s=1', '-s==2'])).resolves.toEqual({ string: '=2' });
       });
-
-      it.skip('should throw a name suggestion on parse failure from string option with fallback', async () => {
-        const message =
-          `Invalid parameter to -s: 's'. Value must match the regex /\\d+/.\n` +
-          `Did you mean to specify an option name instead of s? Similar names are [-s].\n`;
-        const options = {
-          string: {
-            type: 'string',
-            names: ['-s'],
-            regex: /\d+/,
-            positional: true,
-            fallback: '',
-          },
-        } as const satisfies Options;
-        const parser = new ArgumentParser(options);
-        await expect(parser.parse(['s'])).rejects.toThrow(message);
-        await expect(parser.parse(['-s', 's'])).rejects.toThrow(message);
-      });
     });
 
     describe('number', () => {
@@ -630,24 +612,6 @@ describe('ArgumentParser', () => {
         await expect(parser.parse(['-n', '123'])).resolves.toEqual({ number: 123 });
         await expect(parser.parse(['--number', '0'])).resolves.toEqual({ number: 0 });
         await expect(parser.parse(['-n=1', '-n=2'])).resolves.toEqual({ number: 2 });
-      });
-
-      it.skip('should throw a name suggestion on parse failure from number option with fallback', async () => {
-        const message =
-          `Invalid parameter to -n: NaN. Value must be in the range [0, 1].\n` +
-          `Did you mean to specify an option name instead of n? Similar names are [-n].\n`;
-        const options = {
-          number: {
-            type: 'number',
-            names: ['-n'],
-            range: [0, 1],
-            positional: true,
-            fallback: 0,
-          },
-        } as const satisfies Options;
-        const parser = new ArgumentParser(options);
-        await expect(parser.parse(['n'])).rejects.toThrow(message);
-        await expect(parser.parse(['-n', 'n'])).rejects.toThrow(message);
       });
     });
 
@@ -684,41 +648,6 @@ describe('ArgumentParser', () => {
         } as const satisfies Options;
         const parser = new ArgumentParser(options);
         await expect(parser.parse(['-ss=one', 'two'])).rejects.toThrow(`Unknown option two.`);
-      });
-
-      it.skip('should throw a name suggestion on parse failure from variadic strings option', async () => {
-        const message =
-          `Option -ss has too many values (2). Should have at most 1.\n` +
-          `Did you mean to specify an option name instead of ss? Similar names are [-ss].\n`;
-        const options = {
-          strings: {
-            type: 'strings',
-            names: ['-ss'],
-            limit: 1,
-            positional: true,
-          },
-        } as const satisfies Options;
-        const parser = new ArgumentParser(options);
-        await expect(parser.parse(['ss', 'ss'])).rejects.toThrow(message);
-        await expect(parser.parse(['-ss', 'ss', 'ss'])).rejects.toThrow(message);
-      });
-
-      it.skip('should throw a name suggestion on parse failure from variadic strings option with fallback', async () => {
-        const message =
-          `Option -ss has too many values (1). Should have at most 0.\n` +
-          `Did you mean to specify an option name instead of ss? Similar names are [-ss].\n`;
-        const options = {
-          strings: {
-            type: 'strings',
-            names: ['-ss'],
-            limit: 0,
-            positional: true,
-            fallback: [],
-          },
-        } as const satisfies Options;
-        const parser = new ArgumentParser(options);
-        await expect(parser.parse(['ss'])).rejects.toThrow(message);
-        await expect(parser.parse(['-ss', 'ss'])).rejects.toThrow(message);
       });
 
       it('should handle a strings option that can be specified multiple times', async () => {
@@ -807,41 +736,6 @@ describe('ArgumentParser', () => {
         } as const satisfies Options;
         const parser = new ArgumentParser(options);
         await expect(parser.parse(['-ns=1', '2'])).rejects.toThrow(`Unknown option 2.`);
-      });
-
-      it.skip('should throw a name suggestion on parse failure from variadic numbers option', async () => {
-        const message =
-          `Option -ns has too many values (2). Should have at most 1.\n` +
-          `Did you mean to specify an option name instead of ns? Similar names are [-ns].\n`;
-        const options = {
-          numbers: {
-            type: 'numbers',
-            names: ['-ns'],
-            limit: 1,
-            positional: true,
-          },
-        } as const satisfies Options;
-        const parser = new ArgumentParser(options);
-        await expect(parser.parse(['ns', 'ns'])).rejects.toThrow(message);
-        await expect(parser.parse(['-ns', 'ns', 'ns'])).rejects.toThrow(message);
-      });
-
-      it.skip('should throw a name suggestion on parse failure from variadic numbers option with fallback', async () => {
-        const message =
-          `Option -ns has too many values (1). Should have at most 0.\n` +
-          `Did you mean to specify an option name instead of ns? Similar names are [-ns].\n`;
-        const options = {
-          numbers: {
-            type: 'numbers',
-            names: ['-ns'],
-            limit: 0,
-            positional: true,
-            fallback: [],
-          },
-        } as const satisfies Options;
-        const parser = new ArgumentParser(options);
-        await expect(parser.parse(['ns'])).rejects.toThrow(message);
-        await expect(parser.parse(['-ns', 'ns'])).rejects.toThrow(message);
       });
 
       it('should handle a numbers option that can be specified multiple times', async () => {

--- a/packages/tsargp/test/parser/parser.spec.ts
+++ b/packages/tsargp/test/parser/parser.spec.ts
@@ -253,7 +253,8 @@ describe('ArgumentParser', () => {
         expect(options.function.exec).not.toHaveBeenCalled();
         await expect(parser.parse(['-f'])).resolves.toEqual({ function: 'abc' });
         expect(options.function.exec).toHaveBeenCalledWith({
-          values: { function: 'abc' }, // should be { function: undefined } at the time of call
+          // should have been { function: undefined } at the time of call
+          values: { function: 'abc' },
           index: 0,
           name: '-f',
           param: [],
@@ -262,7 +263,8 @@ describe('ArgumentParser', () => {
         options.function.exec.mockClear();
         await expect(parser.parse(['-f', '-f'])).resolves.toEqual({ function: 'abc' });
         expect(options.function.exec).toHaveBeenCalledWith({
-          values: { function: 'abc' }, // should be { function: undefined } at the time of call
+          // should have been { function: undefined } at the time of call
+          values: { function: 'abc' },
           index: 0,
           name: '-f',
           param: ['-f'],
@@ -428,7 +430,8 @@ describe('ArgumentParser', () => {
         const parser = new ArgumentParser(options);
         await expect(parser.parse(['-c'])).resolves.toEqual({ command: { flag: undefined } });
         expect(options.command.exec).toHaveBeenCalledWith({
-          values: { command: { flag: undefined } }, // should be { function: undefined } at the time of call
+          // should have been { command: undefined } at the time of call
+          values: { command: { flag: undefined } },
           index: 0,
           name: '-c',
           param: { flag: undefined },
@@ -437,7 +440,8 @@ describe('ArgumentParser', () => {
         options.command.exec.mockClear();
         await expect(parser.parse(['-c', '-f'])).resolves.toEqual({ command: { flag: true } });
         expect(options.command.exec).toHaveBeenCalledWith({
-          values: { command: { flag: true } }, // should be { function: undefined } at the time of call
+          // should have been { command: undefined } at the time of call
+          values: { command: { flag: true } },
           index: 0,
           name: '-c',
           param: { flag: true },
@@ -463,7 +467,8 @@ describe('ArgumentParser', () => {
         await expect(parser.parse(['-c', '-f'])).resolves.toEqual({ command: 'abc' });
         expect(options.command.options).toHaveBeenCalled();
         expect(options.command.exec).toHaveBeenCalledWith({
-          values: { command: 'abc' }, // should be { function: undefined } at the time of call
+          // should have been { command: undefined } at the time of call
+          values: { command: 'abc' },
           index: 0,
           name: '-c',
           param: { flag: true },

--- a/packages/tsargp/test/validator/validator.names.spec.ts
+++ b/packages/tsargp/test/validator/validator.names.spec.ts
@@ -161,7 +161,7 @@ describe('OptionValidator', () => {
               names: ['flag3'],
             },
           },
-          cmd() {},
+          exec() {},
         },
       } as const satisfies Options;
       const validator = new OptionValidator(options);

--- a/packages/tsargp/test/validator/validator.requirements.spec.ts
+++ b/packages/tsargp/test/validator/validator.requirements.spec.ts
@@ -97,7 +97,7 @@ describe('OptionValidator', () => {
           type: 'command',
           names: ['-c'],
           options: {},
-          cmd: () => {},
+          exec: () => {},
         },
       } as const satisfies Options;
       const validator = new OptionValidator(options);
@@ -213,13 +213,13 @@ describe('OptionValidator', () => {
           type: 'command',
           names: ['-c1'],
           options: {},
-          cmd: () => {},
+          exec: () => {},
         },
         required2: {
           type: 'command',
           names: ['-c2'],
           options: {},
-          cmd: () => {},
+          exec: () => {},
         },
       } as const satisfies Options;
       const validator = new OptionValidator(options);
@@ -499,7 +499,7 @@ describe('OptionValidator', () => {
           type: 'command',
           names: ['-c'],
           options: {},
-          cmd: () => {},
+          exec: () => {},
         },
       } as const satisfies Options;
       const validator = new OptionValidator(options);
@@ -615,13 +615,13 @@ describe('OptionValidator', () => {
           type: 'command',
           names: ['-c1'],
           options: {},
-          cmd: () => {},
+          exec: () => {},
         },
         other2: {
           type: 'command',
           names: ['-c2'],
           options: {},
-          cmd: () => {},
+          exec: () => {},
         },
       } as const satisfies Options;
       const validator = new OptionValidator(options);

--- a/packages/tsargp/test/validator/validator.spec.ts
+++ b/packages/tsargp/test/validator/validator.spec.ts
@@ -94,10 +94,10 @@ describe('OptionValidator', () => {
               type: 'command',
               names: ['-c'],
               options: { flag: { type: 'flag' } },
-              cmd() {},
+              exec() {},
             },
           },
-          cmd() {},
+          exec() {},
         },
       } as const satisfies Options;
       const validator = new OptionValidator(options);
@@ -116,10 +116,10 @@ describe('OptionValidator', () => {
               type: 'command',
               names: ['-c'],
               options: (): Options => options,
-              cmd() {},
+              exec() {},
             },
           },
-          cmd() {},
+          exec() {},
         },
       } as const satisfies Options;
       const validator = new OptionValidator(options);


### PR DESCRIPTION
The parsing callbacks were refactored to accept a single parameter of type `ParseInfo`, which contains information about the current argument sequence in the parsing loop.

The parsing loop was refactored to accumulate a sequence of arguments that are then passed to the parsing callbacks as the option parameter(s).

As a consequence of this change, name suggestions on parse errors are no longer supported. Accordingly, the `parseError` enumerator was removed from `ErrorItem`.

The Parser page was updated to document the new `ParseInfo` type, along with information regarding the parsing callbacks. The Options page was updated to document changes made to the parsing callbacks. The `parseError` enumerator was removed from the Validator page.

Closes #90 
