### PR TITLE
Issues/97

### DIFF
--- a/.changeset/plenty-ghosts-scream.md
+++ b/.changeset/plenty-ghosts-scream.md
@@ -1,0 +1,5 @@
+---
+'tsargp': minor
+---
+
+Added a `breaks` property to help sections, to specify the number of line breaks to insert before a section. Added the `required` and `comment` properties to the usage section, to specify options that should be considered required in the usage, as well as to append a commentary to the usage, respectively. The demo was updated to include multiple usage sections.

--- a/.changeset/purple-paws-know.md
+++ b/.changeset/purple-paws-know.md
@@ -1,0 +1,5 @@
+---
+'@trulysimple/tsargp-docs': minor
+---
+
+Updated the Formatter page to document the new `breaks`, `required` and `comment` properties of help sections.

--- a/packages/docs/pages/docs/library/formatter.mdx
+++ b/packages/docs/pages/docs/library/formatter.mdx
@@ -88,23 +88,31 @@ later in this page.
 Sections are a convenient way to organize the help content. There are three kinds of help sections:
 text, usage and groups. They are explained below.
 
+### Common properties
+
+All help sections share a set of properties:
+
+- `breaks` - the number of line breaks to insert before the section (defaults to `0{:ts}` for the
+  first section, else `2{:ts}`)
+- `noWrap` - true to disable wrapping of provided texts (defaults to `false{:ts}`)
+
 <Callout type="info">
-  In what follows, text properties can contain inline styles and may be formatted according to [text
-  formatting] rules, unless `noWrap` is set.
+  When `noWrap` is set, inline styles may still be used in text properties, but the texts will _not_
+  be formatted according to the [text formatting] rules.
 </Callout>
 
-<Callout type="warning">
-  All sections and headings are separated by two line feeds by default, unless extra spacing is
-  provided in texts. For the sake of simplicity, there is no way to configure this feature.
+<Callout type="info">
+  All headings are separated from their content by _two_ line feeds, unless extra spacing is
+  provided in heading texts. For the sake of simplicity, there is no way to configure this behavior.
 </Callout>
 
 ### Text section
 
 A text section can be used to write many kinds of content, such as an introductory text, CLI usage
-instructions, afterword, copyright notice or external references. It has the following properties:
+instructions, afterword, copyright notice or external references. In addition to the [common
+properties], it has the following properties:
 
-- `text` - the section text
-- `noWrap` - true to disable wrapping of the provided text (defaults to `false{:ts}`)
+- `text` - the section content
 - `indent` - the level of indentation of the section content (defaults to `0{:ts}`)
 
 ### Usage section
@@ -114,8 +122,9 @@ The usage text is a concise representation of a program's command-line. Here is 
 {/* cSpell:disable */}
 
 ```ansi
-demo.js [[95mhelp[0m] [([95m-h[0m|[95m--help[0m)] [([95m-v[0m|[95m--version[0m)]
-        [([95m-f[0m|[95m--flag[0m|[95m--no-flag[0m)] [[95mhello[0m]
+demo.js [([95m-h[0m|[95m--help[0m)] [([95m-v[0m|[95m--version[0m)] [[95mhelp[0m] [32m# get help[0m
+demo.js [0m[95mhello[0m [90m...[0m [32m# execute the hello command[0m
+demo.js [([95m-f[0m|[95m--flag[0m|[95m--no-flag[0m)]
         [([95m-b[0m|[95m--boolean[0m) [90m<boolean>[0m]
         [([95m-s[0m|[95m--stringRegex[0m) [90m<my string>[0m]
         [([95m-n[0m|[95m--numberRange[0m) [90m<my number>[0m]
@@ -129,27 +138,28 @@ demo.js [[95mhelp[0m] [([95m-h[0m|[95m--help[0m)] [([95m-v[0m|[95m--ver
 
 {/* cSpell:enable */}
 
-A usage section has the following properties:
+In addition to the [common properties], a usage section has the following properties:
 
-- `title` - the section heading (defaults to no heading)
+- `title` - the section heading (defaults to none)
 - `style` - the style of the section heading (defaults to `tf.bold{:ts}`)
-- `noWrap` - true to disable wrapping of the provided heading (defaults to `false{:ts}`)
 - `indent` - the level of indentation of the section content (defaults to `0{:ts}`)
 - `filter` - a list of option keys to include or exclude (defaults to none)
 - `exclude` - whether the filter should exclude (defaults to `false{:ts}`)
+- `required` - a list of options that should be considered required in the usage
+- `comment` - a commentary to append to the usage (defaults to none)
 
 <Callout type="default">
-  The filter can be used to create multiple usages of the same command, with different options.
+  The filter can be used to create multiple usages of the same command, with different options. In
+  the case of an inclusion filter, the options are listed in the same order specified in the filter.
 </Callout>
 
 ### Groups section
 
-A groups section is a collection of option groups and their help entries. It has the following
-properties:
+A groups section is a collection of option groups and their help entries. In addition to the [common
+properties] properties, it has the following properties:
 
-- `title` - the default group heading (defaults to no heading)
+- `title` - the default group heading (defaults to none)
 - `style` - the style of group headings (defaults to `tf.bold{:ts}`)
-- `noWrap` - true to disable text wrapping of group headings (defaults to `false{:ts}`)
 - `phrase` - a custom phrase for group headings (defaults to none)
 - `filter` - a list of group names to include or exclude (defaults to none)
 - `exclude` - whether the filter should exclude (defaults to `false{:ts}`)
@@ -332,6 +342,7 @@ overriden by (or combined with) an option's [display styles], if present.
 [alignment]: #help-columns
 [help items]: #help-items
 [names column]: #names-column
+[common properties]: #common-properties
 [terminal strings]: styles#terminal-strings
 [option group]: options#group--hide
 [names]: options#names--preferred-name

--- a/packages/tsargp/examples/demo.options.ts
+++ b/packages/tsargp/examples/demo.options.ts
@@ -24,14 +24,14 @@ const helloOpts = {
   /**
    * A recursive command option that logs the arguments passed after it.
    */
-  command: {
+  hello: {
     type: 'command',
     names: ['hello'],
     desc: 'A recursive command option. Logs the arguments passed after it.',
     options: (): Options => helloOpts,
     exec({ param }): number {
       const vals = param as OptionValues<typeof helloOpts>;
-      const calls = vals.command ?? 0;
+      const calls = vals.hello ?? 0;
       console.log(`[tail call #${calls}]`, ...vals.strings);
       return calls + 1;
     },
@@ -88,6 +88,23 @@ export default {
         type: 'usage',
         title: 'Usage:',
         indent: 2,
+        filter: ['help', 'version', 'helpCmd'],
+        comment: `${style(fg.green)}# get help`,
+      },
+      {
+        type: 'usage',
+        indent: 2,
+        breaks: 1,
+        filter: ['hello'],
+        comment: `${style(fg.green)}# execute the hello command`,
+        required: ['hello'],
+      },
+      {
+        type: 'usage',
+        indent: 2,
+        breaks: 1,
+        filter: ['help', 'version', 'helpCmd', 'hello'],
+        exclude: true,
       },
       {
         type: 'text',
@@ -126,7 +143,7 @@ Report a bug: ${style(tf.faint)}https://github.com/trulysimple/tsargp/issues`,
   /**
    * A command option that logs the arguments passed after it.
    */
-  command: helloOpts.command,
+  hello: helloOpts.hello,
   /**
    * A boolean option that has inline styles and requirements.
    */

--- a/packages/tsargp/examples/demo.ts
+++ b/packages/tsargp/examples/demo.ts
@@ -10,7 +10,7 @@ interface Values {
   version: never;
   helpCmd: undefined;
   flag: boolean | undefined;
-  command: number | undefined;
+  hello: number | undefined;
   boolean: boolean;
   stringRegex: string;
   numberRange: number;
@@ -28,7 +28,7 @@ try {
   if (warning) {
     console.log(`${warning}`);
   }
-  if (!values.command) {
+  if (!values.hello) {
     console.log(values);
   }
 } catch (err) {

--- a/packages/tsargp/lib/formatter.ts
+++ b/packages/tsargp/lib/formatter.ts
@@ -123,6 +123,10 @@ export type WithText = {
  */
 export type WithWrap = {
   /**
+   * The number of line breaks to insert before the section. (Defaults to 2)
+   */
+  readonly breaks?: number;
+  /**
    * True to disable text wrapping of the provided text or headings.
    */
   readonly noWrap?: true;
@@ -159,7 +163,7 @@ export type WithFilter = {
   /**
    * A list of options keys or group names to include or exclude.
    */
-  readonly filter?: Array<string>;
+  readonly filter?: ReadonlyArray<string>;
   /**
    * True if the filter should exclude.
    */
@@ -177,6 +181,20 @@ export type WithPhrase = {
 };
 
 /**
+ * Defines additional attributes for the usage section.
+ */
+export type WithRequired = {
+  /**
+   * A list of options that should be considered required in the usage.
+   */
+  readonly required?: ReadonlyArray<string>;
+  /**
+   * A commentary to append to the usage.
+   */
+  readonly comment?: string;
+};
+
+/**
  * A help text section.
  */
 export type HelpText = WithKind<'text'> & WithText & WithWrap & WithIndent;
@@ -184,7 +202,12 @@ export type HelpText = WithKind<'text'> & WithText & WithWrap & WithIndent;
 /**
  * A help usage section.
  */
-export type HelpUsage = WithKind<'usage'> & WithTitle & WithWrap & WithIndent & WithFilter;
+export type HelpUsage = WithKind<'usage'> &
+  WithTitle &
+  WithWrap &
+  WithIndent &
+  WithFilter &
+  WithRequired;
 
 /**
  * A help groups section.
@@ -528,11 +551,10 @@ function formatParams(
   option: OpaqueOption,
   result: TerminalString,
 ): number {
-  if (config.param.hidden || !getParamCount(option)[1]) {
+  if (config.param.hidden) {
     return 0;
   }
-  result.break(config.param.breaks);
-  const len = formatParam(option, styles, result);
+  const len = formatParam(option, styles, result, config.param.breaks);
   return (result.indent = len); // hack: save the length, since we will need it in `adjustEntries`
 }
 
@@ -746,7 +768,7 @@ function formatSection(
   progName: string,
   result: HelpMessage,
 ) {
-  let breaks = result.length ? 2 : 0;
+  const breaks = section.breaks ?? (result.length ? 2 : 0);
   switch (section.type) {
     case 'text': {
       const { text, indent, noWrap } = section;
@@ -781,7 +803,7 @@ function formatUsageSection(
   progName: string,
   result: HelpMessage,
 ) {
-  const { title, indent, noWrap, filter, exclude, style: sty } = section;
+  const { title, indent, noWrap, style: sty } = section;
   if (title) {
     result.push(formatText(title, sty ?? style(tf.bold), 0, breaks, noWrap));
     breaks = 2;
@@ -792,8 +814,7 @@ function formatUsageSection(
     indent2 = max(0, indent ?? 0) + progName.length + 1;
     breaks = 0;
   }
-  const filterKeys = filter && new Set(filter);
-  result.push(formatUsage(options, styles, indent2, breaks, filterKeys, exclude));
+  result.push(formatUsage(options, styles, section, indent2, breaks));
 }
 
 /**
@@ -865,27 +886,40 @@ function formatText(
  * Options are rendered in the same order as was declared in the option definitions.
  * @param options The option definitions
  * @param styles The set of styles
+ * @param section The help section
  * @param indent The indentation level (negative values are replaced by zero)
  * @param breaks The number of line breaks (non-positive values are ignored)
- * @param filterKeys An optional set of options keys to filter
- * @param exclude Whether the filter should exclude
  * @returns The terminal string
  */
 function formatUsage(
   options: OpaqueOptions,
   styles: FormatStyles,
+  section: HelpUsage,
   indent?: number,
   breaks?: number,
-  filterKeys?: Set<string>,
-  exclude = false,
 ): TerminalString {
+  const { filter, exclude, required, comment } = section;
+  const filterKeys = filter && new Set(filter);
+  const requiredKeys = required && new Set(required);
   const result = new TerminalString(indent, breaks).seq(styles.text);
   const count = result.count;
-  for (const key in options) {
-    const option = options[key];
-    if (!option.hide && (filterKeys?.has(key) ?? !exclude) != exclude) {
-      formatUsageOption(option, styles, result);
+  if (filterKeys && !exclude) {
+    // list options in the same order specified in the filter
+    for (const key of filterKeys) {
+      if (key in options) {
+        formatUsageOption(options[key], styles, result, requiredKeys?.has(key));
+      }
     }
+  } else {
+    for (const key in options) {
+      const option = options[key];
+      if (!option.hide && !(exclude && filterKeys?.has(key))) {
+        formatUsageOption(option, styles, result);
+      }
+    }
+  }
+  if (comment) {
+    result.split(comment);
   }
   if (result.count == count) {
     return new TerminalString(); // this string does not contain any word
@@ -898,16 +932,19 @@ function formatUsage(
  * @param option The option definition
  * @param styles The set of styles
  * @param result The resulting string
+ * @param required True if the option should be considered required
  */
-function formatUsageOption(option: OpaqueOption, styles: FormatStyles, result: TerminalString) {
-  const required = option.required;
+function formatUsageOption(
+  option: OpaqueOption,
+  styles: FormatStyles,
+  result: TerminalString,
+  required = option.required ?? false,
+) {
   if (!required) {
     result.open('[');
   }
   formatUsageNames(option, styles, result);
-  if (getParamCount(option)[1]) {
-    formatParam(option, styles, result);
-  }
+  formatParam(option, styles, result);
   if (!required) {
     result.close(']');
   }
@@ -943,26 +980,40 @@ function formatUsageNames(option: OpaqueOption, styles: FormatStyles, result: Te
  * @param option The option definition
  * @param styles The set of styles
  * @param result The resulting string
+ * @param breaks The number of line breaks (non-positive values are ignored)
  * @returns The string length
  */
-function formatParam(option: OpaqueOption, styles: FormatStyles, result: TerminalString): number {
+function formatParam(
+  option: OpaqueOption,
+  styles: FormatStyles,
+  result: TerminalString,
+  breaks = 0,
+): number {
   if (option.example !== undefined) {
-    return formatExample(option, styles, result);
+    return formatExample(option, styles, result.break(breaks));
   }
   const paramStyle = option.styles?.param ?? styles.value;
+  const ellipsis = '...';
+  if (option.type === 'command') {
+    result.break(breaks).style(paramStyle, ellipsis, styles.text);
+    return ellipsis.length;
+  }
   const [min, max] = getParamCount(option);
-  const ellipsis = max > 1 ? '...' : '';
+  if (!max) {
+    return 0;
+  }
   const paramName = option.paramName;
-  const paramText = paramName
+  const param0 = paramName
     ? paramName.includes('<')
       ? paramName
-      : `<${paramName}>${ellipsis}`
+      : `<${paramName}>`
     : option.type === 'function'
-      ? `<param>${ellipsis}`
-      : `<${option.type}>${ellipsis}`;
-  const param = min <= 0 ? `[${paramText}]` : paramText;
-  result.style(paramStyle, param, styles.text);
-  return param.length;
+      ? '<param>'
+      : `<${option.type}>`;
+  const param1 = param0 + (max > 1 ? ellipsis : '');
+  const param2 = min <= 0 ? `[${param1}]` : param1;
+  result.break(breaks).style(paramStyle, param2, styles.text);
+  return param2.length;
 }
 
 /**

--- a/packages/tsargp/lib/formatter.ts
+++ b/packages/tsargp/lib/formatter.ts
@@ -123,7 +123,8 @@ export type WithText = {
  */
 export type WithWrap = {
   /**
-   * The number of line breaks to insert before the section. (Defaults to 2)
+   * The number of line breaks to insert before the section.
+   * (Defaults to 0 for the first section, else 2)
    */
   readonly breaks?: number;
   /**

--- a/packages/tsargp/test/formatter/formatter.default.spec.ts
+++ b/packages/tsargp/test/formatter/formatter.default.spec.ts
@@ -46,7 +46,7 @@ describe('HelpFormatter', () => {
         },
       } as const satisfies Options;
       const message = new HelpFormatter(new OptionValidator(options)).formatHelp();
-      expect(message.wrap()).toEqual(`  -f, --command    A command option. Defaults to true.\n`);
+      expect(message.wrap()).toEqual(`  -f, --command  ...  A command option. Defaults to true.\n`);
     });
 
     it('should handle a command option with a default callback', () => {
@@ -62,7 +62,7 @@ describe('HelpFormatter', () => {
       } as const satisfies Options;
       const message = new HelpFormatter(new OptionValidator(options)).formatHelp();
       expect(message.wrap()).toEqual(
-        `  -f, --command    A command option. Defaults to <() => 0>.\n`,
+        `  -f, --command  ...  A command option. Defaults to <() => 0>.\n`,
       );
     });
 

--- a/packages/tsargp/test/formatter/formatter.sections.spec.ts
+++ b/packages/tsargp/test/formatter/formatter.sections.spec.ts
@@ -28,6 +28,12 @@ describe('HelpFormatter', () => {
       expect(message.wrap()).toEqual('  text');
     });
 
+    it('should break a text section', () => {
+      const sections: HelpSections = [{ type: 'text', text: 'text', breaks: 1 }];
+      const message = new HelpFormatter(new OptionValidator({})).formatSections(sections);
+      expect(message.wrap()).toEqual('\ntext');
+    });
+
     it('should not wrap a text section', () => {
       const sections: HelpSections = [{ type: 'text', text: 'section  text', noWrap: true }];
       const message = new HelpFormatter(new OptionValidator({})).formatSections(sections);
@@ -52,10 +58,22 @@ describe('HelpFormatter', () => {
       expect(message.wrap()).toEqual('  prog');
     });
 
-    it('should render a usage section with a heading (but not indent it)', () => {
+    it('should break a usage section with a program name', () => {
+      const sections: HelpSections = [{ type: 'usage', breaks: 1 }];
+      const message = new HelpFormatter(new OptionValidator({})).formatSections(sections, 'prog');
+      expect(message.wrap()).toEqual('\nprog');
+    });
+
+    it('should render a usage section with a heading (but not indent the heading)', () => {
       const sections: HelpSections = [{ type: 'usage', title: 'text', indent: 2 }];
       const message = new HelpFormatter(new OptionValidator({})).formatSections(sections);
       expect(message.wrap()).toEqual('text');
+    });
+
+    it('should break a usage section with a heading', () => {
+      const sections: HelpSections = [{ type: 'usage', title: 'text', breaks: 1 }];
+      const message = new HelpFormatter(new OptionValidator({})).formatSections(sections);
+      expect(message.wrap()).toEqual('\ntext');
     });
 
     it('should render a usage section with a required flag option with a single name', () => {
@@ -156,6 +174,32 @@ describe('HelpFormatter', () => {
       expect(message.wrap()).toEqual('[group]\n\n  -f, --flag    A flag option.');
     });
 
+    it('should break a groups section with a default group', () => {
+      const options = {
+        flag: {
+          type: 'flag',
+          names: ['-f', '--flag'],
+          desc: 'A flag option.',
+        },
+      } as const satisfies Options;
+      const sections: HelpSections = [{ type: 'groups', breaks: 1 }];
+      const message = new HelpFormatter(new OptionValidator(options)).formatSections(sections);
+      expect(message.wrap()).toEqual('\n  -f, --flag    A flag option.');
+    });
+
+    it('should break a groups section with a custom heading for the default group', () => {
+      const options = {
+        flag: {
+          type: 'flag',
+          names: ['-f', '--flag'],
+          desc: 'A flag option.',
+        },
+      } as const satisfies Options;
+      const sections: HelpSections = [{ type: 'groups', title: 'text', breaks: 1 }];
+      const message = new HelpFormatter(new OptionValidator(options)).formatSections(sections);
+      expect(message.wrap()).toEqual('\ntext\n\n  -f, --flag    A flag option.');
+    });
+
     it('should not wrap section texts', () => {
       const options = {
         flag: {
@@ -188,9 +232,13 @@ describe('HelpFormatter', () => {
       } as const satisfies Options;
       const sections1: HelpSections = [{ type: 'usage', filter: ['flag1'] }];
       const sections2: HelpSections = [{ type: 'usage', filter: ['flag1'], exclude: true }];
+      const sections3: HelpSections = [{ type: 'usage', filter: ['flag1'], required: ['flag1'] }];
+      const sections4: HelpSections = [{ type: 'usage', filter: ['flag2', 'flag1'] }];
       const formatter = new HelpFormatter(new OptionValidator(options));
       expect(formatter.formatSections(sections1).wrap()).toEqual('[-f1]');
       expect(formatter.formatSections(sections2).wrap()).toEqual('[-f2]');
+      expect(formatter.formatSections(sections3).wrap()).toEqual('-f1');
+      expect(formatter.formatSections(sections4).wrap()).toEqual('[-f2] [-f1]');
     });
 
     it('should include and exclude an group in a groups section', () => {

--- a/packages/tsargp/test/formatter/formatter.spec.ts
+++ b/packages/tsargp/test/formatter/formatter.spec.ts
@@ -76,7 +76,7 @@ describe('HelpFormatter', () => {
         },
       } as const satisfies Options;
       const message = new HelpFormatter(new OptionValidator(options)).formatHelp();
-      expect(message.wrap()).toEqual(`  -f, --command    A command option\n`);
+      expect(message.wrap()).toEqual(`  -f, --command  ...  A command option\n`);
     });
 
     it('should handle a flag option with negation names', () => {


### PR DESCRIPTION
Added a `breaks` property to all help sections, that specifies the number of line breaks to insert before a section.

Added new properties to the usage section:
- `required` - a list of options that should be considered required in the usage
- `comment` - a commentary that is appended to the usage

The demo was updated to include multiple usage sections.

The Formatter page was updated to document the new properties for help sections.

Closes #97 
