### PR TITLE
Issues/83

### DIFF
--- a/.changeset/loud-keys-train.md
+++ b/.changeset/loud-keys-train.md
@@ -1,0 +1,5 @@
+---
+'tsargp': minor
+---
+
+Added the `paramCount` attribute to the function option, to specify the number of parameters that the option expects in the command-line. New enumerators, `invalidParamCount` and `variadicWithClusterLetter`, were added to `ErrorItem`, that are used by the validator when validating the new attribute. The formatter was updated to take this attribute into account when rendering the description of variadic options.

--- a/.changeset/popular-cherries-prove.md
+++ b/.changeset/popular-cherries-prove.md
@@ -1,0 +1,5 @@
+---
+'@trulysimple/tsargp-docs': minor
+---
+
+The Options page was updated to document the new `paramCount` attribute of the function option. The Validator page was updated to document the new validations related to variadic options and the fuction option's parameter count.

--- a/packages/docs/pages/docs/library/formatter.mdx
+++ b/packages/docs/pages/docs/library/formatter.mdx
@@ -219,7 +219,7 @@ and in what order. It is an array whose values can be one of the enumerators fro
 - `synopsis` - the option synopsis
 - `negation` - the negation names of a flag option, if any
 - `separator` - the element delimiter of an array option, if enabled
-- `variadic` - reports if an array option accepts multiple parameters
+- `paramCount` - reports the parameter count of a variadic or polyadic[^1] option
 - `positional` - reports if an option accepts positional arguments
 - `append` - reports if an array option can be specified multiple times
 - `trim` - reports if string parameters will be trimmed (have leading and trailing whitespace removed)
@@ -249,7 +249,7 @@ The `phrases` property specifies the phrases to be used for each kind of help it
 - `synopsis` - `'%t'{:ts}`
 - `negation` - `'Can be negated with %o.'{:ts}`
 - `separator` - `'Values are delimited by (%s|%r).'{:ts}`
-- `variadic` - `'Accepts multiple parameters.'{:ts}`
+- `paramCount` - `'Accepts (multiple|%n|at most %n|at least %n|between %n) parameters.'{:ts}`
 - `positional` - `'Accepts positional parameters(| that may be preceded by %o).'{:ts}`
 - `append` - `'May be specified multiple times.'{:ts}`
 - `trim` - `'Values will be trimmed.'{:ts}`
@@ -283,7 +283,7 @@ description of the corresponding value:
 | synopsis       | `%t` = the option synopsis               |
 | negation       | `%o` = the negation names                |
 | separator      | `%s`/`%r` = the parameter separator      |
-| variadic       |                                          |
+| paramCount     | `%n` = the parameter count               |
 | positional     | `%o` = the positional marker             |
 | append         |                                          |
 | trim           |                                          |
@@ -342,3 +342,7 @@ overriden by (or combined with) an option's [display styles], if present.
 [display styles]: options#display-styles
 [error phrases]: validator#error-phrases
 [format specifiers]: styles#format-specifiers
+
+[^1]:
+    _polyadic_ means that the option accepts more than one parameter, but the parameter count is
+    not variable

--- a/packages/docs/pages/docs/library/options.mdx
+++ b/packages/docs/pages/docs/library/options.mdx
@@ -19,7 +19,7 @@ There is a total of ten option types, as summarized in the table below:
 | ---------- | --------------------------------------- | ------------------ | ------------------------ | ------------------------- |
 | [help]     | niladic                                 | `never{:ts}`[^1]   |                          |                           |
 | [version]  | niladic                                 | `never{:ts}`[^1]   |                          |                           |
-| [function] | niladic                                 | `unknown{:ts}`[^2] |                          |                           |
+| [function] | configurable                            | `unknown{:ts}`[^2] |                          | [param count]             |
 | [command]  | not applicable                          | `unknown{:ts}`[^2] |                          |                           |
 | [flag]     | niladic                                 | `boolean{:ts}`     |                          |                           |
 | [boolean]  | positional, monadic                     | `boolean{:ts}`     |                          | [truth], [falsity]        |
@@ -45,6 +45,7 @@ The parameters column indicates how many parameters an option expects on the com
 - _variadic_ - variable number of parameters
 - _delimited_ - single parameter in which values are delimited by a [separator]
 - _append_ - can be specified multiple times, with values being appended
+- _configurable_ - can be configured with a certain [parameter count]
 - _not applicable_ - does not accept parameters; rather, it starts a new parsing context with the
   remaining arguments
 
@@ -64,8 +65,8 @@ All options that accept parameters can be configured with normalization and cons
 In the case of string-valued and number-valued options, these attributes indicate how the option
 value should be transformed after being parsed, and if it should comply with any value constraints.
 
-In the case of the boolean option, there is a specialized constraint for the handling of option
-parameters (i.e., before they get parsed).
+In the case of the function and boolean options, there are specialized constraints for the handling
+of option parameters (i.e., before they get parsed).
 
 ## Common attributes
 
@@ -534,7 +535,8 @@ value. You can use it to perform many kinds of actions, such as:
 - altering the option definitions in response to an option value
   - e.g., if `--verbose` is set, add more help items to the help option's [format]
 
-In addition to the set of [value attributes], it has the following attributes.
+In addition to the set of [value attributes] and [parameter attributes], it has the following
+attributes.
 
 #### Function callback
 
@@ -542,13 +544,15 @@ The `exec` attribute specifies the [custom callback] that should be executed. It
 parameter that contains the current [argument sequence]:
 
 - `param` -
-  Holds the remaining command-line arguments.
+  Holds either the option parameter(s), if [parameter count] is set to a non-zero value, or all
+  remaining arguments.
 - `comp` -
   Indicates whether [word completion] is in effect (but not in the current iteration).
 - `isComp` -
   A utility function that can be used to check whether any of the remaining arguments is to be
   completed, when `comp` is true. If so, you can throw a new [completion message] inside the
-  callback.
+  callback. This should only be used when [parameter count] is _not_ set; otherwise, the detection
+  logic is performed by the parser.
 
 Notes about this callback:
 
@@ -573,6 +577,19 @@ the callback.
   message that any option required by the affected one must be specified _before_ it.
 </Callout>
 
+#### Parameter count
+
+By default, a function option is niladic. However, this behavior can be changed with the
+`paramCount` attribute. If present, it specifies how many parameters the option expects. It can
+have either of the following values:
+
+- a zero value: same as the niladic case
+- a negative number: the option expects unlimited parameters
+- a positive number: the option expects exactly this number of parameters
+- a numeric range: the option accepts between a minimum and maximum count
+
+Mutually exclusive with [skip count].
+
 #### Skip count
 
 The `skipCount` attribute indicates the number of remaining arguments to skip, after the callback
@@ -593,6 +610,8 @@ callback:
   },
 }
 ```
+
+Mutually exclusive with [parameter count].
 
 <Callout type="info">The parser does not alter the value of this attribute.</Callout>
 
@@ -759,6 +778,7 @@ attributes:
 - [array attributes]
 - [miscellaneous attributes]
 
+[param count]: #parameter-count
 [trim]: #trim-whitespace
 [case]: #case-conversion
 [conv]: #math-conversion
@@ -816,6 +836,7 @@ attributes:
 [array attributes]: #array-attributes
 [cluster letters]: #cluster-letters
 [fallback value]: #fallback-value
+[parameter count]: #parameter-count
 [skip count]: #skip-count
 [formatter]: formatter
 [commands guide]: ../guides/commands

--- a/packages/docs/pages/docs/library/options.mdx
+++ b/packages/docs/pages/docs/library/options.mdx
@@ -584,9 +584,9 @@ By default, a function option is niladic. However, this behavior can be changed 
 have either of the following values:
 
 - a zero value: same as the niladic case
-- a negative number: the option expects unlimited parameters
+- a negative number: the option accepts unlimited parameters
 - a positive number: the option expects exactly this number of parameters
-- a numeric range: the option accepts between a minimum and maximum count
+- a numeric range: the option expects between a minimum and maximum count
 
 Mutually exclusive with [skip count].
 
@@ -851,7 +851,7 @@ attributes:
 [help sections]: formatter#help-sections
 [option filters]: formatter#option-filters
 [custom callback]: parser#custom-callbacks
-[argument sequence]: parser#argument-sequence
+[argument sequence]: parser#sequence-information
 [completion message]: styles#completion-words
 [`parseInto`]: parser#using-your-own-object
 [`shortStyle`]: parser#short-option-style

--- a/packages/docs/pages/docs/library/parser.mdx
+++ b/packages/docs/pages/docs/library/parser.mdx
@@ -111,10 +111,28 @@ Besides, the asynchronous version has the benefit of allowing us to perform some
 concurrently, such as the requirements verification. This should not be a drawback for most CLI
 applications, since argument parsing is usually done at the top-level of a module or script.
 
-#### Argument sequence
+### Argument sequence
 
-The `ParseInfo` object is passed as the parameter of some of the aforementioned callbacks, and
-contains information about the current argument sequence in the parsing loop:
+An argument sequence is the occurrence of an option in the command line with possible parameters.
+The parser looks for option names or positional arguments once it finishes parsing the previous
+option, or if the latter is variadic.
+
+For example, if the option initiating a sequence is a string option with a [fallback value], the
+parser starts looking for new options as soon as it advances to the next argument, since that may be
+either a parameter to the option or the start of a new sequence. Once it advances past this
+argument, it knows that the next one must be a new sequence.
+
+The same algorithm works for function options with variable [parameter count]. For example, if an
+option expects between 1 and 3 parameters, the parser treats the next argument as a parameter to the
+option, regardless of it being an option name or not. As soon as the first parameter is saved, the
+parser resumes the search until 3 parameters are accumulated, at which point it _must_ find an
+option specification (even if it is a new occurrence of the same option).
+
+#### Sequence information
+
+The information gathered by the parser is saved in a `ParseInfo` object that is passed as parameter
+to some of the [custom callbacks]. It contains details about the current argument sequence in the
+parsing loop:
 
 - `values` -
   The previously parsed values. It is an opaque type that should be cast to
@@ -243,6 +261,7 @@ they would pollute the output of process management utilities such as `ps`.
 [parsing flags]: #parsing-flags
 [word completion]: #word-completion
 [inline parameter]: #inline-parameters
+[custom callbacks]: #custom-callbacks
 [valued option]: options#value-attributes
 [message]: styles#terminal-messages
 [append]: options#append-values
@@ -260,6 +279,8 @@ they would pollute the output of process management utilities such as `ps`.
 [preferred name]: options#names--preferred-name
 [truth names]: options#truth-names
 [falsity names]: options#falsity-names
+[fallback value]: options#fallback-value
+[parameter count]: options#parameter-count
 [`break`]: options#break-loop
 [Set]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set
 [Bash docs]: https://www.gnu.org/software/bash/manual/html_node/Programmable-Completion.html

--- a/packages/docs/pages/docs/library/validator.mdx
+++ b/packages/docs/pages/docs/library/validator.mdx
@@ -82,6 +82,14 @@ Cluster letters are subject to the restrictions listed below:
 - **Invalid cluster letter** -
   A cluster letter must not contain whitespace. Any other Unicode character is allowed.
 
+In addition to the above, the validator may generate the following warning:
+
+- **Variadic option with cluster letter** -
+  A variadic option that declares cluster letters must always be the last option in a cluster
+  argument. This includes options with a fallback value, non-delimited array options and function
+  options with a variable [parameter count]. This might not be the intended behavior, and you should
+  consider alternatives.
+
 ### Constraints validation
 
 Constraint definitions are subject to the restrictions listed below:
@@ -95,6 +103,9 @@ Constraint definitions are subject to the restrictions listed below:
 - **Invalid numeric range** -
   In a number-valued option, if the [range] attribute is present, then its minimum value should be
   strictly less than the maximum.
+- **Invalid parameter count** -
+  In a function option, if the [paramCount] attribute is present and is a range, then its minimum
+  value should be strictly less than the maximum, but not less than zero.
 
 ### Value validation
 
@@ -261,6 +272,10 @@ The `ErrorItem` enumeration lists the kinds of error messages that may be raised
   conventions
 - `invalidNumericRange` -
   raised by the validator when a number-valued option has an invalid numeric range
+- `invalidParamCount` -
+  raised by the validator when a function option has an invalid parameter count
+- `variadicWithClusterLetter` -
+  warning produced by the validator when a variadic option declares cluster letters
 - `invalidBooleanParameter` -
   raised by the parser when a parameter to a boolean option fails to be converted
 
@@ -300,6 +315,8 @@ following optional properties, which are the enumerators from `ErrorItem`:
 - `tooSimilarOptionNames` - `'%o: Option name %s1 has too similar names %s2.'{:ts}`
 - `mixedNamingConvention` - `'%o: Name slot %n has mixed naming conventions [%s].'{:ts}`
 - `invalidNumericRange` - `'Option %o has invalid numeric range [%n].'{:ts}`
+- `invalidParamCount` - `'Option %o has invalid parameter count [%n].'{:ts}`
+- `variadicWithClusterLetter` - `'Variadic option %o has cluster letters. It may only appear as the last option in a cluster.'{:ts}`
 - `invalidBooleanParameter` - `'Invalid parameter to %o: %s1. Possible values are {%s2}.'{:ts}`
 
 These phrases will be formatted according to [text formatting] rules.
@@ -343,6 +360,8 @@ with a description of the corresponding value:
 | tooSimilarOptionNames      | `%o` = the command prefix[^1]; `%s1` = the option name; `%s2` = the similar names                  |
 | mixedNamingConvention      | `%o` = the command prefix[^1]; `%n` = the slot index; `%s` = the naming conventions                |
 | invalidNumericRange        | `%o` = the option's key; `%n` = the numeric range                                                  |
+| invalidParamCount          | `%o` = the option's key; `%n` = the parameter count                                                |
+| variadicWithClusterLetter  | `%o` = the option's key                                                                            |
 | invalidBooleanParameter    | `%o` = the specified option name; `%s1` = the specified value; `%s2` = the truth and falsity names |
 
 ### Connective words
@@ -365,6 +384,7 @@ the enumerators from `ConnectiveWords`:
 [regex]: options#regular-expression
 [range]: options#numeric-range
 [limit]: options#count-limit
+[paramCount]: options#parameter-count
 [default callbacks]: options#default-callback
 [requirement callbacks]: options#forward-requirements
 [positional]: options#positional--marker
@@ -375,6 +395,7 @@ the enumerators from `ConnectiveWords`:
 [format specifiers]: styles#format-specifiers
 [always required]: options#always-required
 [default value]: options#default-value
+[parameter count]: options#parameter-count
 
 [^1]:
     the command prefix is a series of option keys interspersed with periods, denoting the current

--- a/packages/docs/pages/docs/library/validator.mdx
+++ b/packages/docs/pages/docs/library/validator.mdx
@@ -104,8 +104,8 @@ Constraint definitions are subject to the restrictions listed below:
   In a number-valued option, if the [range] attribute is present, then its minimum value should be
   strictly less than the maximum.
 - **Invalid parameter count** -
-  In a function option, if the [paramCount] attribute is present and is a range, then its minimum
-  value should be strictly less than the maximum, but not less than zero.
+  In a function option, if the [parameter count] attribute is present and is a range, then its
+  minimum value should be strictly less than the maximum, but not less than zero.
 
 ### Value validation
 
@@ -384,7 +384,6 @@ the enumerators from `ConnectiveWords`:
 [regex]: options#regular-expression
 [range]: options#numeric-range
 [limit]: options#count-limit
-[paramCount]: options#parameter-count
 [default callbacks]: options#default-callback
 [requirement callbacks]: options#forward-requirements
 [positional]: options#positional--marker

--- a/packages/docs/typedoc.json
+++ b/packages/docs/typedoc.json
@@ -23,6 +23,8 @@
     "WithVerInfo",
     "WithResolve",
     "WithAppend",
-    "WithParse"
+    "WithParse",
+    "WithParamCount",
+    "WithSkipCount"
   ]
 }

--- a/packages/tsargp/lib/enums.ts
+++ b/packages/tsargp/lib/enums.ts
@@ -141,6 +141,14 @@ export const enum ErrorItem {
    */
   invalidNumericRange,
   /**
+   * Raised by the validator when a function option has an invalid parameter count.
+   */
+  invalidParamCount,
+  /**
+   * Warning produced by the validator when a variadic option declares cluster letters.
+   */
+  variadicWithClusterLetter,
+  /**
    * Raised by the parser when a parameter to a boolean option fails to be converted.
    */
   invalidBooleanParameter,
@@ -163,9 +171,9 @@ export const enum HelpItem {
    */
   separator,
   /**
-   * Reports if an array option accepts multiple parameters.
+   * Reports the parameter count of a variadic or polyadic option.
    */
-  variadic,
+  paramCount,
   /**
    * Reports if an option accepts positional arguments.
    */

--- a/packages/tsargp/lib/options.ts
+++ b/packages/tsargp/lib/options.ts
@@ -514,9 +514,9 @@ export type WithFunction = {
   /**
    * The function's parameter count.
    *
-   * If negative, then the option expects unlimited parameters.
+   * If negative, then the option accepts unlimited parameters.
    * If non-negative, then the option expects exactly this number of parameters.
-   * If a range, then the option accepts between `min` and `max` parameters.
+   * If a range, then the option expects between `min` and `max` parameters.
    */
   readonly paramCount?: number | Range;
   /**
@@ -955,7 +955,7 @@ type OptionDataType<T extends Option> =
 /**
  * Gets the parameter count of an option as a numeric range.
  * @param option The option definition
- * @returns The range count
+ * @returns The count range
  * @internal
  */
 export function getParamCount(option: OpaqueOption): Range {

--- a/packages/tsargp/lib/options.ts
+++ b/packages/tsargp/lib/options.ts
@@ -512,6 +512,14 @@ export type WithFunction = {
    */
   readonly break?: true;
   /**
+   * The function's parameter count.
+   *
+   * If negative, then the option expects unlimited parameters.
+   * If non-negative, then the option expects exactly this number of parameters.
+   * If a range, then the option accepts between `min` and `max` parameters.
+   */
+  readonly paramCount?: number | Range;
+  /**
    * The number of remaining arguments to skip.
    * You may change this value inside the callback. The parser does not alter this value.
    */
@@ -567,7 +575,9 @@ export type VersionOption = WithType<'version'> &
 export type FunctionOption = WithType<'function'> &
   WithBasic &
   WithFunction &
+  WithParam &
   WithValue<unknown> &
+  (WithParamCount | WithSkipCount) &
   (WithDefault | WithRequired);
 
 /**
@@ -861,6 +871,26 @@ type WithParse = {
 };
 
 /**
+ * Removes mutually exclusive attributes from an option with a parameter count.
+ */
+type WithParamCount = {
+  /**
+   * @deprecated mutually exclusive with {@link WithFunction.paramCount}.
+   */
+  readonly skipCount?: never;
+};
+
+/**
+ * Removes mutually exclusive attributes from an option with a skip count.
+ */
+type WithSkipCount = {
+  /**
+   * @deprecated mutually exclusive with {@link WithFunction.skipCount}.
+   */
+  readonly paramCount?: never;
+};
+
+/**
  * The data type of an option that may have a default value.
  * @template T The option definition type
  */
@@ -923,23 +953,22 @@ type OptionDataType<T extends Option> =
 // Functions
 //--------------------------------------------------------------------------------------------------
 /**
- * Tests if an option is niladic (i.e., accepts no parameter).
+ * Gets the parameter count of an option as a numeric range.
  * @param option The option definition
- * @returns True if the option is niladic
+ * @returns The range count
  * @internal
  */
-export function isNiladic(option: OpaqueOption): boolean {
-  return ['help', 'version', 'function', 'command', 'flag'].includes(option.type);
-}
-
-/**
- * Tests if an option is variadic (i.e., it accepts a variable number of parameters).
- * @param option The option definition
- * @returns True if the option is variadic
- * @internal
- */
-export function isVariadic(option: OpaqueOption): boolean {
-  return isArray(option) && !option.separator;
+export function getParamCount(option: OpaqueOption): Range {
+  if (['help', 'version', 'command', 'flag'].includes(option.type)) {
+    return [0, 0];
+  }
+  if (option.type !== 'function') {
+    const min = option.fallback !== undefined ? 0 : 1;
+    const max = option.separator || !isArray(option) ? 1 : Infinity;
+    return [min, max];
+  }
+  const count = option.paramCount ?? 0;
+  return typeof count === 'object' ? count : count < 0 ? [0, Infinity] : [count, count];
 }
 
 /**

--- a/packages/tsargp/lib/parser.ts
+++ b/packages/tsargp/lib/parser.ts
@@ -26,12 +26,11 @@ import {
   RequiresNot,
   RequiresOne,
   isArray,
-  isVariadic,
-  isNiladic,
   isMessage,
   isString,
   isBoolean,
   isUnknown,
+  getParamCount,
 } from './options';
 import {
   HelpMessage,
@@ -103,7 +102,7 @@ type ParseEntry = [
   value?: string,
   comp?: boolean,
   marker?: boolean,
-  lookFor?: boolean,
+  isNew?: boolean,
 ];
 
 //--------------------------------------------------------------------------------------------------
@@ -247,7 +246,8 @@ function parseCluster(validator: OptionValidator, args: Array<string>) {
       throw validator.error(ErrorItem.unknownOption, { o: letter }, { alt: 0 });
     }
     const option = validator.options[key];
-    if (j < cluster.length - 1 && (option.type === 'command' || isVariadic(option))) {
+    const [min, max] = getParamCount(option);
+    if (j < cluster.length - 1 && (option.type === 'command' || min < max)) {
       throw validator.error(ErrorItem.invalidClusterOption, { o: letter });
     }
     const name = option.names?.find((name) => name);
@@ -255,7 +255,7 @@ function parseCluster(validator: OptionValidator, args: Array<string>) {
       continue; // skip options with no names
     }
     args.splice(i, 0, name);
-    i += isNiladic(option) ? 1 : 2;
+    i += 1 + min;
   }
 }
 
@@ -309,17 +309,29 @@ async function parseArgs(
   let positional = false;
   for (let i = 0, k = 0; i < args.length; i = prev[0]) {
     const next = findNext(validator, args, prev);
-    const [j, info, value, comp, marker] = next;
-    if (prev[1] !== info) {
+    const [j, info, value, comp, marker, isNew] = next;
+    if (isNew || !info) {
       if (prev[1]) {
-        await handleNonNiladic(validator, values, completing, prev[1], i, args.slice(k, j));
+        // process the previous sequence
+        const breakLoop = await handleNonNiladic(
+          validator,
+          values,
+          specifiedKeys,
+          completing,
+          prev[1],
+          i,
+          args.slice(k, j),
+        );
+        if (breakLoop) {
+          return false;
+        }
       }
       if (!info) {
         break; // finished
       }
       prev = next;
       const { key, name, option } = info;
-      const niladic = isNiladic(option);
+      const niladic = !getParamCount(option)[1];
       const hasValue = value !== undefined;
       if (niladic || marker) {
         if (comp) {
@@ -371,7 +383,18 @@ async function parseArgs(
           k = hasValue ? j : j + 1;
         } else {
           // option name with inline parameter
-          await handleNonNiladic(validator, values, completing, info, j, [value]);
+          const breakLoop = await handleNonNiladic(
+            validator,
+            values,
+            specifiedKeys,
+            completing,
+            info,
+            j,
+            [value],
+          );
+          if (breakLoop) {
+            return false;
+          }
           prev[1] = undefined;
         }
         continue; // fetch more
@@ -382,7 +405,6 @@ async function parseArgs(
     if (!info) {
       break; // finished
     }
-    // comp === true
     await handleComplete(values, info, i, args.slice(k, j), value);
     handleCompletion(info.option, value);
     if (!marker && (positional || k < j || info.option.fallback !== undefined)) {
@@ -394,7 +416,8 @@ async function parseArgs(
 }
 
 /**
- * Finds the next option or word to complete in the command-line arguments.
+ * Finds the start of the next sequence in the command-line arguments, or a word to complete.
+ * If a sequence is found, it is a new option specification (but the option can be the same).
  * @param validator The option validator
  * @param args The command-line arguments
  * @param prev The previous parse entry
@@ -405,66 +428,73 @@ function findNext(
   args: ReadonlyArray<string>,
   prev: ParseEntry,
 ): ParseEntry {
-  let [index, info, , , marker, lookFor] = prev;
+  const [index, info, prevVal, , marker] = prev;
+  const inc = prevVal !== undefined ? 1 : 0;
   const positional = validator.positional;
-  const variadic = info ? isVariadic(info.option) : false;
-  for (++index; index < args.length; ++index) {
-    const [arg, rest] = args[index].split('\0', 2);
+  const [min, max] = info ? getParamCount(info.option) : [0, 0];
+  for (let i = index + 1; i < args.length; ++i) {
+    const [arg, rest] = args[i].split('\0', 2);
     const comp = rest !== undefined;
-    if (!info || lookFor) {
+    if (!info || (!marker && i - index + inc > min)) {
       const [name, value] = arg.split(/=(.*)/, 2);
       const key = validator.names.get(name);
       if (key) {
         if (comp && value === undefined) {
           throw new CompletionMessage(name);
         }
-        const isMarker = name === positional?.marker;
-        info = isMarker ? positional : { key, name, option: validator.options[key] };
-        lookFor = !isMarker && info.option.fallback !== undefined;
-        return [index, info, value, comp, isMarker, lookFor];
+        const marker = name === positional?.marker;
+        const info = marker ? positional : { key, name, option: validator.options[key] };
+        return [i, info, value, comp, marker, true];
       }
-      if (!info) {
+      if (!info || i - index + inc > max) {
         if (!positional) {
           if (comp) {
             handleNameCompletion(validator, arg);
           }
           handleUnknownName(validator, name);
         }
-        return [index, positional, arg, comp, false, true];
+        return [i, positional, arg, comp, marker, true];
       }
     }
     if (comp) {
-      return [index, info, arg, comp, marker];
-    }
-    if (!marker) {
-      if (variadic) {
-        lookFor = true;
-      } else {
-        info = undefined;
-      }
+      return [i, info, arg, comp, marker, false];
     }
   }
-  return [index];
+  return [args.length];
 }
 
 /**
  * Handles a non-niladic option.
  * @param validator The option validator
  * @param values The option values
+ * @param specifiedKeys The set of specified keys
  * @param comp True if performing completion
  * @param info The option information
  * @param index The starting index of the argument sequence
  * @param params The option parameters, if any
- * @returns A promise that must be awaited before continuing
+ * @returns True if the parsing loop should be broken
  */
 async function handleNonNiladic(
   validator: OptionValidator,
   values: OpaqueOptionValues,
+  specifiedKeys: Set<string>,
   comp: boolean,
   info: OptionInfo,
   index: number,
   params: Array<string>,
-) {
+): Promise<boolean> {
+  const [min] = getParamCount(info.option);
+  if (params.length < min) {
+    throw validator.error(ErrorItem.missingParameter, { o: info.name });
+  }
+  if (info.option.type === 'function') {
+    const breakLoop = !!info.option.break && !comp;
+    if (breakLoop) {
+      await checkRequired(validator, values, specifiedKeys);
+    }
+    await handleFunction(values, comp, index, params, info);
+    return breakLoop;
+  }
   try {
     // use await here instead of return, in order to catch errors
     await parseParam(validator, values, comp, index, info, params);
@@ -474,6 +504,7 @@ async function handleNonNiladic(
       throw err;
     }
   }
+  return false;
 }
 
 /**
@@ -634,11 +665,7 @@ async function parseParam(
   }
   const { key, name, option } = info;
   if (!params.length) {
-    const fallback = option.fallback;
-    if (fallback === undefined) {
-      throw validator.error(ErrorItem.missingParameter, { o: name });
-    }
-    return setValue(validator, values, key, option, fallback);
+    return setValue(validator, values, key, option, option.fallback);
   }
   const convertFn: (val: string) => unknown =
     option.type === 'boolean' ? bool : isString(option) ? (str: string) => str : Number;
@@ -679,6 +706,10 @@ async function setValue(
   /** @ignore */
   function norm<T>(val: T) {
     return validator.normalize(option, key, val);
+  }
+  if (value === undefined) {
+    values[key] = value;
+    return;
   }
   const resolved = typeof value === 'function' ? await value(values) : value;
   values[key] =
@@ -945,11 +976,7 @@ async function checkEnvVarAndDefaultValue(
     const name = option.preferredName ?? '';
     throw validator.error(ErrorItem.missingRequiredOption, { o: name });
   } else if ('default' in option) {
-    if (option.default === undefined) {
-      values[key] = undefined;
-    } else {
-      return setValue(validator, values, key, option, option.default);
-    }
+    return setValue(validator, values, key, option, option.default);
   }
 }
 

--- a/packages/tsargp/lib/parser.ts
+++ b/packages/tsargp/lib/parser.ts
@@ -405,6 +405,7 @@ async function parseArgs(
     if (!info) {
       break; // finished
     }
+    // comp === true
     await handleComplete(values, info, i, args.slice(k, j), value);
     handleCompletion(info.option, value);
     if (!marker && (positional || k < j || info.option.fallback !== undefined)) {
@@ -453,7 +454,7 @@ function findNext(
           }
           handleUnknownName(validator, name);
         }
-        return [i, positional, arg, comp, marker, true];
+        return [i, positional, arg, comp, false, true];
       }
     }
     if (comp) {
@@ -483,6 +484,9 @@ async function handleNonNiladic(
   index: number,
   params: Array<string>,
 ): Promise<boolean> {
+  // max is not needed here because either:
+  // - the parser would have failed to find an option that starts a new sequence at max + 1; or
+  // - it would have reached the end of the arguments before max + 1
   const [min] = getParamCount(info.option);
   if (params.length < min) {
     throw validator.error(ErrorItem.missingParameter, { o: info.name });

--- a/packages/tsargp/test/formatter/formatter.param.spec.ts
+++ b/packages/tsargp/test/formatter/formatter.param.spec.ts
@@ -4,6 +4,151 @@ import '../utils.spec'; // initialize globals
 
 describe('HelpFormatter', () => {
   describe('formatHelp', () => {
+    it('should handle a function option with a single required parameter', () => {
+      const options = {
+        function: {
+          type: 'function',
+          names: ['-f', '--function'],
+          desc: 'A function option',
+          paramCount: 1,
+        },
+      } as const satisfies Options;
+      const message = new HelpFormatter(new OptionValidator(options)).formatHelp();
+      expect(message.wrap()).toEqual(`  -f, --function  <param>  A function option\n`);
+    });
+
+    it('should handle a function option with a single optional parameter', () => {
+      const options = {
+        function: {
+          type: 'function',
+          names: ['-f', '--function'],
+          desc: 'A function option',
+          paramCount: [0, 1],
+        },
+      } as const satisfies Options;
+      const message = new HelpFormatter(new OptionValidator(options)).formatHelp();
+      expect(message.wrap()).toEqual(`  -f, --function  [<param>]  A function option\n`);
+    });
+
+    it('should handle a function option with an exact parameter count', () => {
+      const options = {
+        function: {
+          type: 'function',
+          names: ['-f', '--function'],
+          desc: 'A function option.',
+          paramCount: 2,
+        },
+      } as const satisfies Options;
+      const message = new HelpFormatter(new OptionValidator(options)).formatHelp();
+      expect(message.wrap()).toEqual(
+        `  -f, --function  <param>...  A function option. Accepts 2 parameters.\n`,
+      );
+    });
+
+    it('should handle a function option with a range parameter count', () => {
+      const options = {
+        function: {
+          type: 'function',
+          names: ['-f', '--function'],
+          desc: 'A function option.',
+          paramCount: [1, 2],
+        },
+      } as const satisfies Options;
+      const message = new HelpFormatter(new OptionValidator(options)).formatHelp();
+      expect(message.wrap()).toEqual(
+        `  -f, --function  <param>...  A function option. Accepts between 1 and 2 parameters.\n`,
+      );
+    });
+
+    it('should handle a function option with a minimum parameter count (1)', () => {
+      const options = {
+        function: {
+          type: 'function',
+          names: ['-f', '--function'],
+          desc: 'A function option.',
+          paramCount: [1, Infinity],
+        },
+      } as const satisfies Options;
+      const message = new HelpFormatter(new OptionValidator(options)).formatHelp();
+      expect(message.wrap()).toEqual(
+        `  -f, --function  <param>...  A function option. Accepts multiple parameters.\n`,
+      );
+    });
+
+    it('should handle a function option with a minimum parameter count (2)', () => {
+      const options = {
+        function: {
+          type: 'function',
+          names: ['-f', '--function'],
+          desc: 'A function option.',
+          paramCount: [2, Infinity],
+        },
+      } as const satisfies Options;
+      const message = new HelpFormatter(new OptionValidator(options)).formatHelp();
+      expect(message.wrap()).toEqual(
+        `  -f, --function  <param>...  A function option. Accepts at least 2 parameters.\n`,
+      );
+    });
+
+    it('should handle a function option with a maximum parameter count', () => {
+      const options = {
+        function: {
+          type: 'function',
+          names: ['-f', '--function'],
+          desc: 'A function option.',
+          paramCount: [0, 2],
+        },
+      } as const satisfies Options;
+      const message = new HelpFormatter(new OptionValidator(options)).formatHelp();
+      expect(message.wrap()).toEqual(
+        `  -f, --function  [<param>...]  A function option. Accepts at most 2 parameters.\n`,
+      );
+    });
+
+    it('should handle a function option with unlimited parameter count (1)', () => {
+      const options = {
+        function: {
+          type: 'function',
+          names: ['-f', '--function'],
+          desc: 'A function option.',
+          paramCount: -1,
+        },
+      } as const satisfies Options;
+      const message = new HelpFormatter(new OptionValidator(options)).formatHelp();
+      expect(message.wrap()).toEqual(
+        `  -f, --function  [<param>...]  A function option. Accepts multiple parameters.\n`,
+      );
+    });
+
+    it('should handle a function option with unlimited parameter count (2)', () => {
+      const options = {
+        function: {
+          type: 'function',
+          names: ['-f', '--function'],
+          desc: 'A function option.',
+          paramCount: [0, Infinity],
+        },
+      } as const satisfies Options;
+      const message = new HelpFormatter(new OptionValidator(options)).formatHelp();
+      expect(message.wrap()).toEqual(
+        `  -f, --function  [<param>...]  A function option. Accepts multiple parameters.\n`,
+      );
+    });
+
+    it('should handle a function option with a parameter name', () => {
+      const options = {
+        function: {
+          type: 'function',
+          names: ['-f', '--function'],
+          desc: 'A function option',
+          paramName: 'myParam',
+          paramCount: 1,
+        },
+      } as const satisfies Options;
+      const message = new HelpFormatter(new OptionValidator(options)).formatHelp();
+      expect(message.wrap()).toEqual(`  -f, --function  <myParam>  A function option\n`);
+    });
+
     it('should handle a boolean option with a parameter name', () => {
       const options = {
         boolean: {

--- a/packages/tsargp/test/parser/parser.cluster.spec.ts
+++ b/packages/tsargp/test/parser/parser.cluster.spec.ts
@@ -135,6 +135,36 @@ describe('ArgumentParser', () => {
       await expect(parser.parse(['f'], { shortStyle: true })).resolves.toEqual({ function: true });
     });
 
+    it('should throw an error on string option with fallback value in the middle of a cluster argument', async () => {
+      const options = {
+        string: {
+          type: 'string',
+          names: ['-s'],
+          fallback: '',
+          clusterLetters: 's',
+        },
+      } as const satisfies Options;
+      const parser = new ArgumentParser(options);
+      await expect(parser.parse(['sx'], { shortStyle: true })).rejects.toThrow(
+        `Option letter s must be the last in a cluster.`,
+      );
+    });
+
+    it('should throw an error on number option with fallback value in the middle of a cluster argument', async () => {
+      const options = {
+        number: {
+          type: 'number',
+          names: ['-n'],
+          fallback: 0,
+          clusterLetters: 'n',
+        },
+      } as const satisfies Options;
+      const parser = new ArgumentParser(options);
+      await expect(parser.parse(['nx'], { shortStyle: true })).rejects.toThrow(
+        `Option letter n must be the last in a cluster.`,
+      );
+    });
+
     it('should throw an error on variadic strings option in the middle of a cluster argument', async () => {
       const options = {
         strings: {
@@ -160,6 +190,36 @@ describe('ArgumentParser', () => {
       const parser = new ArgumentParser(options);
       await expect(parser.parse(['nx'], { shortStyle: true })).rejects.toThrow(
         `Option letter n must be the last in a cluster.`,
+      );
+    });
+
+    it('should throw an error on variadic function option in the middle of a cluster argument (1)', async () => {
+      const options = {
+        function: {
+          type: 'function',
+          names: ['-f'],
+          paramCount: -1,
+          clusterLetters: 'f',
+        },
+      } as const satisfies Options;
+      const parser = new ArgumentParser(options);
+      await expect(parser.parse(['fx'], { shortStyle: true })).rejects.toThrow(
+        `Option letter f must be the last in a cluster.`,
+      );
+    });
+
+    it('should throw an error on variadic function option in the middle of a cluster argument (2)', async () => {
+      const options = {
+        function: {
+          type: 'function',
+          names: ['-f'],
+          paramCount: [0, 1],
+          clusterLetters: 'f',
+        },
+      } as const satisfies Options;
+      const parser = new ArgumentParser(options);
+      await expect(parser.parse(['fx'], { shortStyle: true })).rejects.toThrow(
+        `Option letter f must be the last in a cluster.`,
       );
     });
 

--- a/packages/tsargp/test/parser/parser.completion.spec.ts
+++ b/packages/tsargp/test/parser/parser.completion.spec.ts
@@ -340,10 +340,10 @@ describe('ArgumentParser', () => {
       options.boolean.complete.mockClear();
       await expect(parser.parse('cmd 0 1 ', { compIndex: 8 })).rejects.toThrow(/^abc$/);
       expect(options.boolean.complete).toHaveBeenCalledWith({
-        values: { boolean: undefined },
-        index: 0,
+        values: { boolean: true },
+        index: 1,
         name: '-b',
-        param: ['0', '1'],
+        param: [],
         comp: '',
       });
     });

--- a/packages/tsargp/test/parser/parser.positional.spec.ts
+++ b/packages/tsargp/test/parser/parser.positional.spec.ts
@@ -4,6 +4,41 @@ import '../utils.spec'; // initialize globals
 
 describe('ArgumentParser', () => {
   describe('parse', () => {
+    it('should handle a function option with positional arguments', async () => {
+      const options = {
+        flag: {
+          type: 'flag',
+          names: ['-f1'],
+        },
+        function: {
+          type: 'function',
+          names: ['-f2'],
+          positional: true,
+          paramCount: 2,
+          exec: ({ param }) => param,
+        },
+      } as const satisfies Options;
+      const parser = new ArgumentParser(options);
+      await expect(parser.parse(['0'])).rejects.toThrow('Missing parameter to -f2.');
+      await expect(parser.parse(['0', '1', '2'])).rejects.toThrow('Missing parameter to -f2.');
+      await expect(parser.parse(['0', '-f1'])).resolves.toEqual({
+        flag: undefined,
+        function: ['0', '-f1'],
+      });
+      await expect(parser.parse(['-f1', '0', '1'])).resolves.toEqual({
+        flag: true,
+        function: ['0', '1'],
+      });
+      await expect(parser.parse(['0', '1', '-f1'])).resolves.toEqual({
+        flag: true,
+        function: ['0', '1'],
+      });
+      await expect(parser.parse(['0', '1', '2', '3'])).resolves.toEqual({
+        flag: undefined,
+        function: ['2', '3'],
+      });
+    });
+
     it('should throw an error when a required option with no name is not specified', async () => {
       const options = {
         required: {

--- a/packages/tsargp/test/validator/validator.constraints.spec.ts
+++ b/packages/tsargp/test/validator/validator.constraints.spec.ts
@@ -66,6 +66,19 @@ describe('OptionValidator', () => {
       expect(() => validator.validate()).not.toThrow();
     });
 
+    it('should ignore default value on a non-niladic function option', () => {
+      const options = {
+        function: {
+          type: 'function',
+          names: ['-s'],
+          default: [true, 1, 'abc'],
+          paramCount: 1,
+        },
+      } as const satisfies Options;
+      const validator = new OptionValidator(options);
+      expect(() => validator.validate()).not.toThrow();
+    });
+
     it('should throw an error on string example value not matching regex', () => {
       const options = {
         string: {
@@ -217,6 +230,21 @@ describe('OptionValidator', () => {
       const validator = new OptionValidator(options);
       expect(() => validator.validate()).toThrow(
         `Option number has invalid numeric range [0, NaN].`,
+      );
+    });
+
+    it('should throw an error on function option with invalid parameter count', () => {
+      const options = {
+        function: {
+          type: 'function',
+          names: ['-f'],
+          paramCount: [-1, 1],
+          exec() {},
+        },
+      } as const satisfies Options;
+      const validator = new OptionValidator(options);
+      expect(() => validator.validate()).toThrow(
+        `Option function has invalid parameter count [-1, 1].`,
       );
     });
 

--- a/packages/tsargp/test/validator/validator.spec.ts
+++ b/packages/tsargp/test/validator/validator.spec.ts
@@ -36,6 +36,73 @@ describe('OptionValidator', () => {
       expect(() => validator.validate()).toThrow(`Option version contains empty version.`);
     });
 
+    it('should return a warning on string option with fallback value and cluster letters', () => {
+      const options = {
+        string: {
+          type: 'string',
+          names: ['-s'],
+          fallback: '',
+          clusterLetters: 'a',
+        },
+      } as const satisfies Options;
+      const validator = new OptionValidator(options);
+      const { warning } = validator.validate();
+      expect(warning).toHaveLength(1);
+      expect(warning?.message).toEqual(
+        `Variadic option string has cluster letters. It may only appear as the last option in a cluster.\n`,
+      );
+    });
+
+    it('should return a warning on variadic strings option with cluster letters', () => {
+      const options = {
+        strings: {
+          type: 'strings',
+          names: ['-ss'],
+          clusterLetters: 'a',
+        },
+      } as const satisfies Options;
+      const validator = new OptionValidator(options);
+      const { warning } = validator.validate();
+      expect(warning).toHaveLength(1);
+      expect(warning?.message).toEqual(
+        `Variadic option strings has cluster letters. It may only appear as the last option in a cluster.\n`,
+      );
+    });
+
+    it('should return a warning on variadic function option with cluster letters (1)', () => {
+      const options = {
+        function: {
+          type: 'function',
+          names: ['-f'],
+          paramCount: -1,
+          clusterLetters: 'a',
+        },
+      } as const satisfies Options;
+      const validator = new OptionValidator(options);
+      const { warning } = validator.validate();
+      expect(warning).toHaveLength(1);
+      expect(warning?.message).toEqual(
+        `Variadic option function has cluster letters. It may only appear as the last option in a cluster.\n`,
+      );
+    });
+
+    it('should return a warning on variadic function option with cluster letters (2)', () => {
+      const options = {
+        function: {
+          type: 'function',
+          names: ['-f'],
+          paramCount: [0, 1],
+          clusterLetters: 'a',
+        },
+      } as const satisfies Options;
+      const validator = new OptionValidator(options);
+      const { warning } = validator.validate();
+      expect(warning).toHaveLength(1);
+      expect(warning?.message).toEqual(
+        `Variadic option function has cluster letters. It may only appear as the last option in a cluster.\n`,
+      );
+    });
+
     it('should validate nested command options recursively', () => {
       const options = {
         command: {


### PR DESCRIPTION
Added the `paramCount` attribute to the function option, to specify the number of parameters that the option expects in the command-line.

New enumerators, `invalidParamCount` and `variadicWithClusterLetter`, were added to `ErrorItem`, that are used by the validator when validating variadic options.

The formatter was updated to take the parameter count into account when rendering the description of variadic options.

The Options page was updated to document the new parameter count attribute. The Validator page was updated to document the new validations for variadic options.

Closes #83 
