### PR TITLE
Issues/18

### DIFF
--- a/.changeset/brown-weeks-mix.md
+++ b/.changeset/brown-weeks-mix.md
@@ -1,0 +1,5 @@
+---
+'@trulysimple/tsargp-docs': minor
+---
+
+Updated the Introduction page to document how word completion can be enabled for PowerShell.

--- a/.changeset/kind-dryers-watch.md
+++ b/.changeset/kind-dryers-watch.md
@@ -1,0 +1,5 @@
+---
+'tsargp': minor
+---
+
+Replaced the ANSI escape code `\x9b` by the more traditional `\x1b[`, in order to support terminals that do not recognize the former. Fixed the `getArgs` procedure to support word completion in PowerShell.

--- a/packages/docs/pages/docs/index.mdx
+++ b/packages/docs/pages/docs/index.mdx
@@ -2,6 +2,8 @@
 title: Introduction - Docs
 ---
 
+import { Tabs } from 'nextra/components';
+
 # Introduction
 
 **tsargp** is a command-line argument parsing library that helps you write clean code.
@@ -74,9 +76,23 @@ try {
 
 Optionally, enable word completion:
 
-```sh copy /<your_cli_name>/
-complete -o default -C <path/to/your/main_script> <your_cli_name>
-```
+<Tabs items={['Bash', 'PowerShell']}>
+  <Tabs.Tab>
+    ```sh copy /<your_cli_name>/
+    complete -o default -C <path/to/your/main_script> <your_cli_name>
+    ```
+  </Tabs.Tab>
+  <Tabs.Tab>
+    ```ps copy /<your_cli_name>/
+    Register-ArgumentCompleter -Native -CommandName <your_cli_name> -ScriptBlock { ^
+      param($word, $cmdLine, $cursorPos) ^
+        $env:COMP_LINE="$cmdLine"; $env:COMP_POINT=$cursorPos ^
+        <path/to/your/main_script> ^
+        $env:COMP_LINE=$null; $env:COMP_POINT=$null ^ # reset variables
+    }
+    ```
+  </Tabs.Tab>
+</Tabs>
 
 [^1]: ~32KB minified
 

--- a/packages/docs/pages/docs/library/parser.mdx
+++ b/packages/docs/pages/docs/library/parser.mdx
@@ -177,8 +177,8 @@ The way it does this is by inserting a placeholder into the command-line argumen
 completion index. This placeholder is then looked for at each iteration in the parsing loop to know
 when to perform completion.
 
-The result of completion is a list of words separated by line breaks (on Linux), and should be
-printed on the terminal so that the `complete` builtin can perform the final completion step.
+The result of completion is a list of words separated by line breaks, and should be printed on the
+terminal so that the `complete` builtin can perform the final completion step.
 
 <Callout type="info">
   The parser ignores any errors thrown by callbacks during completion. If an error is thrown by a

--- a/packages/tsargp/lib/styles.ts
+++ b/packages/tsargp/lib/styles.ts
@@ -146,7 +146,7 @@ const formatFunctions = {
  * @template P The type of the sequence parameter
  * @template C The type of the sequence command
  */
-export type CSI<P extends string, C extends cs> = `\x9b${P}${C}`;
+export type CSI<P extends string, C extends cs> = `\x1b[${P}${C}`;
 
 /**
  * A control sequence.
@@ -824,7 +824,7 @@ function omitStyles(width: number): boolean {
  * @returns The control sequence
  */
 function sequence<T extends cs>(cmd: T, ...params: Array<number>): CSI<string, T> {
-  return `\x9b${params.join(';')}${cmd}`;
+  return `\x1b[${params.join(';')}${cmd}`;
 }
 
 /**

--- a/packages/tsargp/lib/utils.ts
+++ b/packages/tsargp/lib/utils.ts
@@ -46,7 +46,7 @@ export const regexps = {
    * A regular expression to match SGR sequences.
    */
   // eslint-disable-next-line no-control-regex
-  style: /(?:\x9b[\d;]+m)+/g,
+  style: /(?:\x1b\[[\d;]+m)+/g,
   /**
    * A regular expression to match `RegExp` special characters.
    */
@@ -210,6 +210,10 @@ export function getArgs(line: string, compIndex = NaN): Array<string> {
   }
   if (arg !== undefined) {
     result.push(arg);
+  }
+  // the following check is needed for PowerShell support
+  if (line.length < compIndex) {
+    result.push('\0');
   }
   return result.slice(1); // remove the command name
 }

--- a/packages/tsargp/test/styles/styles.spec.ts
+++ b/packages/tsargp/test/styles/styles.spec.ts
@@ -13,7 +13,7 @@ describe('TerminalString', () => {
         .seq(seq(cs.rm, 1, 2, 3));
       expect(str).toHaveLength(0);
       expect(str.count).toEqual(4);
-      expect(str.strings).toEqual(['\x9bu', '\x9b1Z', '\x9b1;2r', '\x9b1;2;3l']);
+      expect(str.strings).toEqual(['\x1b[u', '\x1b[1Z', '\x1b[1;2r', '\x1b[1;2;3l']);
     });
   });
 
@@ -50,7 +50,7 @@ describe('TerminalString', () => {
       );
       expect(str).toHaveLength(4);
       expect(str.count).toEqual(1);
-      expect(str.strings).toEqual(['\x9b38;5;0;48;5;0;58;5;0m' + 'type' + '\x9b0m']);
+      expect(str.strings).toEqual(['\x1b[38;5;0;48;5;0;58;5;0m' + 'type' + '\x1b[0m']);
     });
   });
 
@@ -104,7 +104,7 @@ describe('TerminalString', () => {
         .close('.');
       expect(str).toHaveLength(6);
       expect(str.count).toEqual(2);
-      expect(str.strings).toEqual(['type', '\x9b39;49;4;3m].']);
+      expect(str.strings).toEqual(['type', '\x1b[39;49;4;3m].']);
     });
 
     it('should not merge next words if the closing is empty', () => {

--- a/packages/tsargp/test/styles/styles.splitting.spec.ts
+++ b/packages/tsargp/test/styles/styles.splitting.spec.ts
@@ -17,8 +17,8 @@ describe('TerminalString', () => {
       const str = new TerminalString().split(`${style(tf.clear)}type script${style(tf.clear)}`);
       expect(str).toHaveLength(10);
       expect(str.count).toEqual(2);
-      expect(str.strings[0]).toEqual('\x9b0mtype');
-      expect(str.strings[1]).toEqual('script\x9b0m');
+      expect(str.strings[0]).toEqual('\x1b[0mtype');
+      expect(str.strings[1]).toEqual('script\x1b[0m');
     });
 
     it('should split text with paragraphs', () => {

--- a/packages/tsargp/test/utils.spec.ts
+++ b/packages/tsargp/test/utils.spec.ts
@@ -74,6 +74,11 @@ describe('getArgs', () => {
       expect(getArgs('cmd type', 4)).toEqual(['\0type']);
       expect(getArgs('cmd type', 8)).toEqual(['type\0']);
     });
+
+    it('when it is past the end of the line', () => {
+      expect(getArgs('cmd', 4)).toEqual(['\0']);
+      expect(getArgs('cmd type', 9)).toEqual(['type', '\0']);
+    });
   });
 });
 


### PR DESCRIPTION
Replaced the ANSI escape code `\x9b` by the more traditional `\x1b[`, in order to support terminals that do not recognize the former.

Fixed the `getArgs` procedure to support word completion in PowerShell.

Updated the Introduction page to document how word completion can be enabled for PowerShell.

Closes #18
