### PR TITLE
Refactor/83

### DIFF
--- a/.changeset/cuddly-stingrays-report.md
+++ b/.changeset/cuddly-stingrays-report.md
@@ -1,0 +1,5 @@
+---
+'tsargp': minor
+---
+
+Added new attributes for the boolean option: `truthNames`, `falsityNames` and `caseSensitive`. They can be used to configure how option parameters are converted to boolean.

--- a/.changeset/red-ghosts-shake.md
+++ b/.changeset/red-ghosts-shake.md
@@ -1,0 +1,5 @@
+---
+'@trulysimple/tsargp-docs': minor
+---
+
+Some subsections of the "Parameter attributes" section of the Options page were moved to a new section called "Known value attributes", to reflect changes made in the code.

--- a/cspell.json
+++ b/cspell.json
@@ -4,6 +4,7 @@
   "language": "en",
   "dictionaries": ["cpp", "typescript"],
   "words": ["uncategorized"],
+  "flagWords": ["contraint"],
   "ignoreWords": [
     "Sogari",
     "lockb",
@@ -14,12 +15,12 @@
     "trulysimple",
     "nextra",
     "niladic",
+    "polyadic",
     "println",
     "compspec",
     "svgr",
     "oclif",
     "codemirror",
-    "CODEOWNERS",
     "IIFE"
   ],
   "ignoreRegExpList": ["gh-username", "ga-measurement-id"],
@@ -28,8 +29,9 @@
     ".prettierignore",
     "CODEOWNERS",
     "pre.json",
+    "cspell.json",
     ".git",
-    "*.{js,ts,jsx,tsx,mdx}"
+    "*.{js,ts,jsx,tsx}"
   ],
   "useGitignore": true,
   "enableGlobDot": true,

--- a/packages/docs/pages/docs/library/formatter.mdx
+++ b/packages/docs/pages/docs/library/formatter.mdx
@@ -55,7 +55,7 @@ This column contains the options' names separated by commas. The names are liste
 as was specified in the [names] attribute.
 
 Depending on the [alignment] configuration, each option name may reserve a "slot" in the respective
-potision in this column. The length of a name slot will be the length of the largest name in that
+position in this column. The length of a name slot will be the length of the largest name in that
 slot, among all options. Empty strings or `null{:ts}`s can be specified in order to skip a slot.
 
 For example, if an option's names are `'-f'{:ts}`, `'-ff'{:ts}`, `''{:ts}` and `'--flag'{:ts}`, the
@@ -238,6 +238,7 @@ and in what order. It is an array whose values can be one of the enumerators fro
 - `envVar` - the option's environment variable, if any
 - `requiredIf` - the option's conditional requirements, if any
 - `clusterLetters` - the option's cluster letters, if any
+- `fallback` - the option's fallback value, if any
 
 The default is to print all items in the order listed above.
 
@@ -266,7 +267,8 @@ The `phrases` property specifies the phrases to be used for each kind of help it
 - `link` - `'Refer to %u for details.'{:ts}`
 - `envVar` - `'Can be specified through the %o environment variable.'{:ts}`
 - `requiredIf` - `'Required if %p.'{:ts}`
-- `clusterLetters` - `'Can be clusterd with %s.'{:ts}`
+- `clusterLetters` - `'Can be clustered with %s.'{:ts}`
+- `fallback` - `'Falls back to (%b|%s|%n|[%s]|[%n]|%v) if specified without parameter.'{:ts}`
 
 These phrases will be formatted according to [text formatting] rules.
 
@@ -276,30 +278,31 @@ Help phrases may have [format specifiers] prefixed with a percent sign `%`, whic
 a value. The following table lists the available specifiers for each kind of help item, along with a
 description of the corresponding value:
 
-| Error          | Specifiers                              |
-| -------------- | --------------------------------------- |
-| synopsis       | `%t` = the option synopsis              |
-| negation       | `%o` = the negation names               |
-| separator      | `%s`/`%r` = the parameter separator     |
-| variadic       |                                         |
-| positional     | `%o` = the positional marker            |
-| append         |                                         |
-| trim           |                                         |
-| case           |                                         |
-| conv           | `%t` = the math function                |
-| enums          | `%s`/`%n` = the enum values             |
-| regex          | `%r` = the regular expression           |
-| range          | `%n` = the numeric range                |
-| unique         |                                         |
-| limit          | `%n` = the count limit                  |
-| requires       | `%p` = the requirements                 |
-| required       |                                         |
-| default        | `%b`/`%s`/`%n`/`%v` = the default value |
-| deprecated     | `%t` = the deprecation reason           |
-| link           | `%u` = the hyperlink                    |
-| envVar         | `%o` = the variable name                |
-| requiredIf     | `%p` = the requirements                 |
-| clusterLetters | `%s` = the cluster letters              |
+| Error          | Specifiers                               |
+| -------------- | ---------------------------------------- |
+| synopsis       | `%t` = the option synopsis               |
+| negation       | `%o` = the negation names                |
+| separator      | `%s`/`%r` = the parameter separator      |
+| variadic       |                                          |
+| positional     | `%o` = the positional marker             |
+| append         |                                          |
+| trim           |                                          |
+| case           |                                          |
+| conv           | `%t` = the math function                 |
+| enums          | `%s`/`%n` = the enum values              |
+| regex          | `%r` = the regular expression            |
+| range          | `%n` = the numeric range                 |
+| unique         |                                          |
+| limit          | `%n` = the count limit                   |
+| requires       | `%p` = the requirements                  |
+| required       |                                          |
+| default        | `%b`/`%s`/`%n`/`%v` = the default value  |
+| deprecated     | `%t` = the deprecation reason            |
+| link           | `%u` = the hyperlink                     |
+| envVar         | `%o` = the variable name                 |
+| requiredIf     | `%p` = the requirements                  |
+| clusterLetters | `%s` = the cluster letters               |
+| fallback       | `%b`/`%s`/`%n`/`%v` = the fallback value |
 
 ### Option filters
 

--- a/packages/docs/pages/docs/library/options.mdx
+++ b/packages/docs/pages/docs/library/options.mdx
@@ -15,25 +15,25 @@ available types and describe them in detail.
 
 There is a total of ten option types, as summarized in the table below:
 
-| Option type | Parameters                              | Data type          | Normalization      | Constraints         |
-| ----------- | --------------------------------------- | ------------------ | ------------------ | ------------------- |
-| [help]      | niladic                                 | `never{:ts}`[^1]   |                    |                     |
-| [version]   | niladic                                 | `never{:ts}`[^1]   |                    |                     |
-| [function]  | niladic                                 | `unknown{:ts}`[^2] |                    |                     |
-| [command]   | not applicable                          | `unknown{:ts}`[^2] |                    |                     |
-| [flag]      | niladic                                 | `boolean{:ts}`     |                    |                     |
-| [boolean]   | positional, monadic                     | `boolean{:ts}`     |                    |                     |
-| [string]    | positional, monadic                     | `string{:ts}`      | trim, case         | enums, regex        |
-| [number]    | positional, monadic                     | `number{:ts}`      | conv               | enums, range        |
-| [strings]   | positional, delimited, variadic, append | `string[]{:ts}`    | unique, trim, case | enums, regex, limit |
-| [numbers]   | positional, delimited, variadic, append | `number[]{:ts}`    | unique, conv       | enums, range, limit |
+| Type       | Parameters                              | Value              | Normalization            | Constraints               |
+| ---------- | --------------------------------------- | ------------------ | ------------------------ | ------------------------- |
+| [help]     | niladic                                 | `never{:ts}`[^1]   |                          |                           |
+| [version]  | niladic                                 | `never{:ts}`[^1]   |                          |                           |
+| [function] | niladic                                 | `unknown{:ts}`[^2] |                          |                           |
+| [command]  | not applicable                          | `unknown{:ts}`[^2] |                          |                           |
+| [flag]     | niladic                                 | `boolean{:ts}`     |                          |                           |
+| [boolean]  | positional, monadic                     | `boolean{:ts}`     |                          | [truth], [falsity]        |
+| [string]   | positional, monadic                     | `string{:ts}`      | [trim], [case]           | [enums], [regex]          |
+| [number]   | positional, monadic                     | `number{:ts}`      | [conv]                   | [enums], [range]          |
+| [strings]  | positional, delimited, variadic, append | `string[]{:ts}`    | [unique], [trim], [case] | [enums], [regex], [limit] |
+| [numbers]  | positional, delimited, variadic, append | `number[]{:ts}`    | [unique], [conv]         | [enums], [range], [limit] |
 
 The meaning of each column is explained below.
 
 ### Option type
 
 The `type` attribute of an option definition indicates the type of the option. It is the only
-required attribute of any option. It is used as a [discriminant] for determining the avaiable
+required attribute of any option. It is used as a [discriminant] for determining the available
 attributes of each specific option.
 
 ### Option parameters
@@ -41,12 +41,12 @@ attributes of each specific option.
 The parameters column indicates how many parameters an option expects on the command-line:
 
 - _niladic_ - no parameter
-- _monadic_ - a single parameter
-- _variadic_ - a variable number of parameters
-- _delimited_ - a single parameter in which values are delimited by a [separator]
-- _append_ - the option can be specified multiple times, with the elements being appended
-- _not applicable_ - the command option does not accept "parameters"; rather, it starts a new
-  parsing loop with the remaining command-line arguments
+- _monadic_ - single parameter
+- _variadic_ - variable number of parameters
+- _delimited_ - single parameter in which values are delimited by a [separator]
+- _append_ - can be specified multiple times, with values being appended
+- _not applicable_ - does not accept parameters; rather, it starts a new parsing context with the
+  remaining arguments
 
 In the case of non-niladic options, the parameter(s) can be made optional by setting a [fallback
 value].
@@ -59,9 +59,13 @@ for the help and version options, which do not have values, the initial value of
 
 ### Normalization & constraints
 
-All options that accept parameters can be configured with normalization and contraint attributes.
-These attributes indicate how the option value should be transformed after being parsed, and if it
-should comply with any value constraints.
+All options that accept parameters can be configured with normalization and constraint attributes.
+
+In the case of string-valued and number-valued options, these attributes indicate how the option
+value should be transformed after being parsed, and if it should comply with any value constraints.
+
+In the case of the boolean option, there is a specialized constraint for the handling of option
+parameters (i.e., before they get parsed).
 
 ## Common attributes
 
@@ -129,13 +133,16 @@ All option types that may have a value share a set of attributes, which are desc
 #### Always required
 
 The `required` attribute indicates that the option is _always_ required, regardless of other
-options. Mutually exclusive with [default value] and [conditional requirements].
+options.
+
+Mutually exclusive with [default value] and [conditional requirements].
 
 #### Default value
 
 The `default` attribute, if present, specifies a value that is used if the option is specified
-neither on the command-line nor as an [environment variable]. Mutually exclusive with [always
-required].
+neither on the command-line nor as an [environment variable].
+
+Mutually exclusive with [always required].
 
 Both [function options] and [command options] accept any kind of value as the default. In the case
 of object values, it's useful to specify a custom `toString` method in order to render it in the
@@ -206,7 +213,9 @@ Notes about this callback:
 
 The `requiredIf` attribute, if present, specifies conditional requirements. They behave like the
 reverse of the previous attribute: they indicate requirements that must be satisfied for the
-affected option to be _considered_ required. Mutually exclusive with [always required].
+affected option to be _considered_ required.
+
+Mutually exclusive with [always required].
 
 An example might help elucidate this distinction. Suppose we have these requirements:
 
@@ -274,15 +283,12 @@ Notes about this feature:
 
 All non-niladic option types share a set of attributes, which are described below.
 
-#### Example value
-
-The `example` attribute, if present, specifies a value that replaces the option type in the help
-message. Mutually exclusive with [parameter name].
-
 #### Parameter name
 
-The `paramName` attribute, if present, specifies a parameter name that replaces the option type in
-the help message. Mutually exclusive with [example value].
+The `paramName` attribute, if present, specifies a name that replaces the option type in the help
+message.
+
+Mutually exclusive with [example value].
 
 #### Positional | marker
 
@@ -297,12 +303,9 @@ When using this attribute, we recommend also setting [preferred name] to some ex
 
 #### Complete callback
 
-The `complete` attribute, if present, specifies a [custom callback] for word completion. This can be
-used to make better suggestions than the [default algorithm] would do for the option.
-
-It accepts a single parameter that contains the current [argument information], in which `comp` is
-the word being completed. In the case of array-valued options, the `param` property holds the option
-parameters preceding `comp`, if any.
+The `complete` attribute, if present, specifies a [custom callback] for [word completion]. It
+receives a single parameter that contains the current [argument sequence], in which `comp` is the
+word being completed and `param` holds the option parameters preceding `comp`, if any.
 
 Notes about this callback:
 
@@ -310,13 +313,27 @@ Notes about this callback:
 - it should return the list of completion words
 - if an error is thrown, it is ignored, and the default completion message is thrown instead
 
+<Callout type="default">
+  This can be used to make better suggestions than the [completion algorithm] would do for the
+  option.
+</Callout>
+
+### Known value attributes
+
+All option types that have known values share a set of attributes, which are described below.
+
+#### Example value
+
+The `example` attribute, if present, specifies a value that replaces the option type in the help
+message.
+
+Mutually exclusive with [parameter name].
+
 #### Parse callback
 
 The `parse` attribute, if present, specifies a [custom callback] to parse the value of the option
-parameter(s).
-
-It accepts a single parameter that contains the current [argument information], in which `param`
-holds the option parameter(s). The `comp` property indicates whether word completion is in effect
+parameter(s). It receives a single parameter that contains the current [argument sequence], in which
+`param` holds the option parameter(s) and `comp` indicates whether [word completion] is in effect
 (but not in the current iteration).
 
 Notes about this callback:
@@ -326,10 +343,12 @@ Notes about this callback:
 
 #### Enumeration
 
-The `enums` attribute, if present, specifies enumerated values that the option accepts as parameter.
-Any parameter that does not equal one of these values (after normalization) will cause an error to
-be thrown. Explicitly _not_ available for the [boolean option]. Mutually exclusive with [regular
-expression] and [numeric range].
+The `enums` attribute, if present, specifies enumerated values that the option accepts as the result
+of parsing a single option parameter. Any parameter whose parsed and normalized value does not equal
+one of these values will cause an error to be thrown.
+
+Mutually exclusive with [regular expression] and [numeric range]. Explicitly _not_ available for the
+[boolean option].
 
 #### Fallback value
 
@@ -353,7 +372,9 @@ String-valued option types share a set of attributes, as described below.
 
 The `regex` attribute, if present, specifies a regular expression that string parameters should
 match. Any parameter that does _not_ match the regular expression (after normalization) will cause
-an error to be thrown. Mutually exclusive with [enumeration].
+an error to be thrown.
+
+Mutually exclusive with [enumeration].
 
 #### Trim whitespace
 
@@ -376,11 +397,12 @@ Number-valued option types share a set of attributes, as described below.
 The `range` attribute, if present, specifies a (closed) numeric range that number parameters should
 be within. Any parameter that is _not_ within the given range (after normalization) will cause an
 error to be thrown. You may want to use `[-Infinity, Infinity]{:ts}` to disallow `NaN{:ts}`.
+
 Mutually exclusive with [enumeration].
 
-#### Math convertion
+#### Math conversion
 
-The `conv` attribute, if present, specifies the kind of math convertion to apply to number
+The `conv` attribute, if present, specifies the kind of math conversion to apply to number
 parameters. Can be any of JavaScript's [Math] functions that accept a single number parameter. This
 normalization is applied _before_ checking value constraints.
 
@@ -434,7 +456,7 @@ Niladic options do not expect any parameter on the command-line. With the notabl
 [flag option], these options may have _side-effects_.
 
 <Callout type="info">
-  When word completion is in effect, help and version options are _not_ processed.
+  When [word completion] is in effect, help and version options are _not_ processed.
 </Callout>
 
 ### Help option
@@ -479,25 +501,27 @@ message. You may specify either of the following attributes.
 
 #### Version info
 
-The `version` attribute specifies a semantic version or version information. Mutually exclusive with
-[resolve callback].
+The `version` attribute specifies a semantic version or version information.
+
+Mutually exclusive with [resolve callback].
+
+#### Resolve callback
+
+The `resolve` attribute specifies a resolution function scoped to the module where a `package.json`
+file will be searched and read to extract its `version` field.
+
+Notes about this callback:
+
+- it is meant for use in non-browser environments
+- you should use [`import.meta.resolve`] as value
+
+Mutually exclusive with [version info]
 
 #### Save message
 
 By default, the version option will throw a message to be printed in the terminal. However, this
 behavior can be changed with the `saveMessage` attribute. If present, it indicates that the message
 should be saved as the option value instead of being thrown.
-
-#### Resolve callback
-
-The `resolve` attribute specifies a resolution function scoped to the module where a `package.json`
-file will be searched and read to extract its `version` field. You should use
-[`import.meta.resolve`] for this attribute.
-
-Notes about this callback:
-
-- for use in non-browser environments only
-- mutually exclusive with [version info]
 
 ### Function option
 
@@ -514,14 +538,17 @@ In addition to the set of [value attributes], it has the following attributes.
 
 #### Function callback
 
-The `exec` attribute specifies the [custom callback] that should be executed.
+The `exec` attribute specifies the [custom callback] that should be executed. It accepts a single
+parameter that contains the current [argument sequence]:
 
-It accepts a single parameter that contains the current [argument information], in which `param`
-holds the remaining command-line arguments and `comp` indicates whether word completion is in effect
-(but not in the current iteration).
-
-In the above object, `isComp` can be used to check whether any of the remaining arguments is to be
-completed, when `comp` is true. If so, you can throw a new [completion message] inside the callback.
+- `param` -
+  Holds the remaining command-line arguments.
+- `comp` -
+  Indicates whether [word completion] is in effect (but not in the current iteration).
+- `isComp` -
+  A utility function that can be used to check whether any of the remaining arguments is to be
+  completed, when `comp` is true. If so, you can throw a new [completion message] inside the
+  callback.
 
 Notes about this callback:
 
@@ -549,20 +576,25 @@ the callback.
 #### Skip count
 
 The `skipCount` attribute indicates the number of remaining arguments to skip, after the callback
-returns. You may change this value inside the callback. The parser does not alter this value and
-ignores it during word completion.
+returns. Its value is meant to be changed by the callback.
 
-Here is an example of how it might be used inside the callback:
+It is useful in cases where the number of parameters is unknown, and the callback wants to have
+control over where an argument sequence ends. Here is an example of how it might be used inside the
+callback:
 
 ```ts
 {
   // other attributes...
-  exec(_, _, rest: Array<string>) {
-    this.skipCount = 1;
-    return JSON.parse(rest[0]);
+  exec({param}) {
+    const index = param.findIndex((val) => !val.startsWith('{'));
+    const count = index >= 0 ? index : param.length;
+    this.skipCount = count;
+    return param.slice(0, count).map((val) => JSON.parse(val));
   },
 }
 ```
+
+<Callout type="info">The parser does not alter the value of this attribute.</Callout>
 
 ### Command option
 
@@ -580,26 +612,25 @@ In addition to the set of [value attributes], it has the following attributes.
 
 #### Command callback
 
-The `exec` attribute specifies the [custom callback] that should be executed.
-
-It accepts a single parameter that contains the current [argument information], in which `param`
-holds the values parsed for the command.
+The `exec` attribute specifies the [custom callback] that should be executed. It accepts a single
+parameter that contains the current [argument sequence], in which `param` holds the values parsed
+for the command.
 
 Notes about this callback:
 
 - it can be asynchronous
 - the returned value, if any, will be saved as the option value
-- when word completion is in effect, this callback will _not_ be called
+- when [word completion] is in effect, this callback will _not_ be called, since the completion will
+  have taken place before the callback gets a chance to execute
 
 <Callout type="default">
-  The simplest implementation would just return `cmdValues`. This way, the values can be handled
-  after the parser returns from the parsing loop.
+  The simplest implementation would just return `param`. This way, the values can be handled after
+  the parser returns from the parsing loop.
 </Callout>
 
 <Callout type="info">
-  Please note that the library does not offer a direct way for a command to access the parsed values
-  of ancestor commands (except its immediate parent) during parsing. However, this can be achieved
-  by waiting until the parser returns from the parsing loop before acting upon the option values.
+  Please note that a command cannot access the parsed values of _ancestor_ commands (except its
+  immediate parent) during parsing. This can be achieved by handling the values after parsing.
 </Callout>
 
 #### Command options | callback
@@ -646,22 +677,49 @@ Non-niladic options expect one or more parameters on the command-line.
 
 ### Boolean option
 
-The **boolean** option accepts a single parameter that is converted to boolean. Any string that
-either evaluates to a zero number or is one the words `false`, `no`, or `off` (ignoring case), is
-considered `false{:ts}`. Any other string is considered `true{:ts}`. This option has the following
-sets of attributes:
+The **boolean** option accepts a single parameter that is converted to boolean according to the
+following rules:
 
-- [parameter attributes] for a `boolean{:ts}` data type
+- if:
+  - it matches one of the names in [truth names], it is considered `true{:ts}`
+  - it matches one of the names in [falsity names], it is considered `false{:ts}`
+- else if:
+  - there are truth names, but no falsity name, the result is `false{:ts}`
+  - there are falsity names, but no truth name, the result is `true{:ts}`
+  - there are both truth and falsity names, an error is thrown
+- else, the string is considered `false{:ts}` if it evaluates to zero; otherwise `true{:ts}`
+
+This option has the following sets of attributes:
+
+- [parameter attributes]
+- [known value attributes] for a `boolean{:ts}` data type
 - [value attributes]
 - [miscellaneous attributes]
+- the attributes described below
+
+#### Truth names
+
+The `truthNames` attribute, if present, specifies the names of the boolean truth value (e.g. `true`,
+`yes`, `on`). They are also used in the [completion algorithm].
+
+#### Falsity names
+
+The `falsityNames` attribute, if present, specifies the names of the boolean falsity value. (e.g.
+`false`, `no`, `off`). They are also used in the [completion algorithm].
+
+#### Case sensitive
+
+The `caseSensitive` attribute, if present, indicates whether the truth and falsity names should be
+considered case-sensitive.
 
 ### String option
 
 The **string** option accepts a single parameter that is normalized according to the constraints
 specified in its definition. It has the following sets of attributes:
 
-- [parameter attributes] for a `string{:ts}` data type
 - [value attributes]
+- [parameter attributes]
+- [known value attributes] for a `string{:ts}` data type
 - [string attributes]
 - [miscellaneous attributes]
 
@@ -670,8 +728,9 @@ specified in its definition. It has the following sets of attributes:
 The **number** option accepts a single parameter that is converted to `Number{:ts}` and normalized
 according to the constraints specified in its definition. It has the following sets of attributes:
 
-- [parameter attributes] for a `number{:ts}` data type
 - [value attributes]
+- [parameter attributes]
+- [known value attributes] for a `number{:ts}` data type
 - [number attributes]
 - [miscellaneous attributes]
 
@@ -680,8 +739,9 @@ according to the constraints specified in its definition. It has the following s
 The **strings** option accepts multiple parameters that are normalized according to the constraints
 specified in its definition. It has the following sets of attributes:
 
-- [parameter attributes] for a `string[]{:ts}` data type
 - [value attributes]
+- [parameter attributes]
+- [known value attributes] for a `string[]{:ts}` data type
 - [string attributes]
 - [array attributes]
 - [miscellaneous attributes]
@@ -692,12 +752,21 @@ The **numbers** option accepts multiple parameters that are converted to `Number
 normalized according to the constraints specified in its definition. It has the following sets of
 attributes:
 
-- [parameter attributes] for a `number[]{:ts}` data type
 - [value attributes]
+- [parameter attributes]
+- [known value attributes] for a `number[]{:ts}` data type
 - [number attributes]
 - [array attributes]
 - [miscellaneous attributes]
 
+[trim]: #trim-whitespace
+[case]: #case-conversion
+[conv]: #math-conversion
+[enums]: #enumeration
+[regex]: #regular-expression
+[range]: #numeric-range
+[unique]: #remove-duplicates
+[limit]: #count-limit
 [help]: #help-option
 [version]: #version-option
 [function]: #function-option
@@ -711,6 +780,10 @@ attributes:
 [enumeration]: #enumeration
 [separator]: #separator
 [format]: #help-format
+[truth]: #truth-names
+[falsity]: #falsity-names
+[truth names]: #truth-names
+[falsity names]: #falsity-names
 [flag option]: #flag-option
 [command options]: #command-option
 [nested command]: #command-option
@@ -737,24 +810,27 @@ attributes:
 [value attributes]: #value-attributes
 [miscellaneous attributes]: #miscellaneous-attributes
 [parameter attributes]: #parameter-attributes
+[known value attributes]: #known-value-attributes
 [string attributes]: #string-attributes
 [number attributes]: #number-attributes
 [array attributes]: #array-attributes
-[cluster letters]: cluster-letters
-[formatter]: formatter
+[cluster letters]: #cluster-letters
 [fallback value]: #fallback-value
+[skip count]: #skip-count
+[formatter]: formatter
 [commands guide]: ../guides/commands
 [recursive commands]: ../guides/commands
 [styling]: styles#styling-attributes
 [resulting object]: parser#option-values
 [text formatting]: styles#text-splitting
 [warning message]: styles#warning-message
-[default algorithm]: parser#completion-algorithm
+[word completion]: parser#word-completion
+[completion algorithm]: parser#completion-algorithm
 [help format]: formatter#help-format
 [help sections]: formatter#help-sections
 [option filters]: formatter#option-filters
 [custom callback]: parser#custom-callbacks
-[argument information]: parser#argument-information
+[argument sequence]: parser#argument-sequence
 [completion message]: styles#completion-words
 [`parseInto`]: parser#using-your-own-object
 [`shortStyle`]: parser#short-option-style

--- a/packages/docs/pages/docs/library/parser.mdx
+++ b/packages/docs/pages/docs/library/parser.mdx
@@ -111,7 +111,7 @@ Besides, the asynchronous version has the benefit of allowing us to perform some
 concurrently, such as the requirements verification. This should not be a drawback for most CLI
 applications, since argument parsing is usually done at the top-level of a module or script.
 
-#### Argument information
+#### Argument sequence
 
 The `ParseInfo` object is passed as the parameter of some of the aforementioned callbacks, and
 contains information about the current argument sequence in the parsing loop:
@@ -176,8 +176,8 @@ an empty string):
 2. _comp_ is the parameter of a non-niladic option:
    - If the option has a [complete callback], it is called with _comp_ and its result is returned;
      else
-   - If it is a boolean option, the words `'true'{:ts}` and `'false'{:ts}` are filtered by the prefix
-     _comp_, and then returned; else
+   - If it is a boolean option, the option's [truth names] and [falsity names] are filtered by the
+     prefix _comp_, and then returned; else
    - If the option has [enumerated values], those values are converted to string, filtered by the
      prefix _comp_, and then returned; else
    - If it is a variadic array option, and the parameter was specified neither with a positional
@@ -258,6 +258,8 @@ they would pollute the output of process management utilities such as `ps`.
 [command callback]: options#command-callback
 [warning messages]: styles#warning-message
 [preferred name]: options#names--preferred-name
+[truth names]: options#truth-names
+[falsity names]: options#falsity-names
 [`break`]: options#break-loop
 [Set]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set
 [Bash docs]: https://www.gnu.org/software/bash/manual/html_node/Programmable-Completion.html

--- a/packages/docs/pages/docs/library/styles.mdx
+++ b/packages/docs/pages/docs/library/styles.mdx
@@ -252,7 +252,7 @@ preserve the disposition of wrapped text.
 
 ### Default width
 
-In addition to the `wrap` mtehod, this class overrides the `toString` method and provides a
+In addition to the `wrap` method, this class overrides the `toString` method and provides a
 `message` property, both of which can be used to obtain a string wrapped with a default terminal
 width.
 

--- a/packages/docs/pages/docs/library/validator.mdx
+++ b/packages/docs/pages/docs/library/validator.mdx
@@ -139,7 +139,7 @@ the restrictions listed below:
   Since a requirement may be an object with values of any kind, the data type of these values must
   be validated at run-time. Thus, an option must not declare a requirement that references a valued
   option, if it requires a value that does _not_ conform to the data type expected by that option.
-- **Constraint violationn** -
+- **Constraint violation** -
   If an option declares a requirement that includes a required value, then that value is subject to
   the same set of constraints as that of the command-line arguments, so it must satisfy the
   restrictions listed in [value validation].
@@ -250,8 +250,8 @@ The `ErrorItem` enumeration lists the kinds of error messages that may be raised
 - `duplicateClusterLetter` -
   raised by the validator when an option has a duplicate cluster letter
 - `invalidClusterOption` -
-  raised by the parser when either a variadic array option or a command option is specified in the
-  middle of a cluster argument
+  raised by the parser when either a variadic option or a command option is specified in the middle
+  of a cluster argument
 - `invalidClusterLetter` -
   raised by the validator when an option has an invalid cluster letter
 - `tooSimilarOptionNames` -
@@ -260,7 +260,9 @@ The `ErrorItem` enumeration lists the kinds of error messages that may be raised
   warning produced by the validator when a name slot contains names with different naming
   conventions
 - `invalidNumericRange` -
-  raised by the validator when an option has an invalid numeric range
+  raised by the validator when a number-valued option has an invalid numeric range
+- `invalidBooleanParameter` -
+  raised by the parser when a parameter to a boolean option fails to be converted
 
 ### Error phrases
 
@@ -298,6 +300,7 @@ following optional properties, which are the enumerators from `ErrorItem`:
 - `tooSimilarOptionNames` - `'%o: Option name %s1 has too similar names %s2.'{:ts}`
 - `mixedNamingConvention` - `'%o: Name slot %n has mixed naming conventions [%s].'{:ts}`
 - `invalidNumericRange` - `'Option %o has invalid numeric range [%n].'{:ts}`
+- `invalidBooleanParameter` - `'Invalid parameter to %o: %s1. Possible values are {%s2}.'{:ts}`
 
 These phrases will be formatted according to [text formatting] rules.
 
@@ -307,38 +310,40 @@ Error phrases may have [format specifiers] prefixed with a percent sign `%`, whi
 a value. The following table lists the available specifiers for each kind of error message, along
 with a description of the corresponding value:
 
-| Error                      | Specifiers                                                                                  |
-| -------------------------- | ------------------------------------------------------------------------------------------- |
-| unknownOption              | `%o`/`%o1` = the unknown option name; `%o2` = similar option names                          |
-| unsatisfiedRequirement     | `%o` = the specified option name; `%p` = the option's requirements                          |
-| missingRequiredOption      | `%o` = the option's preferred name                                                          |
-| missingParameter           | `%o` = the specified option name                                                            |
-| missingPackageJson         |                                                                                             |
-| disallowedInlineValue      | `%o` = the specified option name or positional marker                                       |
-| emptyPositionalMarker      | `%o` = the option's key                                                                     |
-| unnamedOption              | `%o` = the option's key                                                                     |
-| invalidOptionName          | `%o` = the option's key; `%s` = the invalid name                                            |
-| emptyVersionDefinition     | `%o` = the option's key                                                                     |
-| invalidSelfRequirement     | `%o` = the option's key                                                                     |
-| unknownRequiredOption      | `%o` = the required option's key                                                            |
-| invalidRequiredOption      | `%o` = the required option's key                                                            |
-| invalidRequiredValue       | `%o` = the required option's key                                                            |
-| incompatibleRequiredValue  | `%o` = the required option's key; `%v` = the incompatible value; `%s` = the expected type   |
-| emptyEnumsDefinition       | `%o` = the option's key                                                                     |
-| duplicateOptionName        | `%o` = the option's key; `%s` = the duplicate name                                          |
-| duplicatePositionalOption  | `%o1` = the duplicate option's key; `%o2` = the previous option's key                       |
-| duplicateEnumValue         | `%o` = the option's key; `%s`/`%n` = the duplicate enum value                               |
-| enumsConstraintViolation   | `%o` = the option's key or name; `%s1`/`%n1` = the specified value; `%s2`/`%n2` = the enums |
-| regexConstraintViolation   | `%o` = the option's key or name; `%s` = the specified value; `%r` = the regex               |
-| rangeConstraintViolation   | `%o` = the option's key or name; `%n1` = the specified value; `%n2` = the range             |
-| limitConstraintViolation   | `%o` = the option's key or name; `%n1` = the value count; `%n2` = the count limit           |
-| deprecatedOption           | `%o` = the specified option name                                                            |
-| unsatisfiedCondRequirement | `%o` = the specified option name; `%p` = the option's requirements                          |
-| duplicateClusterLetter     | `%o` = the option's key; `%s` = the duplicate letter                                        |
-| invalidClusterOption       | `%o` = the specified cluster letter                                                         |
-| invalidClusterLetter       | `%o` = the option's key; `%s` = the invalid letter                                          |
-| tooSimilarOptionNames      | `%o` = the command prefix[^1]; `%s1` = the option name; `%s2` = the similar names           |
-| mixedNamingConvention      | `%o` = the command prefix[^1]; `%n` = the slot index; `%s` = the naming conventions         |
+| Error                      | Specifiers                                                                                         |
+| -------------------------- | -------------------------------------------------------------------------------------------------- |
+| unknownOption              | `%o`/`%o1` = the unknown option name; `%o2` = similar option names                                 |
+| unsatisfiedRequirement     | `%o` = the specified option name; `%p` = the option's requirements                                 |
+| missingRequiredOption      | `%o` = the option's preferred name                                                                 |
+| missingParameter           | `%o` = the specified option name                                                                   |
+| missingPackageJson         |                                                                                                    |
+| disallowedInlineValue      | `%o` = the specified option name or positional marker                                              |
+| emptyPositionalMarker      | `%o` = the option's key                                                                            |
+| unnamedOption              | `%o` = the option's key                                                                            |
+| invalidOptionName          | `%o` = the option's key; `%s` = the invalid name                                                   |
+| emptyVersionDefinition     | `%o` = the option's key                                                                            |
+| invalidSelfRequirement     | `%o` = the option's key                                                                            |
+| unknownRequiredOption      | `%o` = the required option's key                                                                   |
+| invalidRequiredOption      | `%o` = the required option's key                                                                   |
+| invalidRequiredValue       | `%o` = the required option's key                                                                   |
+| incompatibleRequiredValue  | `%o` = the required option's key; `%v` = the incompatible value; `%s` = the expected type          |
+| emptyEnumsDefinition       | `%o` = the option's key                                                                            |
+| duplicateOptionName        | `%o` = the option's key; `%s` = the duplicate name                                                 |
+| duplicatePositionalOption  | `%o1` = the duplicate option's key; `%o2` = the previous option's key                              |
+| duplicateEnumValue         | `%o` = the option's key; `%s`/`%n` = the duplicate enum value                                      |
+| enumsConstraintViolation   | `%o` = the option's key or name; `%s1`/`%n1` = the specified value; `%s2`/`%n2` = the enums        |
+| regexConstraintViolation   | `%o` = the option's key or name; `%s` = the specified value; `%r` = the regular expression         |
+| rangeConstraintViolation   | `%o` = the option's key or name; `%n1` = the specified value; `%n2` = the numeric range            |
+| limitConstraintViolation   | `%o` = the option's key or name; `%n1` = the value count; `%n2` = the count limit                  |
+| deprecatedOption           | `%o` = the specified option name                                                                   |
+| unsatisfiedCondRequirement | `%o` = the specified option name; `%p` = the option's requirements                                 |
+| duplicateClusterLetter     | `%o` = the option's key; `%s` = the duplicate letter                                               |
+| invalidClusterOption       | `%o` = the specified cluster letter                                                                |
+| invalidClusterLetter       | `%o` = the option's key; `%s` = the invalid letter                                                 |
+| tooSimilarOptionNames      | `%o` = the command prefix[^1]; `%s1` = the option name; `%s2` = the similar names                  |
+| mixedNamingConvention      | `%o` = the command prefix[^1]; `%n` = the slot index; `%s` = the naming conventions                |
+| invalidNumericRange        | `%o` = the option's key; `%n` = the numeric range                                                  |
+| invalidBooleanParameter    | `%o` = the specified option name; `%s1` = the specified value; `%s2` = the truth and falsity names |
 
 ### Connective words
 
@@ -373,7 +378,7 @@ the enumerators from `ConnectiveWords`:
 
 [^1]:
     the command prefix is a series of option keys interspersed with periods, denoting the current
-    [nested command] in a hierarquical option definition. It starts as the empty string and is
+    [nested command] in a hierarchical option definition. It starts as the empty string and is
     appended with the command option's key whenever a nested command is encountered. This prefix
     also appears in other validation error messages, embedded in the value that replaces the `%o`
     specifier. Here's an example: `cmd1.cmd2.flag`.

--- a/packages/tsargp/lib/enums.ts
+++ b/packages/tsargp/lib/enums.ts
@@ -119,8 +119,8 @@ export const enum ErrorItem {
    */
   duplicateClusterLetter,
   /**
-   * Raised by the parser when either a variadic array option or a command option is specified in
-   * the middle of a cluster argument.
+   * Raised by the parser when either a variadic option or a command option is specified in the
+   * middle of a cluster argument.
    */
   invalidClusterOption,
   /**
@@ -137,9 +137,13 @@ export const enum ErrorItem {
    */
   mixedNamingConvention,
   /**
-   * Raised by the validator when an option has an invalid numeric range.
+   * Raised by the validator when a number-valued option has an invalid numeric range.
    */
   invalidNumericRange,
+  /**
+   * Raised by the parser when a parameter to a boolean option fails to be converted.
+   */
+  invalidBooleanParameter,
 }
 
 /**

--- a/packages/tsargp/lib/formatter.ts
+++ b/packages/tsargp/lib/formatter.ts
@@ -983,11 +983,11 @@ function formatExample(option: OpaqueOption, styles: FormatStyles, result: Termi
     const sep = typeof separator === 'string' ? separator : separator.source;
     const value = (example as Array<unknown>).join(sep);
     result.formatArgs(styles, '%s', { s: value });
-  } else {
-    const spec = isBoolean(option) ? 'b' : isString(option) ? 's' : isNumber(option) ? 'n' : 'v';
-    result.formatArgs(styles, `%${spec}`, { [spec]: example }, {});
+    return result.length;
   }
-  const nonDelimited = Array.isArray(example) && !separator;
+  const spec = isBoolean(option) ? 'b' : isString(option) ? 's' : isNumber(option) ? 'n' : 'v';
+  result.formatArgs(styles, `%${spec}`, { [spec]: example }, {});
+  const nonDelimited = spec !== 'v' && Array.isArray(example);
   return result.length + (nonDelimited ? example.length - 1 : 0);
 }
 

--- a/packages/tsargp/lib/options.ts
+++ b/packages/tsargp/lib/options.ts
@@ -3,7 +3,7 @@
 //--------------------------------------------------------------------------------------------------
 import type { FormatterConfig, HelpSections } from './formatter';
 import type { HelpMessage, Style } from './styles';
-import type { Resolve, URL, Flatten, KeyHaving, Range } from './utils';
+import type { Resolve, URL, KeyHaving, Range } from './utils';
 
 //--------------------------------------------------------------------------------------------------
 // Constants
@@ -316,14 +316,8 @@ export type WithValue<T> = {
 
 /**
  * Defines attributes common to options with parameters.
- * @template P The parameter data type
- * @template T The option value data type
  */
-export type WithParam<P, T> = {
-  /**
-   * The option example value. Replaces the option type in the help message parameter column.
-   */
-  readonly example?: Readonly<T>;
+export type WithParam = {
   /**
    * The option parameter name. Replaces the option type in the help message parameter column.
    */
@@ -345,16 +339,24 @@ export type WithParam<P, T> = {
    * If it throws an error, it is ignored, and the default completion message is thrown instead.
    */
   readonly complete?: CompleteCallback;
+};
+
+/**
+ * Defines attributes common to options with known values.
+ * @template P The parameter data type
+ * @template T The option value data type
+ */
+export type WithKnownValue<P, T> = {
+  /**
+   * The option example value. Replaces the option type in the help message parameter column.
+   */
+  readonly example?: Readonly<T>;
   /**
    * A custom callback to parse the value of the option parameter(s).
    * It should return the new option value.
    * Normalization and constraints will be applied to the returned value.
    */
   readonly parse?: ParseCallback<P, T>;
-  /**
-   * The enumerated values.
-   */
-  readonly enums?: ReadonlyArray<Flatten<T>>;
   /**
    * A fallback value that is used if the option is specified, but without any parameter.
    * This makes the option parameter(s) optional, both for single-valued and array-valued options.
@@ -363,9 +365,31 @@ export type WithParam<P, T> = {
 };
 
 /**
+ * Defines additional attributes for the boolean option.
+ */
+export type WithBoolean = {
+  /**
+   * The names of the truth value.
+   */
+  readonly truthNames?: ReadonlyArray<string>;
+  /**
+   * The names of the falsity value.
+   */
+  readonly falsityNames?: ReadonlyArray<string>;
+  /**
+   * True if the truth and falsity names should be case-sensitive.
+   */
+  readonly caseSensitive?: true;
+};
+
+/**
  * Defines attributes common to string-valued options.
  */
 export type WithString = {
+  /**
+   * The enumerated values.
+   */
+  readonly enums?: ReadonlyArray<string>;
   /**
    * The regular expression.
    */
@@ -384,6 +408,10 @@ export type WithString = {
  * Defines attributes common to number-valued options.
  */
 export type WithNumber = {
+  /**
+   * The enumerated values.
+   */
+  readonly enums?: ReadonlyArray<number>;
   /**
    * The numeric range. You may want to use `[-Infinity, Infinity]` to disallow `NaN`.
    */
@@ -539,6 +567,7 @@ export type VersionOption = WithType<'version'> &
 export type FunctionOption = WithType<'function'> &
   WithBasic &
   WithFunction &
+  WithParam &
   WithValue<unknown> &
   (WithDefault | WithRequired);
 
@@ -567,8 +596,10 @@ export type FlagOption = WithType<'flag'> &
 export type BooleanOption = WithType<'boolean'> &
   WithBasic &
   WithMisc &
+  WithParam &
+  WithBoolean &
   WithValue<boolean> &
-  WithParam<string, boolean> &
+  WithKnownValue<string, boolean> &
   (WithDefault | WithRequired) &
   (WithExample | WithParamName);
 
@@ -579,8 +610,9 @@ export type StringOption = WithType<'string'> &
   WithBasic &
   WithMisc &
   WithString &
+  WithParam &
   WithValue<string> &
-  WithParam<string, string> &
+  WithKnownValue<string, string> &
   (WithDefault | WithRequired) &
   (WithExample | WithParamName) &
   (WithEnums | WithRegex);
@@ -592,8 +624,9 @@ export type NumberOption = WithType<'number'> &
   WithBasic &
   WithMisc &
   WithNumber &
+  WithParam &
   WithValue<number> &
-  WithParam<string, number> &
+  WithKnownValue<string, number> &
   (WithDefault | WithRequired) &
   (WithExample | WithParamName) &
   (WithEnums | WithRange);
@@ -606,8 +639,9 @@ export type StringsOption = WithType<'strings'> &
   WithMisc &
   WithString &
   WithArray &
+  WithParam &
   WithValue<Array<string>> &
-  WithParam<Array<string>, Array<string>> &
+  WithKnownValue<Array<string>, Array<string>> &
   (WithDefault | WithRequired) &
   (WithExample | WithParamName) &
   (WithAppend | WithParse) &
@@ -621,8 +655,9 @@ export type NumbersOption = WithType<'numbers'> &
   WithMisc &
   WithNumber &
   WithArray &
+  WithParam &
   WithValue<Array<number>> &
-  WithParam<Array<string>, Array<number>> &
+  WithKnownValue<Array<string>, Array<number>> &
   (WithDefault | WithRequired) &
   (WithExample | WithParamName) &
   (WithAppend | WithParse) &
@@ -681,14 +716,16 @@ type OptionTypes =
  */
 export type OpaqueOption = WithType<OptionTypes> &
   WithBasic &
+  WithParam &
   WithValue<unknown> &
-  WithParam<unknown, unknown> &
+  WithKnownValue<unknown, unknown> &
   WithHelp &
   WithVersion &
   WithMessage &
   WithFunction &
   WithCommand &
   WithFlag &
+  WithBoolean &
   WithString &
   WithNumber &
   WithArray &
@@ -735,7 +772,7 @@ type WithDefault = {
  */
 type WithExample = {
   /**
-   * @deprecated mutually exclusive with {@link WithParam.example}
+   * @deprecated mutually exclusive with {@link WithKnownValue.example}
    */
   readonly paramName?: never;
 };
@@ -755,11 +792,11 @@ type WithParamName = {
  */
 type WithEnums = {
   /**
-   * @deprecated mutually exclusive with {@link WithParam.enums}
+   * @deprecated mutually exclusive with {@link WithString.enums}
    */
   readonly regex?: never;
   /**
-   * @deprecated mutually exclusive with {@link WithParam.enums}
+   * @deprecated mutually exclusive with {@link WithNumber.enums}
    */
   readonly range?: never;
 };
@@ -819,7 +856,7 @@ type WithAppend = {
  */
 type WithParse = {
   /**
-   * @deprecated mutually exclusive with {@link WithParam.parse}
+   * @deprecated mutually exclusive with {@link WithKnownValue.parse}
    */
   readonly append?: never;
 };

--- a/packages/tsargp/test/parser/parser.environment.spec.ts
+++ b/packages/tsargp/test/parser/parser.environment.spec.ts
@@ -21,12 +21,10 @@ describe('ArgumentParser', () => {
       const parser = new ArgumentParser(options);
       // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
       delete process.env['FLAG2'];
-      process.env['FLAG'] = '1';
-      await expect(parser.parse([])).rejects.toThrow(`Option -f1 requires -f2.`);
-      process.env['FLAG2'] = '1';
-      await expect(parser.parse([])).resolves.toEqual({ flag: true, required: true });
       process.env['FLAG'] = '';
-      await expect(parser.parse(['-f2'])).resolves.toEqual({ flag: false, required: true });
+      await expect(parser.parse([])).rejects.toThrow(`Option -f1 requires -f2.`);
+      process.env['FLAG2'] = '';
+      await expect(parser.parse([])).resolves.toEqual({ flag: true, required: true });
     });
 
     it('should handle a boolean option with an environment variable', async () => {

--- a/packages/tsargp/test/parser/parser.spec.ts
+++ b/packages/tsargp/test/parser/parser.spec.ts
@@ -591,7 +591,40 @@ describe('ArgumentParser', () => {
         await expect(parser.parse(['-b', ' +0.0 '])).resolves.toEqual({ boolean: false });
         await expect(parser.parse(['-b', ' 1 '])).resolves.toEqual({ boolean: true });
         await expect(parser.parse(['--boolean', ''])).resolves.toEqual({ boolean: false });
-        await expect(parser.parse(['-b=1', '-b= False '])).resolves.toEqual({ boolean: false });
+        await expect(parser.parse(['-b=1', '-b=0'])).resolves.toEqual({ boolean: false });
+      });
+
+      it('should handle a boolean option with truth and falsity names', async () => {
+        const options = {
+          boolean: {
+            type: 'boolean',
+            names: ['-b'],
+            truthNames: ['true'],
+            falsityNames: ['false'],
+          },
+        } as const satisfies Options;
+        const parser = new ArgumentParser(options);
+        await expect(parser.parse(['-b', ' False '])).resolves.toEqual({ boolean: false });
+        await expect(parser.parse(['-b', ' True '])).resolves.toEqual({ boolean: true });
+      });
+
+      it('should throw an error on invalid parameter to boolean option with case-sensitive truth and falsity names', async () => {
+        const options = {
+          boolean: {
+            type: 'boolean',
+            names: ['-b'],
+            truthNames: ['true'],
+            falsityNames: ['false'],
+            caseSensitive: true,
+          },
+        } as const satisfies Options;
+        const parser = new ArgumentParser(options);
+        await expect(parser.parse(['-b', 'False'])).rejects.toThrow(
+          `Invalid parameter to -b: 'False'. Possible values are {'true', 'false'}.`,
+        );
+        await expect(parser.parse(['-b', 'True'])).rejects.toThrow(
+          `Invalid parameter to -b: 'True'. Possible values are {'true', 'false'}.`,
+        );
       });
     });
 
@@ -619,6 +652,7 @@ describe('ArgumentParser', () => {
         await expect(parser.parse(['-s', '123'])).resolves.toEqual({ string: '123' });
         await expect(parser.parse(['--string', ''])).resolves.toEqual({ string: '' });
         await expect(parser.parse(['-s=1', '-s==2'])).resolves.toEqual({ string: '=2' });
+        await expect(parser.parse(['-s', '1', '-s', '2'])).resolves.toEqual({ string: '2' });
       });
     });
 
@@ -644,8 +678,9 @@ describe('ArgumentParser', () => {
         const parser = new ArgumentParser(options);
         await expect(parser.parse([])).resolves.toEqual({ number: undefined });
         await expect(parser.parse(['-n', '123'])).resolves.toEqual({ number: 123 });
-        await expect(parser.parse(['--number', '0'])).resolves.toEqual({ number: 0 });
-        await expect(parser.parse(['-n=1', '-n=2'])).resolves.toEqual({ number: 2 });
+        await expect(parser.parse(['--number', ''])).resolves.toEqual({ number: 0 });
+        await expect(parser.parse(['-n=1', '-n==2'])).resolves.toEqual({ number: NaN });
+        await expect(parser.parse(['-n', '1', '-n', '2'])).resolves.toEqual({ number: 2 });
       });
     });
 

--- a/packages/tsargp/test/utils.spec.ts
+++ b/packages/tsargp/test/utils.spec.ts
@@ -218,31 +218,43 @@ describe('splitPhrase', () => {
 
 describe('isTrue', () => {
   it('should return false on zero', () => {
-    expect(isTrue('')).toBeFalsy();
-    expect(isTrue('00')).toBeFalsy();
+    expect(isTrue('  ')).toBeFalsy();
+    expect(isTrue(' 00 ')).toBeFalsy();
     expect(isTrue(' +0.0 ')).toBeFalsy();
   });
 
-  it('should return false on false', () => {
-    expect(isTrue('false')).toBeFalsy();
-    expect(isTrue(' FalsE ')).toBeFalsy();
+  it('should return true on non-zero and NaN', () => {
+    expect(isTrue(' 0.1 ')).toBeTruthy();
+    expect(isTrue(' -1 ')).toBeTruthy();
+    expect(isTrue(' abc ')).toBeTruthy();
   });
 
-  it('should return false on no', () => {
-    expect(isTrue('no')).toBeFalsy();
-    expect(isTrue(' No ')).toBeFalsy();
+  it('should return true on matched truth names', () => {
+    const flags = { truthNames: ['true', 'yes', 'on'] };
+    expect(isTrue(' TruE ', flags)).toBeTruthy();
+    expect(isTrue(' yES ', flags)).toBeTruthy();
+    expect(isTrue(' ON ', flags)).toBeTruthy();
+    expect(isTrue(' abc ', flags)).toBeFalsy();
+    expect(isTrue(' True ', { ...flags, caseSensitive: true })).toBeFalsy();
   });
 
-  it('should return false on off', () => {
-    expect(isTrue('off')).toBeFalsy();
-    expect(isTrue(' oFF ')).toBeFalsy();
+  it('should return false on matched falsity names', () => {
+    const flags = { falsityNames: ['false', 'no', 'off'] };
+    expect(isTrue(' FalsE ', flags)).toBeFalsy();
+    expect(isTrue(' No ', flags)).toBeFalsy();
+    expect(isTrue(' oFF ', flags)).toBeFalsy();
+    expect(isTrue(' abc ', flags)).toBeTruthy();
+    expect(isTrue(' False ', { ...flags, caseSensitive: true })).toBeTruthy();
   });
 
-  it('should return true on any other string', () => {
-    expect(isTrue('/0.0')).toBeTruthy();
-    expect(isTrue('/false')).toBeTruthy();
-    expect(isTrue('/no')).toBeTruthy();
-    expect(isTrue('/off')).toBeTruthy();
+  it('should return undefined on unmatched truth and falsity names', () => {
+    const flags = {
+      truthNames: ['true', 'yes', 'on'],
+      falsityNames: ['false', 'no', 'off'],
+    };
+    expect(isTrue(' abc ', flags)).toBeUndefined();
+    expect(isTrue(' True ', { ...flags, caseSensitive: true })).toBeUndefined();
+    expect(isTrue(' False ', { ...flags, caseSensitive: true })).toBeUndefined();
   });
 });
 

--- a/packages/tsargp/test/validator/validator.constraints.spec.ts
+++ b/packages/tsargp/test/validator/validator.constraints.spec.ts
@@ -4,6 +4,68 @@ import '../utils.spec';
 
 describe('OptionValidator', () => {
   describe('validate', () => {
+    it('should throw an error on string option with zero enumerated values', () => {
+      const options = {
+        string: {
+          type: 'string',
+          names: ['-s'],
+          enums: [],
+        },
+      } as const satisfies Options;
+      const validator = new OptionValidator(options);
+      expect(() => validator.validate()).toThrow(`Option string has zero enum values.`);
+    });
+
+    it('should throw an error on number option with zero enumerated values', () => {
+      const options = {
+        number: {
+          type: 'number',
+          names: ['-n'],
+          enums: [],
+        },
+      } as const satisfies Options;
+      const validator = new OptionValidator(options);
+      expect(() => validator.validate()).toThrow(`Option number has zero enum values.`);
+    });
+
+    it('should throw an error on strings option with zero enumerated values', () => {
+      const options = {
+        strings: {
+          type: 'strings',
+          names: ['-ss'],
+          enums: [],
+        },
+      } as const satisfies Options;
+      const validator = new OptionValidator(options);
+      expect(() => validator.validate()).toThrow(`Option strings has zero enum values.`);
+    });
+
+    it('should throw an error on numbers option with zero enumerated values', () => {
+      const options = {
+        numbers: {
+          type: 'numbers',
+          names: ['-ns'],
+          enums: [],
+        },
+      } as const satisfies Options;
+      const validator = new OptionValidator(options);
+      expect(() => validator.validate()).toThrow(`Option numbers has zero enum values.`);
+    });
+
+    it('should ignore default and fallback callbacks on a string option', () => {
+      const options = {
+        string: {
+          type: 'string',
+          names: ['-s'],
+          regex: /\d+/s,
+          default: () => 'abc',
+          fallback: () => 'abc',
+        },
+      } as const satisfies Options;
+      const validator = new OptionValidator(options);
+      expect(() => validator.validate()).not.toThrow();
+    });
+
     it('should throw an error on string example value not matching regex', () => {
       const options = {
         string: {

--- a/packages/tsargp/test/validator/validator.spec.ts
+++ b/packages/tsargp/test/validator/validator.spec.ts
@@ -36,54 +36,6 @@ describe('OptionValidator', () => {
       expect(() => validator.validate()).toThrow(`Option version contains empty version.`);
     });
 
-    it('should throw an error on string option with zero enumerated values', () => {
-      const options = {
-        string: {
-          type: 'string',
-          names: ['-s'],
-          enums: [],
-        },
-      } as const satisfies Options;
-      const validator = new OptionValidator(options);
-      expect(() => validator.validate()).toThrow(`Option string has zero enum values.`);
-    });
-
-    it('should throw an error on number option with zero enumerated values', () => {
-      const options = {
-        number: {
-          type: 'number',
-          names: ['-n'],
-          enums: [],
-        },
-      } as const satisfies Options;
-      const validator = new OptionValidator(options);
-      expect(() => validator.validate()).toThrow(`Option number has zero enum values.`);
-    });
-
-    it('should throw an error on strings option with zero enumerated values', () => {
-      const options = {
-        strings: {
-          type: 'strings',
-          names: ['-ss'],
-          enums: [],
-        },
-      } as const satisfies Options;
-      const validator = new OptionValidator(options);
-      expect(() => validator.validate()).toThrow(`Option strings has zero enum values.`);
-    });
-
-    it('should throw an error on numbers option with zero enumerated values', () => {
-      const options = {
-        numbers: {
-          type: 'numbers',
-          names: ['-ns'],
-          enums: [],
-        },
-      } as const satisfies Options;
-      const validator = new OptionValidator(options);
-      expect(() => validator.validate()).toThrow(`Option numbers has zero enum values.`);
-    });
-
     it('should validate nested command options recursively', () => {
       const options = {
         command: {


### PR DESCRIPTION
Added new attributes for the boolean option: `truthNames`, `falsityNames` and `caseSensitive`. They can be used to configure how option parameters are converted to boolean.

Added a new enumerator called `invalidBooleanParameter` to `ErrorItem`. It is used by the parser to throw an error when a conversion from string to boolean fails.

Some attributes of the `WithParam` type were moved to a new type called `WithKnownValue`, in anticipation for the feature that will be implemented in #83.

Some sections of the Options page were updated to reflect the changes made in the code.
