### PR TITLE
Issues/118

### DIFF
--- a/.changeset/fifty-dryers-collect.md
+++ b/.changeset/fifty-dryers-collect.md
@@ -1,0 +1,5 @@
+---
+'@trulysimple/tsargp-docs': minor
+---
+
+The Introduction page now has documentation on how to enable word completion for Nushell.

--- a/.changeset/shaggy-horses-hunt.md
+++ b/.changeset/shaggy-horses-hunt.md
@@ -1,0 +1,5 @@
+---
+'tsargp': patch
+---
+
+The parsing procedures now accept the `BUFFER` environment variable without its sibling `CURSOR` variable.

--- a/cspell.json
+++ b/cspell.json
@@ -7,6 +7,7 @@
   "ignoreWords": [
     "tsargp",
     "nextra",
+    "nushell",
     "publint",
     "println",
     "compspec",

--- a/packages/docs/pages/docs/index.mdx
+++ b/packages/docs/pages/docs/index.mdx
@@ -99,7 +99,7 @@ Optionally, enable word completion:
   </Tabs.Tab>
   <Tabs.Tab>
     ```fish copy /<your_cli_name>/ /<path_to_main_script>/
-    complete <your_cli_name> -a '(set -x BUFFER (commandline -c); <path_to_main_script>; set -e BUFFER)'
+    complete <your_cli_name> -f -a '(set -x BUFFER (commandline -c); <path_to_main_script>; set -e BUFFER)'
     ```
   </Tabs.Tab>
   <Tabs.Tab>

--- a/packages/docs/pages/docs/index.mdx
+++ b/packages/docs/pages/docs/index.mdx
@@ -76,7 +76,7 @@ try {
 
 Optionally, enable word completion:
 
-<Tabs items={['Bash', 'PowerShell', 'Zsh', 'Fish']}>
+<Tabs items={['Bash', 'PowerShell', 'Zsh', 'Fish', 'Nushell']}>
   <Tabs.Tab>
     ```bash copy /<your_cli_name>/ /<path_to_main_script>/
     complete -o default -C <path_to_main_script> <your_cli_name>
@@ -99,11 +99,18 @@ Optionally, enable word completion:
   </Tabs.Tab>
   <Tabs.Tab>
     ```fish copy /<your_cli_name>/ /<path_to_main_script>/
-    complete <your_cli_name> -a '(
-      set -x BUFFER (commandline); set -x CURSOR (commandline -C)
-      <path_to_main_script>
-      set -e BUFFER; set -e CURSOR # reset variables
-    )'
+    complete <your_cli_name> -a '(set -x BUFFER (commandline -c); <path_to_main_script>; set -e BUFFER)'
+    ```
+  </Tabs.Tab>
+  <Tabs.Tab>
+    ```nu copy /<your_cli_name>/ /<path_to_main_script>/
+    $env.config.completions.external.completer = {|spans|
+      {
+        <your_cli_name>: {
+          with-env { BUFFER: ($spans | str join ' ') } { <path_to_main_script> } | lines
+        }
+      } | get $spans.0 | each { || do $in }
+    }
     ```
   </Tabs.Tab>
 </Tabs>

--- a/packages/tsargp/lib/parser.ts
+++ b/packages/tsargp/lib/parser.ts
@@ -24,7 +24,7 @@ import { ConnectiveWords, ErrorItem } from './enums';
 import { HelpFormatter, HelpSections } from './formatter';
 import { RequiresAll, RequiresNot, RequiresOne, isOpt, getParamCount } from './options';
 import { format, HelpMessage, WarnMessage, CompletionMessage, TerminalString } from './styles';
-import { areEqual, findSimilar, getArgs, isTrue, max, findInObject } from './utils';
+import { areEqual, findSimilar, getArgs, isTrue, max, findInObject, env } from './utils';
 import { OptionValidator, defaultConfig } from './validator';
 
 //--------------------------------------------------------------------------------------------------
@@ -152,10 +152,10 @@ export class ArgumentParser<T extends Options = Options> {
    */
   async parseInto(
     values: OptionValues<T>,
-    cmdLine = process?.env['COMP_LINE'] ?? process?.env['BUFFER'] ?? process?.argv.slice(2) ?? [],
+    cmdLine = env('COMP_LINE') ?? env('BUFFER') ?? process?.argv.slice(2) ?? [],
     flags: ParsingFlags = {
       progName: process?.argv[1].split(/[\\/]/).at(-1),
-      compIndex: Number(process?.env['COMP_POINT'] ?? process?.env['CURSOR']),
+      compIndex: Number(env('COMP_POINT') ?? env('CURSOR') ?? env('BUFFER')?.length),
     },
   ): Promise<ParsingResult> {
     const args = typeof cmdLine === 'string' ? getArgs(cmdLine, flags.compIndex) : cmdLine;
@@ -283,7 +283,7 @@ function parseCluster(validator: OptionValidator, args: Array<string>, completin
 async function readEnvVar(context: ParseContext, info: OptionInfo): Promise<boolean> {
   const [, values] = context;
   const [key, name, option] = info;
-  const value = process?.env[name];
+  const value = env(name);
   if (value !== undefined) {
     if (option.type === 'flag') {
       // don't parse the flag value, for consistency with the semantics of the command-line

--- a/packages/tsargp/lib/styles.ts
+++ b/packages/tsargp/lib/styles.ts
@@ -3,7 +3,7 @@
 //--------------------------------------------------------------------------------------------------
 import type { Alias, Concrete, Enumerate, URL, ValuesOf } from './utils';
 import { cs, tf, fg, bg } from './enums';
-import { max, overrides, regexps, selectAlternative } from './utils';
+import { env, max, overrides, regexps, selectAlternative } from './utils';
 
 export { sequence as seq, sgr as style, foreground as fg8, background as bg8, underline as ul8 };
 export { underlineStyle as ul, formatFunctions as format };
@@ -810,10 +810,7 @@ function formatArgs(
  * @see https://clig.dev/#output
  */
 function omitStyles(width: number): boolean {
-  return (
-    !process?.env['FORCE_COLOR'] &&
-    (!width || !!process?.env['NO_COLOR'] || process?.env['TERM'] === 'dumb')
-  );
+  return !env('FORCE_COLOR') && (!width || !!env('NO_COLOR') || env('TERM') === 'dumb');
 }
 
 /**

--- a/packages/tsargp/lib/utils.ts
+++ b/packages/tsargp/lib/utils.ts
@@ -162,7 +162,7 @@ export type Range = [min: number, max: number];
 /**
  * Gets a list of arguments from a raw command line.
  * @param line The command line, including the command name
- * @param compIndex The completion index, if any
+ * @param compIndex The completion index, if any (if negative, the line length is used)
  * @returns The list of arguments, up to the completion index
  * @internal
  */
@@ -506,4 +506,13 @@ export function findInObject<T extends object>(
       return val;
     }
   }
+}
+
+/**
+ * Gets the value of an environment variable.
+ * @param name The variable name
+ * @returns The variable value, if it exists; else undefined
+ */
+export function env(name: string): string | undefined {
+  return process?.env[name];
 }

--- a/packages/tsargp/lib/utils.ts
+++ b/packages/tsargp/lib/utils.ts
@@ -162,7 +162,7 @@ export type Range = [min: number, max: number];
 /**
  * Gets a list of arguments from a raw command line.
  * @param line The command line, including the command name
- * @param compIndex The completion index, if any (if negative, the line length is used)
+ * @param compIndex The completion index, if any (should be non-negative)
  * @returns The list of arguments, up to the completion index
  * @internal
  */


### PR DESCRIPTION
Updated the parsing methods to accept the `BUFFER` environment variable without the `CURSOR` variable.

Updated the Introduction page to document how to enable word completion for Nushell.

Closes #118 
