### PR TITLE
Issues/116

### DIFF
--- a/.changeset/chatty-bikes-promise.md
+++ b/.changeset/chatty-bikes-promise.md
@@ -1,0 +1,5 @@
+---
+'tsargp': patch
+---
+
+The parsing methods now support characters escaped with `\` in raw command lines.

--- a/.changeset/shiny-meals-visit.md
+++ b/.changeset/shiny-meals-visit.md
@@ -1,0 +1,5 @@
+---
+'@trulysimple/tsargp-docs': minor
+---
+
+Updated the Introduction page to document how word completion can be enabled in Fish shell.

--- a/packages/docs/pages/docs/index.mdx
+++ b/packages/docs/pages/docs/index.mdx
@@ -76,7 +76,7 @@ try {
 
 Optionally, enable word completion:
 
-<Tabs items={['Bash', 'PowerShell', 'Zsh']}>
+<Tabs items={['Bash', 'PowerShell', 'Zsh', 'Fish']}>
   <Tabs.Tab>
     ```bash copy /<your_cli_name>/ /<path_to_main_script>/
     complete -o default -C <path_to_main_script> <your_cli_name>
@@ -84,17 +84,26 @@ Optionally, enable word completion:
   </Tabs.Tab>
   <Tabs.Tab>
     ```ps copy /<your_cli_name>/ /<path_to_main_script>/
-    Register-ArgumentCompleter -Native -CommandName <your_cli_name> -ScriptBlock { ^
-      param($word, $cmdLine, $cursorPos) ^
-        $env:BUFFER="$cmdLine"; $env:CURSOR=$cursorPos ^
-        <path_to_main_script> ^
-        $env:BUFFER=$null; $env:CURSOR=$null ^ # reset variables
+    Register-ArgumentCompleter -Native -CommandName <your_cli_name> -ScriptBlock {
+      param($word, $cmdLine, $cursorPos)
+        $env:BUFFER="$cmdLine"; $env:CURSOR=$cursorPos
+        <path_to_main_script>
+        $env:BUFFER=$null; $env:CURSOR=$null # reset variables
     }
     ```
   </Tabs.Tab>
   <Tabs.Tab>
     ```zsh copy /<your_cli_name>/ /<path_to_main_script>/
     compdef 'export BUFFER CURSOR; _values <your_cli_name> `<path_to_main_script>`' <your_cli_name>
+    ```
+  </Tabs.Tab>
+  <Tabs.Tab>
+    ```fish copy /<your_cli_name>/ /<path_to_main_script>/
+    complete <your_cli_name> -a '(
+      set -x BUFFER (commandline); set -x CURSOR (commandline -C)
+      <path_to_main_script>
+      set -e BUFFER; set -e CURSOR # reset variables
+    )'
     ```
   </Tabs.Tab>
 </Tabs>

--- a/packages/tsargp/lib/utils.ts
+++ b/packages/tsargp/lib/utils.ts
@@ -176,8 +176,21 @@ export function getArgs(line: string, compIndex = NaN): Array<string> {
   line = rest < 0 ? line + ' ' : rest >= 0 ? line.slice(0, compIndex) : line.trimEnd();
   let arg: string | undefined;
   let quote = '';
+  let escape = false;
   for (const char of line) {
+    if (escape) {
+      append(char);
+      escape = false;
+      continue;
+    }
     switch (char) {
+      case '\\':
+        if (quote) {
+          append(char);
+        } else {
+          escape = true;
+        }
+        break;
       case ' ':
         if (quote) {
           append(char);

--- a/packages/tsargp/test/utils.spec.ts
+++ b/packages/tsargp/test/utils.spec.ts
@@ -53,6 +53,13 @@ describe('getArgs', () => {
       expect(getArgs(`cmd type" "script' 'is fun`)).toEqual(['type script is', 'fun']);
       expect(getArgs(`cmd "'type' script" 'is "fun"'`)).toEqual([`'type' script`, 'is "fun"']);
     });
+
+    it('should handle escaped characters', () => {
+      expect(getArgs(`cmd type\\ script`)).toEqual(['type script']);
+      expect(getArgs(`cmd type\\\\script`)).toEqual(['type\\script']);
+      expect(getArgs(`cmd "type\\ script"`)).toEqual(['type\\ script']);
+      expect(getArgs(`cmd 'type\\ script'`)).toEqual(['type\\ script']);
+    });
   });
 
   describe('with completion index', () => {


### PR DESCRIPTION
Patched the `getArgs` utility function to handle characters escaped with a backslash.

Updated the Introduction page to document how word completion can be enabled in Fish shell.

Closes #116 
