### PR TITLE
Issues/112

### DIFF
--- a/.changeset/fuzzy-trainers-swim.md
+++ b/.changeset/fuzzy-trainers-swim.md
@@ -1,0 +1,5 @@
+---
+'@trulysimple/tsargp-docs': minor
+---
+
+Removed documentation of the `isComp` property from the Parser page, to reflect changes made in the code.

--- a/.changeset/rich-garlics-perform.md
+++ b/.changeset/rich-garlics-perform.md
@@ -1,0 +1,5 @@
+---
+'tsargp': minor
+---
+
+Refactored the parser to ignore command-line arguments coming after the completion index. As a consequence, the `isComp` utility function and the `WithIsComp` type were removed, as they are no longer needed.

--- a/packages/docs/pages/docs/library/options.mdx
+++ b/packages/docs/pages/docs/library/options.mdx
@@ -569,18 +569,9 @@ This option has the following sets of attributes:
 #### Function callback
 
 The `exec` attribute specifies the [custom callback] that should be executed. It receives a single
-parameter that contains the current [argument sequence] information:
-
-- `param` -
-  Holds either the option parameter(s) (if [parameter count] is set to a non-zero value) or all
-  remaining arguments.
-- `comp` -
-  Indicates whether [word completion] is in effect (but not in the current sequence).
-- `isComp` -
-  A utility function that can be used to check whether any of the remaining arguments is to be
-  completed, when `comp` is true. If so, you can throw a [completion message] inside the callback.
-  This should only be used when [parameter count] is _not_ set; otherwise, the detection logic is
-  performed by the parser.
+parameter that contains the current [argument sequence] information, in which `param` holds either
+the remaining arguments or the option parameters (if [parameter count] is set), and `comp` indicates
+whether [word completion] is in effect.
 
 Notes about this callback:
 
@@ -621,7 +612,9 @@ Mutually exclusive with [skip count].
 #### Skip count
 
 The `skipCount` attribute indicates the number of remaining arguments to skip, after the callback
-returns. Its value is meant to be changed by the callback.
+returns. Its value is meant to be changed by the callback (the parser does not alter it).
+
+Mutually exclusive with [parameter count].
 
 It is useful in cases where the number of parameters is unknown, and the callback wants to have
 control over where an argument sequence ends. Here is an example of how it might be used inside the
@@ -639,9 +632,10 @@ callback:
 }
 ```
 
-Mutually exclusive with [parameter count].
-
-<Callout type="info">The parser does not alter the value of this attribute.</Callout>
+<Callout type="info">
+  When [word completion] is in effect, the last argument will be the word to complete. If the latter
+  pertains to the current sequence, you can throw a [completion message] inside the callback.
+</Callout>
 
 ### Command option
 

--- a/packages/docs/pages/docs/library/options.mdx
+++ b/packages/docs/pages/docs/library/options.mdx
@@ -340,7 +340,7 @@ Mutually exclusive with [parameter name].
 The `parse` attribute, if present, specifies a [custom callback] to parse the value of the option
 parameter(s). It receives a single parameter that contains the current [argument sequence]
 information, in which `param` holds the option parameter(s) and `comp` indicates whether [word
-completion] is in effect (but not in the current sequence).
+completion] is in effect.
 
 Mutually exclusive with [append values].
 

--- a/packages/docs/pages/docs/library/parser.mdx
+++ b/packages/docs/pages/docs/library/parser.mdx
@@ -75,10 +75,10 @@ executing script. You can set it to the empty string in order to suppress its ap
 
 ### Completion index
 
-The `compIndex` property is the completion index of a raw command line. When supplying the parsing
-methods with a command-line string, this value instructs the parser to perform word completion when
-parsing the argument that overlaps this position in the string. It defaults to the value of the
-`COMP_POINT` environment variable.
+The `compIndex` property is the cursor position in a command line for which the user pressed `Tab`.
+When invoking the parsing methods with a raw command line, and this flag is set, the parser knows
+to perform word completion for the argument ending at this position. It defaults to the value of the
+`COMP_POINT` environment variable, if it exists.
 
 ### Short-option style
 
@@ -151,11 +151,6 @@ parsing loop:
 - `comp` -
   True if performing word completion, or the word being completed. Not available for the [command
   callback].
-- `isComp` -
-  An additional property only available to the [function callback] to check whether any of the
-  remaining arguments is to be completed, when `comp` is true. It accepts a single string parameter
-  and returns the word to be completed, if any (it may be an empty string); otherwise it returns
-  `undefined{:ts}`.
 
 ### Word completion
 
@@ -165,20 +160,18 @@ Quoting the [Bash docs]:
 > specification (a compspec) has been defined using the `complete` builtin (see Programmable
 > Completion Builtins), the programmable completion facilities are invoked.
 
-The parser does not use the completion facilities, because it relies on the command line string and
-the completion index into that string, which can be retrieved from the following environment
-variables (available when performing completion):
+The parser does not use the completion facilities, because it relies on the command line and the
+cursor position in that line, which can be retrieved from the following environment variables:
 
 - `COMP_LINE` - the current command line
 - `COMP_POINT` - the index of the current cursor position relative to the beginning of the current
   command
 
-The way it does this is by inserting a placeholder into the command-line argument that is under the
-completion index. This placeholder is then looked for at each iteration in the parsing loop to know
-when to perform completion.
+When both of these variables are available, the parser enters into completion mode: it truncates the
+command line at the cursor position and performs completion of the last argument.
 
-The result of completion is a list of words separated by line breaks, and should be printed on the
-terminal so that the `complete` builtin can perform the final completion step.
+The result of completion is a list of words separated by line breaks, which should be printed on the
+terminal so that the completion builtins can perform the final completion step.
 
 <Callout type="info">
   The parser ignores any errors thrown by callbacks during completion. If an error is thrown by a

--- a/packages/docs/pages/docs/library/parser.mdx
+++ b/packages/docs/pages/docs/library/parser.mdx
@@ -76,9 +76,9 @@ executing script. You can set it to the empty string in order to suppress its ap
 ### Completion index
 
 The `compIndex` property is the cursor position in a command line for which the user pressed `Tab`.
-When invoking the parsing methods with a raw command line, and this flag is set, the parser knows
-to perform word completion for the argument ending at this position. It defaults to the value of the
-`COMP_POINT` environment variable, if it exists.
+When invoking the parsing methods with a raw command line, and this flag is set, the parser will
+know to perform word completion for the argument ending at this position. It defaults to the value
+of the `COMP_POINT` environment variable, if it exists.
 
 ### Short-option style
 
@@ -160,7 +160,7 @@ Quoting the [Bash docs]:
 > specification (a compspec) has been defined using the `complete` builtin (see Programmable
 > Completion Builtins), the programmable completion facilities are invoked.
 
-The parser does not use the completion facilities, because it relies on the command line and the
+The parser does not use the completion facilities, because it relies on the raw command line and the
 cursor position in that line, which can be retrieved from the following environment variables:
 
 - `COMP_LINE` - the current command line

--- a/packages/tsargp/lib/options.ts
+++ b/packages/tsargp/lib/options.ts
@@ -221,7 +221,7 @@ export type CompleteCallback = CustomCallback<
  * @see CustomCallback
  */
 export type FunctionCallback = CustomCallback<
-  ParseInfo<Array<string>> & WithComp<boolean> & WithIsComp,
+  ParseInfo<Array<string>> & WithComp<boolean>,
   unknown
 >;
 
@@ -266,19 +266,6 @@ export type WithComp<C> = {
    * True if performing word completion, or the word being completed.
    */
   comp: C;
-};
-
-/**
- * Defines additional properties to be used by a function callback.
- */
-export type WithIsComp = {
-  /**
-   * Checks whether an option parameter is a word to be completed.
-   * You can `throw new CompletionMessage(...words)` inside the function callback, if needed.
-   * @param param The option parameter
-   * @returns The word being completed, if any (it may be an empty string); else undefined
-   */
-  isComp: (param: string) => string | undefined;
 };
 
 /**

--- a/packages/tsargp/lib/utils.ts
+++ b/packages/tsargp/lib/utils.ts
@@ -163,7 +163,7 @@ export type Range = [min: number, max: number];
  * Gets a list of arguments from a raw command line.
  * @param line The command line, including the command name
  * @param compIndex The completion index, if any
- * @returns The list of arguments up to the completion index
+ * @returns The list of arguments, up to the completion index
  * @internal
  */
 export function getArgs(line: string, compIndex = NaN): Array<string> {

--- a/packages/tsargp/test/parser/parser.completion.spec.ts
+++ b/packages/tsargp/test/parser/parser.completion.spec.ts
@@ -4,6 +4,11 @@ import '../utils.spec'; // initialize globals
 
 describe('ArgumentParser', () => {
   describe('parse', () => {
+    it('should complete an empty command line', async () => {
+      const parser = new ArgumentParser({});
+      await expect(parser.parse('cmd', { compIndex: 4 })).rejects.toThrow(/^$/);
+    });
+
     it('should ignore parsing errors during completion', async () => {
       const options = {
         string: {
@@ -682,6 +687,20 @@ describe('ArgumentParser', () => {
       const flags = { shortStyle: true, compIndex: 5 };
       await expect(parser.parse('cmd --', flags)).rejects.toThrow(/^$/);
       await expect(parser.parse('cmd ff', flags)).rejects.toThrow(/^$/);
+    });
+
+    it('should complete the paramater of an option specified in a cluster argument (and ignore the rest)', async () => {
+      const options = {
+        boolean: {
+          type: 'boolean',
+          names: ['-b'],
+          truthNames: ['yes'],
+          clusterLetters: 'b',
+        },
+      } as const satisfies Options;
+      const parser = new ArgumentParser(options);
+      const flags = { shortStyle: true, compIndex: 7 };
+      await expect(parser.parse('cmd bx  rest', flags)).rejects.toThrow(/^yes$/);
     });
 
     it('should handle the completion of a boolean option with async custom completion', async () => {

--- a/packages/tsargp/test/parser/parser.completion.spec.ts
+++ b/packages/tsargp/test/parser/parser.completion.spec.ts
@@ -48,29 +48,9 @@ describe('ArgumentParser', () => {
         values: { function: undefined },
         index: 0,
         name: '-f',
-        param: ['\0'],
+        param: [''],
         comp: true,
-        isComp: expect.anything(),
       });
-    });
-
-    it('can check whether any remaining argument is a word to be completed', async () => {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      let savedParam: any, savedIsComp: any;
-      const options = {
-        function: {
-          type: 'function',
-          names: ['-f'],
-          exec({ param, isComp }) {
-            savedParam = param;
-            savedIsComp = isComp;
-          },
-        },
-      } as const satisfies Options;
-      const parser = new ArgumentParser(options);
-      await expect(parser.parse('cmd -f ab cd', { compIndex: 8 })).rejects.toThrow(/^$/);
-      expect(savedIsComp(savedParam[0])).toEqual('a');
-      expect(savedIsComp(savedParam[1])).toBeUndefined();
     });
 
     it('can throw completion words from a function callback during completion', async () => {
@@ -138,9 +118,8 @@ describe('ArgumentParser', () => {
         values: { function: undefined },
         index: 0,
         name: '-f',
-        param: ['\0'],
+        param: [''],
         comp: true,
-        isComp: expect.anything(),
       });
       options.function.exec.mockClear();
       await expect(parser.parse('cmd -f=', { compIndex: 7 })).rejects.toThrow(/^$/);
@@ -164,9 +143,8 @@ describe('ArgumentParser', () => {
         values: { function: undefined },
         index: 0,
         name: '-f',
-        param: ['\0'],
+        param: [''],
         comp: true,
-        isComp: expect.anything(),
       });
     });
 

--- a/packages/tsargp/test/parser/parser.spec.ts
+++ b/packages/tsargp/test/parser/parser.spec.ts
@@ -332,7 +332,6 @@ describe('ArgumentParser', () => {
           name: '-f',
           param: [],
           comp: false,
-          isComp: expect.anything(),
         });
         options.function.exec.mockClear();
         await expect(parser.parse(['-f', '-f'])).resolves.toEqual({ function: 'abc' });
@@ -343,7 +342,6 @@ describe('ArgumentParser', () => {
           name: '-f',
           param: ['-f'],
           comp: false,
-          isComp: expect.anything(),
         });
         expect(options.function.exec).toHaveBeenCalledTimes(2);
       });

--- a/packages/tsargp/test/utils.spec.ts
+++ b/packages/tsargp/test/utils.spec.ts
@@ -41,7 +41,7 @@ describe('getArgs', () => {
     });
 
     it('should ignore leading and trailing whitespace', () => {
-      expect(getArgs(' cmd')).toEqual([]);
+      expect(getArgs(' cmd ')).toEqual([]);
       expect(getArgs(' cmd  type  script ')).toEqual(['type', 'script']);
     });
 
@@ -68,7 +68,7 @@ describe('getArgs', () => {
 
     it('when it is past the end of the line', () => {
       expect(getArgs('cmd', 4)).toEqual(['']);
-      expect(getArgs('cmd ""', 8)).toEqual(['', '']);
+      expect(getArgs('cmd ""', 7)).toEqual(['', '']);
       expect(getArgs('cmd type', 9)).toEqual(['type', '']);
     });
   });


### PR DESCRIPTION
Refactored the parser to ignore command-line arguments coming after the completion index.

Removed the `isComp` utility function and the `WithIsComp` type, as they are no longer needed.

Removed documentation of the `isComp` property from the Parser page.

Closes #112 
