### PR TITLE
Issues/122

### DIFF
--- a/.changeset/beige-drinks-battle.md
+++ b/.changeset/beige-drinks-battle.md
@@ -1,0 +1,5 @@
+---
+'tsargp': minor
+---
+
+Cluster arguments now support inline parameters (this is not to be confused with inline parameters of normal arguments).

--- a/.changeset/shiny-jeans-arrive.md
+++ b/.changeset/shiny-jeans-arrive.md
@@ -1,0 +1,5 @@
+---
+'@trulysimple/tsargp-docs': minor
+---
+
+The Parser and Options pages were updated to document the new syntax for inline cluster parameters.

--- a/packages/docs/components/calc.tsx
+++ b/packages/docs/components/calc.tsx
@@ -5,7 +5,7 @@ import React from 'react';
 import { ArgumentParser, ErrorMessage, HelpMessage } from 'tsargp';
 import { type Props, Command } from './classes/command';
 
-// @ts-expect-error since tsargp demo does not export types
+// @ts-expect-error since tsargp examples do not export types
 import { calc as options } from 'tsargp/examples';
 
 //--------------------------------------------------------------------------------------------------

--- a/packages/docs/components/classes/command.tsx
+++ b/packages/docs/components/classes/command.tsx
@@ -183,7 +183,7 @@ abstract class Command<P extends Props = Props, S extends State = State> extends
     if (pos <= 0) {
       return; // happens when the cursor is positioned before the start of the command
     }
-    let commands = ['clear', this.commands];
+    let commands = ['clear', ...this.commands];
     for (let i = 0; i < pos && i < command.length; ++i) {
       commands = commands.filter((cmd) => i < cmd.length && cmd[i] === line[i]);
     }

--- a/packages/docs/components/demo.tsx
+++ b/packages/docs/components/demo.tsx
@@ -5,11 +5,10 @@ import React from 'react';
 import { ArgumentParser, ErrorMessage, HelpMessage } from 'tsargp';
 import { type Props, Command } from './classes/command';
 
-// @ts-expect-error since tsargp demo does not export types
+// @ts-expect-error since tsargp examples do not export types
 import { demo as options } from 'tsargp/examples';
 
-// remove version option since there's no package.json file in the browser
-delete options.version;
+delete options.version; // remove version option since there's no package.json in the browser
 
 //--------------------------------------------------------------------------------------------------
 // Classes
@@ -24,7 +23,8 @@ class DemoCommand extends Command {
   override async run(line: string, compIndex?: number) {
     try {
       const values: { hello?: number } = {};
-      const { warning } = await this.parser.parseInto(values, line, { compIndex });
+      const flags = { progName: 'tsargp', compIndex, clusterPrefix: '-' };
+      const { warning } = await this.parser.parseInto(values, line, flags);
       if (warning) {
         this.println(warning.wrap(this.state.width));
       }

--- a/packages/docs/pages/demo.mdx
+++ b/packages/docs/pages/demo.mdx
@@ -25,13 +25,18 @@ export const Demo = dynamic(() => import('@components/demo'), { ssr: false });
 
 - check if completion works by pressing `Tab` (it behaves slightly differently than a real bash)
 - check if an option name gets completed (e.g., `-<Tab>`, `--<Tab>`, `--h<Tab>`)
-- check if an option parameter gets completed (e.g., `o<Tab>`, `-se <Tab>`, `--ne <Tab>`)
+- check if an option parameter gets completed (e.g., `o<Tab>`, `-b <Tab>`, `-se <Tab>`, `-ne <Tab>`)
 
 ### Positional arguments
 
 - check if positional arguments can be specified before named ones (e.g., `one -s 0`)
 - check if all arguments after `--` are recognized as positional (e.g., try `-- -f` and see that it
   fails)
+
+### Cluster arguments
+
+- check if cluster arguments can be specified (e.g., `-sn 1 -1`)
+- check if cluster arguments can be specified with inline values (e.g., `-s1` or `-n-1`)
 
 ### String parameters
 

--- a/packages/docs/pages/demo.mdx
+++ b/packages/docs/pages/demo.mdx
@@ -36,7 +36,7 @@ export const Demo = dynamic(() => import('@components/demo'), { ssr: false });
 ### Cluster arguments
 
 - check if cluster arguments can be specified (e.g., `-sn 1 -1`)
-- check if cluster arguments can be specified with inline values (e.g., `-s1` or `-n-1`)
+- check if cluster arguments can be specified with inline parameters (e.g., `-s1` or `-n-1`)
 
 ### String parameters
 
@@ -64,7 +64,7 @@ export const Demo = dynamic(() => import('@components/demo'), { ssr: false });
 
 - check if the `-f` option can be specified without a parameter, and negated with `--no-flag`
 - check if the `-b` option can be specified in combination with other options
-- check if values can be inlined with option names (e.g., `-ss=abc`)
+- check if parameters can be inlined with option names (e.g., `-ss=abc`)
 - check if the help option accepts option filters (e.g., `-h -b`)
 
 ### Nested commands

--- a/packages/docs/pages/docs/library/options.mdx
+++ b/packages/docs/pages/docs/library/options.mdx
@@ -288,7 +288,8 @@ letter that is _not_ the first. For example, using the same option definitions a
 line `cmd -s'my str' -n123{:sh}` would be parsed as `cmd --str 'my str' --num 123{:sh}`.
 
 Notice how the parameters appear "glued" to the first letter, with no intervening space, and they
-contain characters that are not valid cluster letters. The first letter _must_ be a valid letter.
+contain characters that are not valid cluster letters. The first one _must_ be valid, otherwise the
+argument will not be considered a cluster.
 
 ### Parameter attributes
 

--- a/packages/docs/pages/docs/library/options.mdx
+++ b/packages/docs/pages/docs/library/options.mdx
@@ -281,10 +281,14 @@ Notes about this feature:
 - if word completion is attempted in a cluster, the default [completion message] is thrown
 - if a nameless positional option appears in a cluster, its argument will be treated as positional
 
-<Callout type="info">
-  Sticking option arguments right after a cluster letter, with no intervening space, is _not_
-  supported. For example, the following command line would be invalid: `cmd -s'my str' -n123{:sh}`.
-</Callout>
+##### Inline parameters
+
+Cluster arguments may be considered to have an inline parameter if they contain at least one unknown
+letter that is _not_ the first. For example, using the same option definitions as above, the command
+line `cmd -s'my str' -n123{:sh}` would be parsed as `cmd --str 'my str' --num 123{:sh}`.
+
+Notice how the parameters appear "glued" to the first letter, with no intervening space, and they
+contain characters that are not valid cluster letters. The first letter _must_ be a valid letter.
 
 ### Parameter attributes
 

--- a/packages/docs/pages/docs/library/parser.mdx
+++ b/packages/docs/pages/docs/library/parser.mdx
@@ -250,9 +250,9 @@ with normal parameters, the value may contain any number of equal signs, and eve
 (e.g., `-opt==val` would be parsed as `'=val'{:ts}`).
 
 Cluster arguments may also have inline parameters, but their syntax is different. A cluster argument
-is considered to have an inline parameter if it contains an unknown letter that is _not_ the first
-letter in the cluster. In this case, the first letter is the option and the rest is its parameter.
-See cluster letters' [inline parameters] for details about this syntax.
+is considered to have an inline parameter if it contains an unknown letter that is not the first one
+in the cluster. In this case, the first letter _must_ be an option and the rest is its parameter.
+See [cluster inline parameters] for details about this syntax.
 
 ### Process title
 
@@ -300,7 +300,7 @@ they would pollute the output of process management utilities such as `ps`.
 [fallback value]: options#fallback-value
 [parameter count]: options#parameter-count
 [usage section]: formatter#usage-section
-[inline parameters]: options#inline-parameters
+[cluster inline parameters]: options#inline-parameters
 [`break`]: options#break-loop
 [Set]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set
 [Bash docs]: https://www.gnu.org/software/bash/manual/html_node/Programmable-Completion.html

--- a/packages/docs/pages/docs/library/parser.mdx
+++ b/packages/docs/pages/docs/library/parser.mdx
@@ -249,6 +249,11 @@ is only valid for non-niladic options and cannot be used with the positional mar
 with normal parameters, the value may contain any number of equal signs, and even start with one
 (e.g., `-opt==val` would be parsed as `'=val'{:ts}`).
 
+Cluster arguments may also have inline parameters, but their syntax is different. A cluster argument
+is considered to have an inline parameter if it contains an unknown letter that is _not_ the first
+letter in the cluster. In this case, the first letter is the option and the rest is its parameter.
+See cluster letters' [inline parameters] for details about this syntax.
+
 ### Process title
 
 The process title will be updated to reflect the current command being executed. This includes the
@@ -295,6 +300,7 @@ they would pollute the output of process management utilities such as `ps`.
 [fallback value]: options#fallback-value
 [parameter count]: options#parameter-count
 [usage section]: formatter#usage-section
+[inline parameters]: options#inline-parameters
 [`break`]: options#break-loop
 [Set]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set
 [Bash docs]: https://www.gnu.org/software/bash/manual/html_node/Programmable-Completion.html

--- a/packages/tsargp/examples/demo.options.ts
+++ b/packages/tsargp/examples/demo.options.ts
@@ -152,6 +152,7 @@ Report a bug: ${style(tf.faint)}https://github.com/trulysimple/tsargp/issues`,
     regex: /^\d+$/,
     default: '123456789',
     paramName: 'my str',
+    clusterLetters: 's',
   },
   /**
    * A number option that has a range constraint.
@@ -164,6 +165,7 @@ Report a bug: ${style(tf.faint)}https://github.com/trulysimple/tsargp/issues`,
     range: [-Infinity, 0],
     default: -1.23,
     paramName: 'my num',
+    clusterLetters: 'n',
   },
   /**
    * A string option that has an enumeration constraint.

--- a/packages/tsargp/examples/demo.ts
+++ b/packages/tsargp/examples/demo.ts
@@ -23,8 +23,9 @@ interface Values {
 }
 
 try {
+  const parser = new ArgumentParser(options);
   const values = {} as Values;
-  const { warning } = await new ArgumentParser(options).parseInto(values);
+  const { warning } = await parser.parseInto(values, undefined, { clusterPrefix: '-' });
   if (warning) {
     console.log(`${warning}`);
   }

--- a/packages/tsargp/test/parser/parser.cluster.spec.ts
+++ b/packages/tsargp/test/parser/parser.cluster.spec.ts
@@ -7,7 +7,7 @@ describe('ArgumentParser', () => {
   describe('parse', () => {
     const flags: ParsingFlags = { clusterPrefix: '-' };
 
-    it('should throw an error on unknown option in cluster', async () => {
+    it('should throw an error on unrecognized cluster argument', async () => {
       const parser = new ArgumentParser({});
       await expect(parser.parse(['-x'], flags)).rejects.toThrow(`Unknown option -x.`);
     });

--- a/packages/tsargp/test/parser/parser.completion.spec.ts
+++ b/packages/tsargp/test/parser/parser.completion.spec.ts
@@ -10,6 +10,17 @@ describe('ArgumentParser', () => {
       await expect(parser.parse('cmd', { compIndex: 4 })).rejects.toThrow(/^$/);
     });
 
+    it('should ignore unknown options during completion', async () => {
+      const options = {
+        flag: {
+          type: 'flag',
+          names: ['-f'],
+        },
+      } as const satisfies Options;
+      const parser = new ArgumentParser(options);
+      await expect(parser.parse('cmd x ', { compIndex: 6 })).rejects.toThrow(/^-f$/);
+    });
+
     it('should ignore parsing errors during completion', async () => {
       const options = {
         string: {
@@ -676,7 +687,7 @@ describe('ArgumentParser', () => {
       await expect(parser.parse('cmd -ns 1 -ns', { compIndex: 13 })).rejects.toThrow(/^-ns$/);
     });
 
-    it('should throw the default completion when completing a cluster argument', async () => {
+    it('should handle the completion of a cluster argument', async () => {
       const options = {
         flag: {
           type: 'flag',
@@ -686,13 +697,18 @@ describe('ArgumentParser', () => {
       } as const satisfies Options;
       const parser = new ArgumentParser(options);
       const flags: ParsingFlags = { clusterPrefix: '-', compIndex: 6 };
-      await expect(parser.parse('cmd  -f', flags)).rejects.toThrow(/^$/);
-      await expect(parser.parse('cmd --f', flags)).rejects.toThrow(/^$/);
+      await expect(parser.parse('cmd  -f', flags)).rejects.toThrow(/^--flag$/);
+      await expect(parser.parse('cmd --f', flags)).rejects.toThrow(/^--flag$/);
       await expect(parser.parse('cmd -ff', flags)).rejects.toThrow(/^$/);
     });
 
     it('should complete the parameter of a clustered option (and ignore the rest)', async () => {
       const options = {
+        flag: {
+          type: 'flag',
+          names: ['--flag'],
+          clusterLetters: 'f',
+        },
         boolean: {
           type: 'boolean',
           names: ['--bool'],
@@ -702,7 +718,7 @@ describe('ArgumentParser', () => {
       } as const satisfies Options;
       const parser = new ArgumentParser(options);
       const flags: ParsingFlags = { clusterPrefix: '-', compIndex: 8 };
-      await expect(parser.parse('cmd -bx  rest', flags)).rejects.toThrow(/^yes$/);
+      await expect(parser.parse('cmd -bf  rest', flags)).rejects.toThrow(/^yes$/);
     });
 
     it('should ignore unknown cluster letters during completion', async () => {
@@ -716,7 +732,7 @@ describe('ArgumentParser', () => {
       } as const satisfies Options;
       const parser = new ArgumentParser(options);
       const flags: ParsingFlags = { clusterPrefix: '-', compIndex: 8 };
-      await expect(parser.parse('cmd -xb ', flags)).rejects.toThrow(/^yes$/);
+      await expect(parser.parse('cmd -xb ', flags)).rejects.toThrow(/^--bool$/);
     });
 
     it('should handle the completion of a boolean option with async custom completion', async () => {


### PR DESCRIPTION
Implemented support for inline cluster parameters (this is not to be confused with inline parameters of normal arguments).

Updated the Parser and Options pages to document the new syntax for inline cluster parameters.

Closes #122 
