### PR TITLE
Issues/120

### DIFF
--- a/.changeset/cuddly-kings-play.md
+++ b/.changeset/cuddly-kings-play.md
@@ -1,0 +1,5 @@
+---
+'@trulysimple/tsargp-docs': minor
+---
+
+The Parser page was updated to document the new `clusterPrefix` configuration flag, which replaced the `shortStyle` flag. The Options page was updated to document the new behavior of cluster arguments.

--- a/.changeset/flat-cooks-mix.md
+++ b/.changeset/flat-cooks-mix.md
@@ -1,0 +1,5 @@
+---
+'tsargp': minor
+---
+
+The `shortStyle` configuration flag was replaced by the more generic `clusterPrefix`, which allows cluster arguments anywhere in the command line.

--- a/packages/docs/pages/docs/library/options.mdx
+++ b/packages/docs/pages/docs/library/options.mdx
@@ -251,8 +251,8 @@ If they were defined in the `requiredIf` attribute, they would mean:
 #### Cluster letters
 
 The `clusterLetters` attribute, if present, specifies letters (or any Unicode characters except
-whitespace) that can be used to cluster options in the first command-line argument. This is also
-known as [_short-option_ style]. This feature can be enabled via the parser's [`shortStyle`]
+whitespace) that can be used to cluster options in a single command-line argument. This is also
+known as [_short-option_ style]. This feature can be enabled via the parser's [`clusterPrefix`]
 configuration flag.
 
 Here is an example that illustrates how it works. Suppose we have the following options:
@@ -264,26 +264,27 @@ Here is an example that illustrates how it works. Suppose we have the following 
 Given these options, the following invocations would all be equivalent:
 
 ```sh
-my_cli fsn 'my string' 123
-my_cli -fsn 'my string' 123
-my_cli fSN 'my string' 123
-my_cli -Fsn 'my string' 123
+cmd -fsn 'my string' 123
+cmd -Fsn 'my string' 123
 ```
 
 They would be transformed to their "canonical" form, i.e.:
 
 ```sh
-my_cli --flag --str 'my string' --num 123
+cmd --flag --str 'my string' --num 123
 ```
 
 Notes about this feature:
 
-- if enabled, then the first command-line argument _must_ be a cluster
-- the order of the options in the cluster are preserved when converting to the canonical form
+- the order of options in a cluster is preserved when converting to the canonical form
 - variadic options and command options are supported, but they must be the last in a cluster
-- if a single dash is specified as the first character in a cluster argument, it is ignored
-- if word completion is attempted in a cluster argument, the default [completion message] is thrown
+- if word completion is attempted in a cluster, the default [completion message] is thrown
 - if a nameless positional option appears in a cluster, its argument will be treated as positional
+
+<Callout type="info">
+  Sticking option arguments right after a cluster letter, with no intervening space, is _not_
+  supported. For example, the following command line would be invalid: `cmd -s'my str' -n123{:sh}`.
+</Callout>
 
 ### Parameter attributes
 
@@ -907,7 +908,7 @@ attributes:
 [argument sequence]: parser#sequence-information
 [completion message]: styles#completion-message
 [`parseInto`]: parser#using-your-own-object
-[`shortStyle`]: parser#short-option-style
+[`clusterPrefix`]: parser#cluster-prefix
 [constraints validation]: validator#constraints-validation
 [help items]: formatter#help-items
 [help item]: formatter#help-items

--- a/packages/docs/pages/docs/library/options.mdx
+++ b/packages/docs/pages/docs/library/options.mdx
@@ -264,7 +264,7 @@ Here is an example that illustrates how it works. Suppose we have the following 
 Given these options, the following invocations would all be equivalent:
 
 ```sh
-cmd -fsn 'my string' 123
+cmd -fSN 'my string' 123
 cmd -Fsn 'my string' 123
 ```
 

--- a/packages/docs/pages/docs/library/parser.mdx
+++ b/packages/docs/pages/docs/library/parser.mdx
@@ -80,10 +80,17 @@ When invoking the parsing methods with a raw command line, and this flag is set,
 know to perform word completion for the argument ending at this position. It defaults to the value
 of the `COMP_POINT` or `CURSOR` environment variables, whichever is present.
 
-### Short-option style
+### Cluster prefix
 
-The `shortStyle` property indicates whether the first argument is expected to be an option cluster.
-This must be used in conjunction with the [cluster letters] option attribute.
+The `clusterPrefix` property specifies the prefix for option clusters. If set, then eligible
+arguments that have this prefix will be considered a cluster. This must be used in conjunction with
+the [cluster letters] option attribute.
+
+<Callout type="info">
+  Option names have precedence over the cluster prefix. For example, if the prefix is a single dash
+  and there's an option named `'-flag'{:ts}`, then an argument with this name will _not_ be
+  considered a cluster argument.
+</Callout>
 
 ## Parsing features
 

--- a/packages/tsargp/lib/options.ts
+++ b/packages/tsargp/lib/options.ts
@@ -588,9 +588,10 @@ export type WithCommand = {
    */
   readonly options?: Options | (() => Options);
   /**
-   * True if the first argument is expected to be an option cluster (i.e., short-option style).
+   * The prefix of option clusters.
+   * If set, then eligible arguments that have this prefix will be considered a cluster.
    */
-  readonly shortStyle?: true;
+  readonly clusterPrefix?: string;
 };
 
 /**


### PR DESCRIPTION
Replaced the `shortStyle` configuration flag by the more generic `clusterPrefix`, which allows cluster arguments anywhere in the command line.

Updated the Parser page to document the new flag, as well as the Options page to document the new behavior of cluster arguments.

Closes #120 
