### PR TITLE
Issues/129

### DIFF
--- a/.changeset/nine-lies-care.md
+++ b/.changeset/nine-lies-care.md
@@ -1,0 +1,5 @@
+---
+'@trulysimple/tsargp-docs': patch
+---
+
+The `clear` command in the Demo page has been fixed. This was a regression from the last release.

--- a/.changeset/small-feet-retire.md
+++ b/.changeset/small-feet-retire.md
@@ -1,0 +1,5 @@
+---
+'tsargp': patch
+---
+
+The wording for the `tooSimilarOptionNames` and `mixedNamingConvention` warnings was changed.

--- a/packages/docs/components/classes/command.tsx
+++ b/packages/docs/components/classes/command.tsx
@@ -231,16 +231,10 @@ abstract class Command<P extends Props = Props, S extends State = State> extends
     const cmdLine = processEnvVars(line.trimStart());
     if (cmdLine) {
       const [command, line] = cmdLine;
-      if (this.commands.includes(command)) {
-        switch (command) {
-          case 'clear':
-            this.term.clear();
-            break;
-          default: {
-            await this.run(line);
-            break;
-          }
-        }
+      if (command === 'clear') {
+        this.term.clear();
+      } else if (this.commands.includes(command)) {
+        await this.run(line);
       } else {
         this.readline.println(`${command}: command not found`);
       }

--- a/packages/docs/pages/docs/guides/help.mdx
+++ b/packages/docs/pages/docs/guides/help.mdx
@@ -82,7 +82,7 @@ Which, when invoked with `--help`, would render something like:
 ```ansi
 A command-line interface for <purpose>.
 
-cmd [[95m--help[0m]
+cli [[95m--help[0m]
 
 [4mOptions:[0m
 
@@ -95,10 +95,10 @@ Refer to [90m<website>[39m for support.
 ## Help command
 
 <Callout type="default">
-  Since this guide was written, the [enable nested] attribute for help options was introduced, which
-  offers what is described below in a more convenient way. The only difference is that it does not
-  allow an [enumeration] constraint for the available command names (which is used in error messages
-  and word completion).
+  Since this guide was written, the [enable nested] attribute for help options has been introduced.
+  It supersedes help commands and offers a more convenient way to achieve what is described below.
+  However, if you need an [enumeration] constraint for the available command names, then what
+  follows might still be relevant.
 </Callout>
 
 Another way to offer help is by defining a "help" command. This method still uses the help option
@@ -107,8 +107,8 @@ commands. For example, to present help for a nested command called `cmd`, the fo
 would be equivalent:
 
 ```sh
-./my_cli help cmd
-./my_cli cmd --help
+cli help cmd
+cli cmd --help
 ```
 
 To achieve this, we have to define a [command option]. We can start with the definitions for the
@@ -174,8 +174,8 @@ The `progName` configuration flag is set in order to avoid appending the script 
 process title.
 
 <Callout type="info">
-  Keep in mind that, when word completion is in effect, the command callback [is not called]. Thus,
-  if the callback _does_ get executed, you need not worry about the [`compIndex`] flag for the
+  Keep in mind that, when word completion is in effect, the [command callback] will _not_ be called.
+  Thus, if the callback _does_ get executed, you need not worry about the [`compIndex`] flag for the
   delegated `parse` call.
 </Callout>
 
@@ -183,5 +183,5 @@ process title.
 [enable nested]: ../library/options#enable-nested
 [help option]: ../library/options#help-option
 [command option]: ../library/options#command-option
-[is not called]: ../library/options#command-callback
+[command callback]: ../library/options#command-callback
 [`compIndex`]: ../library/parser#completion-index

--- a/packages/docs/pages/docs/library/formatter.mdx
+++ b/packages/docs/pages/docs/library/formatter.mdx
@@ -320,9 +320,9 @@ description of the corresponding value:
 
 ### Option filter
 
-The `filter` property specifies a list of patterns that are used to select the options that will be
-rendered in the help message. The filter matches options' names, synopsis and environment variable
-names. If multiple patterns are provided, any matched one will suffice to include an option in the message.
+The `filter` property specifies a list of patterns to select the options that will be rendered in
+the help message. The filter matches options' names, synopsis and environment variable names. If
+multiple patterns are provided, any matched one will suffice to include an option in the message.
 
 <Callout type="default">
   This is inherently different from what a text search utility like `grep` would produce. The

--- a/packages/docs/pages/docs/library/formatter.mdx
+++ b/packages/docs/pages/docs/library/formatter.mdx
@@ -41,7 +41,7 @@ parameter.
 The `formatSections` method returns a help message that includes [help sections], as will be
 explained later in this page. It accepts two parameters:
 
-- `sections` - a list of `HelpSection` to include in the help message
+- `sections` - a list of `HelpSection`s to include in the help message
 - `progName` - an optional program name to display in usage sections
 
 ## Help entries
@@ -148,7 +148,7 @@ demo.js [([95m-f[0m|[95m--flag[0m|[95m--no-flag[0m)]
 In addition to the [common properties], a usage section has the following properties:
 
 - `indent` - the level of indentation of the section content (defaults to `0{:ts}`)
-- `filter` - a list of option keys to include or exclude (defaults to none)
+- `filter` - a list of option keys to include or exclude (defaults to including all options)
 - `exclude` - whether the filter should exclude (defaults to `false{:ts}`)
 - `required` - a list of options that should be considered required in the usage
 - `comment` - a commentary to append to the usage (defaults to none)
@@ -161,16 +161,16 @@ In addition to the [common properties], a usage section has the following proper
 ### Groups section
 
 A groups section is a collection of option groups and their help entries. In addition to the [common
-properties] properties, it has the following properties:
+properties], it has the following properties:
 
-- `filter` - a list of group names to include or exclude (defaults to none)
+- `filter` - a list of group names to include or exclude (defaults to including all groups)
 - `exclude` - whether the filter should exclude (defaults to `false{:ts}`)
 
 ## Help format
 
 In addition to the validator instance, the formatter constructor accepts a `FormatterConfig` object
 that can be used to customize the format of help entries in option groups. This configuration will
-apply to all help entries. Its properties are optional and are described below.
+apply to all entries. Its properties are optional and are described below.
 
 ### Help columns
 
@@ -205,7 +205,7 @@ configuration:
   descr: {
     align: 'right', // align option descriptions to the right
     breaks: 1,      // break option descriptions
-    indent: 20,     // indent 20 terminal columns
+    indent: 20,     // indent 20 terminal columns...
     absolute: true, // from the beginning of the line
   }
 }
@@ -230,7 +230,7 @@ and in what order. It is an array whose values can be one of the enumerators fro
 
 - `synopsis` - the option [synopsis]
 - `negation` - the [negation names] of a flag option, if any
-- `separator` - the element [delimiter] of an array option, if enabled
+- `separator` - the parameter [delimiter] of an array option, if enabled
 - `paramCount` - reports the [parameter count] of a variadic or polyadic[^1] option
 - `positional` - reports if an option accepts [positional] arguments
 - `append` - reports if an array option can be specified [multiple times]
@@ -320,9 +320,9 @@ description of the corresponding value:
 
 ### Option filter
 
-The `filter` property specifies a list of patterns that can be used to select options to render in
-the help message. The filter matches options' names, synopsis and environment variable names. If
-multiple patterns are provided, any matched one will suffice to include an option in the message.
+The `filter` property specifies a list of patterns that are used to select the options that will be
+rendered in the help message. The filter matches options' names, synopsis and environment variable
+names. If multiple patterns are provided, any matched one will suffice to include an option in the message.
 
 <Callout type="default">
   This is inherently different from what a text search utility like `grep` would produce. The
@@ -332,7 +332,7 @@ multiple patterns are provided, any matched one will suffice to include an optio
 
 ## Help styles
 
-Help messages are styled with the set of [error styles] from the validator configuration, except
+Help messages are styled using the set of [error styles] from the validator configuration, except
 that they may get overridden by (or combined with) an option's [display styles], if present.
 
 <Callout type="default">

--- a/packages/docs/pages/docs/library/options.mdx
+++ b/packages/docs/pages/docs/library/options.mdx
@@ -254,7 +254,7 @@ If they were defined in the `requiredIf` attribute, they would mean:
 
 The `clusterLetters` attribute, if present, specifies letters (or any Unicode characters except
 whitespace) that can be used to cluster options in a single command-line argument. This feature is
-also known as [_short-option_ style], and it can be enabled via the parser's [`clusterPrefix`]
+also known as [short-option] style, and can be enabled via the parser's [`clusterPrefix`]
 configuration flag.
 
 Here is an example that illustrates how it works. Suppose we have the following options:
@@ -924,7 +924,7 @@ attributes:
 [Set]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set
 [Math]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math
 [`import.meta.resolve`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/import.meta/resolve
-[_short-option_ style]: https://www.linuxtopia.org/online_books/linux_tool_guides/tar_user_guide/Short-Options.html
+[short-option]: https://www.linuxtopia.org/online_books/linux_tool_guides/tar_user_guide/Short-Options.html
 [discriminant]: https://www.typescriptlang.org/docs/handbook/2/narrowing.html#discriminated-unions
 
 [^1]: help and version options throw a message instead of having a value.

--- a/packages/docs/pages/docs/library/options.mdx
+++ b/packages/docs/pages/docs/library/options.mdx
@@ -15,18 +15,18 @@ available types and describe them in detail.
 
 There is a total of ten option types, as summarized in the table below:
 
-| Type       | Parameters                              | Value              | Normalization            | Constraints               |
-| ---------- | --------------------------------------- | ------------------ | ------------------------ | ------------------------- |
-| [help]     | niladic                                 | `never{:ts}`[^1]   |                          |                           |
-| [version]  | niladic                                 | `never{:ts}`[^1]   |                          |                           |
-| [function] | configurable                            | `unknown{:ts}`[^2] |                          | [param count]             |
-| [command]  | not applicable                          | `unknown{:ts}`[^2] |                          |                           |
-| [flag]     | niladic                                 | `boolean{:ts}`     |                          |                           |
-| [boolean]  | positional, monadic                     | `boolean{:ts}`     |                          | [truth and falsity]       |
-| [string]   | positional, monadic                     | `string{:ts}`      | [trim], [case]           | [enums], [regex]          |
-| [number]   | positional, monadic                     | `number{:ts}`      | [conv]                   | [enums], [range]          |
-| [strings]  | positional, delimited, variadic, append | `string[]{:ts}`    | [unique], [trim], [case] | [enums], [regex], [limit] |
-| [numbers]  | positional, delimited, variadic, append | `number[]{:ts}`    | [unique], [conv]         | [enums], [range], [limit] |
+| Type       | Parameters                                   | Value              | Normalization            | Constraints               |
+| ---------- | -------------------------------------------- | ------------------ | ------------------------ | ------------------------- |
+| [help]     | niladic                                      | `never{:ts}`[^1]   |                          |                           |
+| [version]  | niladic                                      | `never{:ts}`[^1]   |                          |                           |
+| [function] | configurable                                 | `unknown{:ts}`[^2] |                          | [param count]             |
+| [command]  | not applicable[^3]                           | `unknown{:ts}`[^2] |                          |                           |
+| [flag]     | niladic                                      | `boolean{:ts}`     |                          |                           |
+| [boolean]  | positional, monadic                          | `boolean{:ts}`     |                          | [truth and falsity]       |
+| [string]   | positional, monadic                          | `string{:ts}`      | [trim], [case]           | [enums], [regex]          |
+| [number]   | positional, monadic                          | `number{:ts}`      | [conv]                   | [enums], [range]          |
+| [strings]  | positional, delimited, variadic, append-able | `string[]{:ts}`    | [unique], [trim], [case] | [enums], [regex], [limit] |
+| [numbers]  | positional, delimited, variadic, append-able | `number[]{:ts}`    | [unique], [conv]         | [enums], [range], [limit] |
 
 The meaning of each column is explained below.
 
@@ -40,14 +40,12 @@ attributes of each specific option.
 
 The parameters column indicates how many parameters an option expects on the command-line:
 
-- _niladic_ - no parameter
-- _monadic_ - single parameter
-- _variadic_ - variable number of parameters
-- _delimited_ - single parameter in which values are delimited by a [separator]
-- _append_ - can be specified multiple times, with values getting [appended]
-- _configurable_ - can be configured with a certain [parameter count]
-- _not applicable_ - does not accept parameters; rather, it starts a new parsing context with the
-  remaining arguments
+- **niladic** - no parameter
+- **monadic** - single parameter
+- **variadic** - variable number of parameters
+- **delimited** - single parameter in which values are delimited by a [separator]
+- **append-able** - can be specified multiple times, with values getting [appended]
+- **configurable** - can be configured with a certain [parameter count]
 
 In the case of non-niladic options, parameters can be made optional by setting a [fallback value].
 
@@ -68,7 +66,7 @@ for the help and version options, which do not have values, the initial value of
 All options that accept parameters can be configured with normalization and constraint attributes.
 
 In the case of string- and number-valued options, these attributes indicate how the option value
-should be transformed after being parsed, and if it should comply with any value constraints.
+should be transformed after being parsed, and if it should comply with value constraints.
 
 In the case of the function and boolean options, there are specialized constraints for the handling
 of option parameters (i.e., before they get parsed).
@@ -142,6 +140,10 @@ other options.
 
 Mutually exclusive with [default value] and [conditional requirements].
 
+<Callout type="default">
+  When using this attribute, we recommend also setting [preferred name] to some explanatory name.
+</Callout>
+
 #### Default value
 
 The `default` attribute, if present, specifies a value to be used in case the option is specified
@@ -163,9 +165,9 @@ toString() {
 
 ##### Default callback
 
-If the value is not known beforehand (e.g., if it depends on the values of other options), you may
-want to use a callback to inspect parsed values and determine the default based on those values. It
-receives one parameter:
+If the default value is not known beforehand (e.g., if it depends on the values of other options),
+you may want to use a callback to inspect parsed values and determine the default based on those
+values. It receives one parameter:
 
 - `values` - the parsed values
 
@@ -179,10 +181,10 @@ Notes about this callback:
 The `requires` attribute, if present, specifies requirements that must be satisfied _if_ the option
 is specified on the command-line. It can be either:
 
-- an option key;
-- an object that maps option keys to required values;
-- a requirement expression; or
-- a requirement callback
+- an option **key**;
+- an object that maps option keys to required **values**;
+- a requirement **expression**; or
+- a requirement **callback**
 
 In the case of an option key, the referenced option must also be present on the command-line.
 In the case of an object, every referenced option must have the corresponding value.
@@ -251,8 +253,8 @@ If they were defined in the `requiredIf` attribute, they would mean:
 #### Cluster letters
 
 The `clusterLetters` attribute, if present, specifies letters (or any Unicode characters except
-whitespace) that can be used to cluster options in a single command-line argument. This is also
-known as [_short-option_ style]. This feature can be enabled via the parser's [`clusterPrefix`]
+whitespace) that can be used to cluster options in a single command-line argument. This feature is
+also known as [_short-option_ style], and it can be enabled via the parser's [`clusterPrefix`]
 configuration flag.
 
 Here is an example that illustrates how it works. Suppose we have the following options:
@@ -264,28 +266,28 @@ Here is an example that illustrates how it works. Suppose we have the following 
 Given these options, the following invocations would all be equivalent:
 
 ```sh
-cmd -fSN 'my string' 123
-cmd -Fsn 'my string' 123
+cli -fSN 'my string' 123
+cli -Fsn 'my string' 123
 ```
 
 They would be transformed to their "canonical" form, i.e.:
 
 ```sh
-cmd --flag --str 'my string' --num 123
+cli --flag --str 'my string' --num 123
 ```
 
 Notes about this feature:
 
 - the order of options in a cluster is preserved when converting to the canonical form
 - variadic options and command options are supported, but they must be the last in a cluster
-- if word completion is attempted in a cluster, the default [completion message] is thrown
+- if word completion is attempted for a cluster, the default [completion message] is thrown
 - if a nameless positional option appears in a cluster, its argument will be treated as positional
 
 ##### Inline parameters
 
 Cluster arguments may be considered to have an inline parameter if they contain at least one unknown
 letter that is _not_ the first. For example, using the same option definitions as above, the command
-line `cmd -s'my str' -n123{:sh}` would be parsed as `cmd --str 'my str' --num 123{:sh}`.
+line `cli -s'my str' -n123{:sh}` would be parsed as `cli --str 'my str' --num 123{:sh}`.
 
 Notice how the parameters appear "glued" to the first letter, with no intervening space, and they
 contain characters that are not valid cluster letters. The first one _must_ be valid, otherwise the
@@ -308,10 +310,12 @@ The `positional` attribute, if present, indicates that the option accepts _posit
 There may be at most _one_ option with this setting.
 
 If set to `true{:ts}`, then any argument not recognized as an option name will be considered
-positional. If set to a string, then it acts as positional marker, and all arguments that appear
-_beyond_ the marker will be considered positional.
+positional. If set to a string, then it acts as positional marker, in which case all arguments that
+appear _beyond_ the marker will be considered positional.
 
-When using this attribute, we recommend also setting [preferred name] to some explanatory name.
+<Callout type="default">
+  When using this attribute, we recommend also setting [preferred name] to some explanatory name.
+</Callout>
 
 #### Complete callback
 
@@ -332,7 +336,7 @@ Notes about this callback:
 
 ### Known value attributes
 
-All options that have known values share a set of attributes, which are described below.
+All non-niladic options that have known values share a set of attributes, which are described below.
 
 #### Example value
 
@@ -427,7 +431,7 @@ Array-valued options share a set of attributes, as described below.
 #### Separator
 
 The `separator` attribute, if present, specifies a delimiter by which to split the option parameter.
-If specified, the option will accept a single parameter[^3] on the command-line, not multiple
+If specified, the option will accept a single parameter[^4] on the command-line, not multiple
 parameters (as is the default). It can be either a string or a regular expression.
 
 #### Remove duplicates
@@ -608,10 +612,10 @@ By default, a function option is niladic. However, this behavior can be changed 
 `paramCount` attribute. If present, it specifies how many parameters the option expects. It can
 have either of the following values:
 
-- a zero value: same as the niladic case
-- a negative number: the option accepts unlimited parameters
-- a positive number: the option expects exactly this number of parameters
-- a numeric range: the option expects between a minimum and maximum count
+- a **zero** value: same as the niladic case
+- a **negative** number: the option accepts unlimited parameters
+- a **positive** number: the option expects exactly this number of parameters
+- a numeric **range**: the option expects between a minimum and maximum count
 
 Mutually exclusive with [skip count].
 
@@ -697,10 +701,10 @@ The `options` attribute specifies the set of option definitions for the command,
   pertaining to the command must be specified _after_ it.
 </Callout>
 
-#### Short-option style
+#### Cluster letters
 
-The `shortStyle` property indicates whether the first command argument is expected to be an option
-cluster. This must be used in conjunction with the [cluster letters] of the command's options.
+The `clusterLetters` property indicates whether the command accepts cluster arguments. This must be
+used in conjunction with the [cluster letters] of the command's options.
 
 ### Flag option
 
@@ -709,7 +713,7 @@ differs from the [boolean option] in that it does _not_ expect a parameter. Whil
 configured to have a [fallback value] (thus making its parameter optional), that potentially
 introduces ambiguity of whether arguments are positional or not.
 
-For example, consider the command line `cmd -b 1`, where `-b` is a boolean option with a fallback
+For example, consider the command line `cli -b 1`, where `-b` is a boolean option with a fallback
 value and there is a positional option. In this case, would `1` be a parameter to `-b` or a
 positional argument? The parser is implemented to consider it a parameter to `-b`. However, the flag
 option completely solves this ambiguity.
@@ -736,7 +740,7 @@ flag that has been previously specified must be reset by a supplementary list of
 
 ## Non-niladic options
 
-Non-niladic options expect one or more parameters on the command-line.
+Non-niladic options accept one or more parameters on the command-line.
 
 ### Boolean option
 
@@ -793,7 +797,7 @@ specified in its definition. It has the following sets of attributes:
 
 ### Number option
 
-The **number** option accepts a single parameter that is converted to `Number{:ts}` and normalized
+The **number** option accepts a single parameter that is converted to `number{:ts}` and normalized
 according to the constraints specified in its definition. It has the following sets of attributes:
 
 - [basic attributes]
@@ -818,7 +822,7 @@ specified in its definition. It has the following sets of attributes:
 
 ### Numbers option
 
-The **numbers** option accepts multiple parameters that are converted to `Number{:ts}` and
+The **numbers** option accepts multiple parameters that are converted to `number{:ts}` and
 normalized according to the constraints specified in its definition. It has the following sets of
 attributes:
 
@@ -925,4 +929,5 @@ attributes:
 
 [^1]: help and version options throw a message instead of having a value.
 [^2]: the return type of the function or command callback.
-[^3]: we say that it is _delimited_, rather than _variadic_.
+[^3]: rather than accepting parameters, it starts a new parsing context with the remaining arguments.
+[^4]: we say that it is _delimited_, rather than _variadic_.

--- a/packages/docs/pages/docs/library/parser.mdx
+++ b/packages/docs/pages/docs/library/parser.mdx
@@ -23,11 +23,13 @@ method accepts two optional parameters:
 - `cmdLine` - the raw command line (`string{:ts}`) or the command-line arguments (`string[]{:ts}`)
 - `flags` - a `ParsingFlags` object with the [parsing flags]
 
-Normally you should _not_ need to pass these parameters, as they have sensible default values:
+Normally you should _not_ need to pass these parameters, as they have sensible default values. The
+command line defaults to the value of either the `COMP_LINE` or `BUFFER` environment variables
+(whichever is present) or the process arguments:
 
-- `cmdLine` - `process.env['COMP_LINE'] ?? process.env['BUFFER'] ?? process.argv.slice(2){:ts}`
-- `flags.progName` - `process.argv[1].split(/[\\/]/).at(-1){:ts}`
-- `flags.compIndex` - `Number(process.env['COMP_POINT'] ?? process.env['CURSOR']) || process.env['BUFFER']?.length{:ts}`
+```ts
+process.env['COMP_LINE'] ?? process.env['BUFFER'] ?? process.argv.slice(2);
+```
 
 If you feel the need to configure the parsing procedure, make sure to first understand how [word
 completion] works.
@@ -45,12 +47,16 @@ the previous one, except for an additional (first) parameter:
 
 - `values` - the option values to parse into
 
-Existing values are preserved until they get overridden by values parsed either from the
-command-line or from environment variables. When using TypeScript, this parameter will be
-type-checked against the expected type of the option values for a given set of option definitions.
+<Callout type="info">
+  Existing values are preserved until they get overridden by values parsed either from the command
+  line or from environment variables.
+</Callout>
+
+When using TypeScript, this parameter will be type-checked against the expected type of the option
+values for a given set of option definitions.
 
 <Callout type="default">
-  You may want to use IntelliSense to peak at the resulting type of the `parse` method (or declare a
+  You may want to peak at the resulting type of the `parse` method using IntelliSense (or declare a
   temporary type alias for `OptionValues<typeof _your_options_>{:ts}`) to see how the object is
   structured.
 </Callout>
@@ -67,17 +73,27 @@ properties, as described below.
 
 ### Program name
 
-The `progName` property is a custom name for the program, which is used to update the [process
+The `progName` property is a custom name for the main command, which is used to update the [process
 title] and is rendered in the help message's [usage section]. It defaults to the basename of the
-executing script. You can set it to the empty string in order to suppress its appearance.
+executing script:
+
+```ts
+process.argv[1].split(/[\\/]/).at(-1);
+```
+
+<Callout type="default">You can set it to an empty string to suppress its appearance.</Callout>
 
 <Callout type="info">This flag is ignored when word completion is in effect.</Callout>
 
 ### Completion index
 
 The `compIndex` property is the cursor position in a command line for which the user pressed `Tab`.
-It defaults to the value of the `COMP_POINT` or `CURSOR` environment variables, or to the length of
-the `BUFFER` variable, whichever is present.
+It defaults to the value of either the `COMP_POINT` or `CURSOR` environment variables, or to the
+length of the `BUFFER` variable (whichever is present, otherwise undefined):
+
+```ts
+Number(process.env['COMP_POINT'] ?? process.env['CURSOR']) || process.env['BUFFER']?.length;
+```
 
 When invoking the parsing methods with a raw command line, and this flag is set, the parser will
 know to perform word completion for the argument ending at this position.
@@ -96,8 +112,7 @@ arguments with this prefix may be considered a cluster. This must be used in con
 
 ## Parsing features
 
-The parser supports an assortment of features that should fulfill most use cases. They are listed
-below.
+The parser supports a set of features that should fulfill most use cases. They are listed below.
 
 ### Custom callbacks
 
@@ -110,18 +125,18 @@ Custom parsing operations are supported through the following kinds of callbacks
 - [function callback]
 - [command callback]
 
-All of these can be asynchronous, and the parser always awaits the resolution of returned promises,
-either because it needs their result or to avoid data races when reading and modifying the option
-values.
+All of these can be asynchronous, in which case the parser awaits their resolution, either because
+it needs their result or to avoid data races when reading and modifying the option values.
 
 Note that there is no synchronous version of the parsing procedure. This is a design choice: in
 order to support a fully synchronous `parse` method using the same code base, the parser would have
 to deal with returned promises in a way that would make it hard to maintain (remember the classic
 [callback hell]).
 
-Besides, the asynchronous version has the benefit of allowing us to perform some operations
-concurrently, such as the [requirements checking]. This should not be a drawback for most CLI
-applications, since argument parsing is usually done at the top-level of a module or script.
+Besides, the asynchronous version has the benefit of allowing us to perform some operations, such as
+[requirements checking], concurrently. This should not be a drawback for most CLI applications,
+since argument parsing is usually done at the top-level of a module or script, where this construct
+is easily available
 
 ### Argument sequence
 
@@ -131,7 +146,7 @@ option, or if the latter is variadic.
 
 For example, if the option initiating a sequence is a string option with a [fallback value], the
 parser starts looking for new options as soon as it advances to the next argument, since that may be
-either the option parameter or the start of a new sequence. Supposing that it is a parameter, once
+either the option's parameter or the start of a new sequence. Supposing that it is a parameter, once
 the parser advances past this argument, it knows that the next one must be the start of a sequence.
 
 The same algorithm works for function options with a variable [parameter count]. For example, if the
@@ -170,14 +185,14 @@ Quoting the [Bash docs]:
 > Completion Builtins), the programmable completion facilities are invoked.
 
 The parser does not use the completion facilities, because it relies on the raw command line and the
-cursor position in that line, which can be retrieved from the following environment variables:
+cursor position into that line, which can be retrieved from the following environment variables:
 
 - `COMP_LINE` or `BUFFER` - the current command line
 - `COMP_POINT` or `CURSOR` - the index of the cursor position relative to the beginning of the
   command line
 
-When these variables are available, the parser enters into completion mode: it truncates the command
-line at the cursor position and performs completion of the last argument.
+When these variables are available, the parser enters into _completion_ mode: it truncates the
+command line at the cursor position and performs completion of the last argument.
 
 The result of completion is a list of words separated by line breaks, which should be printed on the
 terminal so that the completion builtins can perform the final completion step.
@@ -213,25 +228,38 @@ an empty string):
      count of an option
 
 If all of the above results in an empty list, the default completion (usually file completion, if
-enabled in the completion specification) will be attempted. Note that the conditions of the third
+enabled in the builtin's configuration) will be attempted. Note that the conditions of the third
 step exclude the possibility of it being an [inline parameter], when considering option names.
 
-During completion, both the help and version options are skipped, and the [command callback] does
-not get executed. Other options are processed as usual, which means that a completion callback can
-inspect the values parsed before it, in order to make better suggestions based on those values.
+#### Altered parsing behavior
+
+Since the completion builtins always expect a list of words as a result, the library must suppress
+all errors that occur during parsing, and it does not make sense to perform some operations. Hence,
+when word completion is in effect, the parsing behavior is changed in the following manner:
+
+- parsing errors, such as unknown option names, are suppressed
+- unknown-valued options (help and version) are skipped
+- the [command callback] does not get executed
+- option requirements are not verified
+- cluster arguments are completed with the default completion (an empty list)
+
+<Callout type="default">
+  Other arguments are processed as usual, which means that a completion callback can inspect the
+  values parsed before it, in order to make better suggestions based on those values.
+</Callout>
 
 ### Requirements checking
 
-Generally, option requirements are evaluated after all arguments have been parsed. During this
-analysis, an option's value is compared against any value required by other options. This check may
-also be performed in two more situations:
+When the parser evaluates option requirements, it compares an option's value against any value
+required by other options. Generally, this analysis is performed after all arguments have been
+parsed, but it may also be performed in two more situations:
 
 - before calling a [function callback], if the function option's [`break`] attribute was set
 - before calling a [command callback]
 
-However, requirements are not checked when performing word completion. This is due to the fact that
-the completion builtin always expects a list of words as a result. Hence, the library must suppress
-any errors that occur during parsing and it does not make sense to verify requirements in that case.
+<Callout type="info">
+  As has been mentioned, requirements are _not_ checked when word completion is in effect.
+</Callout>
 
 ### Name suggestions
 
@@ -241,14 +269,14 @@ positional option), it may select option names that are similar to the current a
 
 ### Error messages
 
-Error messages generated by the parsing procedure can be customized via the [validator
-configuration], which can be provided as an additional parameter to the parser constructor.
+Error messages generated by the parser can be customized via the [validator configuration], which
+can be provided as an additional parameter to the parser constructor.
 
 ### Inline parameters
 
-Option parameters may be passed on the command-line using the syntax `<name>=<value>`. This syntax
+Option parameters may be passed on the command-line using the syntax `<name>=<param>`. This syntax
 is only valid for non-niladic options and cannot be used with the positional marker. As is the case
-with normal parameters, the value may contain any number of equal signs, and even start with one
+with standalone parameters, the value may contain any number of equal signs, and even start with one
 (e.g., `-opt==val` would be parsed as `'=val'{:ts}`).
 
 Cluster arguments may also have inline parameters, but their syntax is different. A cluster argument
@@ -262,15 +290,15 @@ The process title will be updated to reflect the current command being executed.
 main script and any nested commands. For example, if the command-line is:
 
 ```sh
-./path/to/myscript.js -flag0 cmd1 -flag1 cmd2 args...
+path/to/main/script.js -flag0 cmd1 -flag1 cmd2 args...
 ```
 
 The process title would be updated in the following way:
 
 1. `node` - this the starting title, before any updates
-2. `node myscript.js` - the title at the beginning of the parsing loop
-3. `node myscript.js cmd1` - the title at the start of the `cmd1` command
-4. `node myscript.js cmd1 cmd2` - the title at the start of the `cmd2` command
+2. `node script.js` - the title at the beginning of the parsing loop
+3. `node script.js cmd1` - the title at the start of the `cmd1` command
+4. `node script.js cmd1 cmd2` - the title at the start of the `cmd2` command
 
 The title will remain unchanged after the parser returns. Other option names are not used, because
 they would pollute the output of process management utilities such as `ps`.

--- a/packages/docs/pages/docs/library/parser.mdx
+++ b/packages/docs/pages/docs/library/parser.mdx
@@ -56,8 +56,8 @@ When using TypeScript, this parameter will be type-checked against the expected 
 values for a given set of option definitions.
 
 <Callout type="default">
-  You may want to peak at the resulting type of the `parse` method using IntelliSense (or declare a
-  temporary type alias for `OptionValues<typeof _your_options_>{:ts}`) to see how the object is
+  Using IntelliSense, you can peak at the resulting type of the `parse` method, or declare a
+  temporary type alias for `OptionValues<typeof _your_options_>{:ts}`, to see how the object is
   structured.
 </Callout>
 
@@ -134,9 +134,9 @@ to deal with returned promises in a way that would make it hard to maintain (rem
 [callback hell]).
 
 Besides, the asynchronous version has the benefit of allowing us to perform some operations, such as
-[requirements checking], concurrently. This should not be a drawback for most CLI applications,
-since argument parsing is usually done at the top-level of a module or script, where this construct
-is easily available
+[requirements checking], concurrently. This should not be a drawback for most applications, since
+argument parsing is usually done at the top-level of a module or script, where the `await` primitive
+is available.
 
 ### Argument sequence
 
@@ -234,8 +234,9 @@ step exclude the possibility of it being an [inline parameter], when considering
 #### Altered parsing behavior
 
 Since the completion builtins always expect a list of words as a result, the library must suppress
-all errors that occur during parsing, and it does not make sense to perform some operations. Hence,
-when word completion is in effect, the parsing behavior is changed in the following manner:
+all errors that occur during parsing, and it does not make sense to perform some operations that
+might throw. Therefore, when word completion is in effect, parsing behavior will change in the
+following important ways:
 
 - parsing errors, such as unknown option names, are suppressed
 - unknown-valued options (help and version) are skipped

--- a/packages/docs/pages/docs/library/styles.mdx
+++ b/packages/docs/pages/docs/library/styles.mdx
@@ -189,7 +189,7 @@ some corner case that is not currently covered by our unit tests, please submit 
 <Callout type="warning">
   Phrases can contain inline styles, but not in the _same_ word as a format specifier. Otherwise,
   they will mess up the text wrapping. For example, the following phrase is not valid:
-  ``` `Requires ${style(tf.bold)}%p`{:ts} ```. You must insert a space between them.
+  ``` `Requires ${style(tf.bold)}%p`{:ts} ```. You must insert a space in-between.
 </Callout>
 
 #### Paragraphs and lists
@@ -268,9 +268,9 @@ preserve the disposition of wrapped text.
 
 ### Default width
 
-In addition to the `wrap` method, this class overrides the `toString` method and provides a
-`message` property, both of which can be used to obtain a string wrapped with a default terminal
-width.
+In addition to providing a `wrap` method, the terminal message overrides the `toString` method and
+has a `message` property, both of which can be used to obtain a string wrapped with a default
+terminal width.
 
 The default width depends on the kind of message: in the case of `TerminalMessage`, it is the width
 of the standard _output_ stream (`process.stdout.columns{:ts}`). Therefore, this kind of message

--- a/packages/docs/pages/docs/library/styles.mdx
+++ b/packages/docs/pages/docs/library/styles.mdx
@@ -269,8 +269,8 @@ preserve the disposition of wrapped text.
 ### Default width
 
 In addition to providing a `wrap` method, the terminal message overrides the `toString` method and
-has a `message` property, both of which can be used to obtain a string wrapped with a default
-terminal width.
+has a convenient `message` property, both of which can be used to obtain a string wrapped with a
+default terminal width.
 
 The default width depends on the kind of message: in the case of `TerminalMessage`, it is the width
 of the standard _output_ stream (`process.stdout.columns{:ts}`). Therefore, this kind of message

--- a/packages/docs/pages/docs/library/validator.mdx
+++ b/packages/docs/pages/docs/library/validator.mdx
@@ -6,27 +6,28 @@ import { Callout } from 'nextra/components';
 
 # Validator
 
-The `OptionValidator` class is an internal component that the parser uses to register and validate
+The `OptionValidator` class is an internal component used by the library to register and validate
 option definitions. You should _not_ need to instantiate this class directly. Instead, use the
 `validate` method on the parser instance.
 
 ## Option validation
 
-The term _validation_ here means verifying the sanity of the options' definitions. It is intended
-for use during _development_, not in production where it would impose a needless performance penalty
-on your application. The validations behave like assertions: they assert that your program will work
-as expected when delivered to end-users.
+We use the term _validation_ to refer to the "sanity check" of option definitions. It is intended
+for use during development, whereas in production it would impose an unnecessary performance penalty
+on your application. Validations behave like assertions: they assert that your program will work as
+expected when delivered to end-users.
 
 To validate a set of option definitions, you must call the `validate` method on the parser instance.
 This method accepts a `ValidationFlags` argument with the following optional properties:
 
-- `detectNamingIssues` - whether the validation procedure should try to detect inconsistencies
-  across option names
+- `detectNamingIssues` -
+  whether the validation procedure should try to detect inconsistencies across option names
 
 It returns a `ValidationResult` object with the following properties:
 
-- `warning` - A compilation of warning messages that represent non-impeditive issues encountered in
-  the option definitions. You may want to print it to see if they are important to your application.
+- `warning` -
+  A compilation of warning messages that represent non-impeditive issues encountered in the option
+  definitions. You may want to print it to see if they are important to your application.
 
 The following sections describe the various kinds of validation performed by the validator. Unless
 otherwise noted, any option definition that does not satisfy one of these restrictions will raise an
@@ -43,7 +44,7 @@ Option names are subject to the restrictions listed below:
 
 - **Option with no name** -
   If the option is not positional (i.e., it does not accept [positional] arguments), then it must
-  contain at least one _non-empty_ name.
+  have at least one _non-empty_ name.
 - **Invalid option name** -
   An option name must not contain whitespace or the equals sign `'='{:ts}`, since this character can
   be used as option-parameter separator on the command-line. Any other Unicode character is allowed.
@@ -51,8 +52,8 @@ Option names are subject to the restrictions listed below:
   An option should not have duplicate names, and there cannot be two options with the same name.
 
 <Callout type="info">
-  In any of these restrictions, empty strings and `null{:ts}`s are ignored, while flags' [negation
-  names] and the [positional marker] are included.
+  In any of these restrictions, empty strings and `null{:ts}`s are ignored, while [negation names]
+  and the [positional marker] are included.
 </Callout>
 
 #### Naming inconsistencies
@@ -249,13 +250,13 @@ They are listed in the next sub-sections.
 - `emptyEnumsDefinition` -
   either an [enumeration] constraint or the [truth and falsity] names have zero length
 - `duplicateOptionName` -
-  when an option has a duplicate name
+  when there are two identical option names
 - `duplicatePositionalOption` -
   when there are two or more [positional] options
 - `duplicateEnumValue` -
   when either an [enumeration] constraint or the [truth and falsity] names have duplicate values
 - `duplicateClusterLetter` -
-  when an option has a duplicate [cluster letter]
+  when there are two identical [cluster letters]
 - `invalidClusterLetter` -
   when an option has an invalid [cluster letter]
 - `invalidNumericRange` -
@@ -308,10 +309,10 @@ It has the following optional properties, whose keys are enumerators from `Error
 - `invalidRequiredOption` - `'Invalid option %o in requirement.'{:ts}`
 - `invalidRequiredValue`- `'Invalid required value for option %o. Option is always required or has a default value.'{:ts}`
 - `incompatibleRequiredValue` - `'Incompatible required value %v for option %o. Should be of type %s.'{:ts}`
-- `emptyEnumsDefinition` - `'Option %o has zero enum values.'{:ts}`
+- `emptyEnumsDefinition` - `'Option %o has zero-length enumeration.'{:ts}`
 - `duplicateOptionName` - `'Option %o has duplicate name %s.'{:ts}`
 - `duplicatePositionalOption` - `'Duplicate positional option %o1: previous was %o2.'{:ts}`
-- `duplicateEnumValue` - `'Option %o has duplicate enum (%s|%n).'{:ts}`
+- `duplicateEnumValue` - `'Option %o has duplicate enumerator (%s|%n).'{:ts}`
 - `enumsConstraintViolation` - `'Invalid parameter to %o: (%s1|%n1). Possible values are {(%s2|%n2)}.'{:ts}`
 - `regexConstraintViolation` - `'Invalid parameter to %o: %s. Value must match the regex %r.'{:ts}`
 - `rangeConstraintViolation` - `'Invalid parameter to %o: %n1. Value must be in the range [%n2].'{:ts}`
@@ -321,8 +322,8 @@ It has the following optional properties, whose keys are enumerators from `Error
 - `duplicateClusterLetter` - `'Option %o has duplicate cluster letter %s.'{:ts}`
 - `invalidClusterOption` - `'Option letter %o must be the last in a cluster.'{:ts}`
 - `invalidClusterLetter` - `'Option %o has invalid cluster letter %s.'{:ts}`
-- `tooSimilarOptionNames` - `'%o: Option name %s1 has too similar names [%s2].'{:ts}`
-- `mixedNamingConvention` - `'%o: Name slot %n has mixed naming conventions [%s].'{:ts}`
+- `tooSimilarOptionNames` - `'%o: Option name %s1 has too similar names: %s2.'{:ts}`
+- `mixedNamingConvention` - `'%o: Name slot %n has mixed naming conventions: %s.'{:ts}`
 - `invalidNumericRange` - `'Option %o has invalid numeric range [%n].'{:ts}`
 - `invalidParamCount` - `'Option %o has invalid parameter count [%n].'{:ts}`
 - `variadicWithClusterLetter` - `'Variadic option %o may only appear as the last option in a cluster.'{:ts}`
@@ -337,7 +338,7 @@ message, along with a description of the corresponding value:
 
 | Error                      | Specifiers                                                                                                                                 |
 | -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
-| unknownOption              | `%o`/`%o1` = the unknown option name; `%o2` = similar option names                                                                         |
+| unknownOption              | `%o`/`%o1` = the unknown option name; `%o2` = the similar names                                                                            |
 | unsatisfiedRequirement     | `%o` = the specified option name; `%p` = the option's requirements                                                                         |
 | missingRequiredOption      | `%o` = the option's preferred name                                                                                                         |
 | missingParameter           | `%o` = the specified option name                                                                                                           |
@@ -355,7 +356,7 @@ message, along with a description of the corresponding value:
 | emptyEnumsDefinition       | `%o` = the option's key                                                                                                                    |
 | duplicateOptionName        | `%o` = the option's key; `%s` = the duplicate name                                                                                         |
 | duplicatePositionalOption  | `%o1` = the duplicate option's key; `%o2` = the previous option's key                                                                      |
-| duplicateEnumValue         | `%o` = the option's key; `%s`/`%n` = the duplicate enum value                                                                              |
+| duplicateEnumValue         | `%o` = the option's key; `%s`/`%n` = the duplicate value                                                                                   |
 | enumsConstraintViolation   | `%o` = the option's key or specified name; `%s1`/`%n1` = the specified value; `%s2`/`%n2` = the enum values or the truth and falsity names |
 | regexConstraintViolation   | `%o` = the option's key or specified name; `%s` = the specified value; `%r` = the regular expression                                       |
 | rangeConstraintViolation   | `%o` = the option's key or specified name; `%n1` = the specified value; `%n2` = the numeric range                                          |
@@ -374,8 +375,8 @@ message, along with a description of the corresponding value:
 ### Connective words
 
 The `connectives` property specifies the connective words that are used to format options'
-requirements, in both error and help messages. It has the following optional properties, which are
-enumerators from `ConnectiveWords`:
+requirements, in both error and help messages. It has the following optional properties, whose keys
+are enumerators from `ConnectiveWords`:
 
 - `and` - the word used to connect two logical expressions in conjunction
 - `or` - the word used to connect two logical expressions in disjunction

--- a/packages/tsargp/lib/enums.ts
+++ b/packages/tsargp/lib/enums.ts
@@ -79,7 +79,7 @@ export const enum ErrorItem {
    */
   emptyEnumsDefinition,
   /**
-   * Raised by the validator when an option has a duplicate name.
+   * Raised by the validator when there are two identical option names.
    */
   duplicateOptionName,
   /**
@@ -117,7 +117,7 @@ export const enum ErrorItem {
    */
   unsatisfiedCondRequirement,
   /**
-   * Raised by the validator when an option has a duplicate cluster letter.
+   * Raised by the validator when there are two identical cluster letters.
    */
   duplicateClusterLetter,
   /**

--- a/packages/tsargp/lib/validator.ts
+++ b/packages/tsargp/lib/validator.ts
@@ -71,8 +71,8 @@ export const defaultConfig: ConcreteConfig = {
     [ErrorItem.duplicateClusterLetter]: 'Option %o has duplicate cluster letter %s.',
     [ErrorItem.invalidClusterOption]: 'Option letter %o must be the last in a cluster.',
     [ErrorItem.invalidClusterLetter]: 'Option %o has invalid cluster letter %s.',
-    [ErrorItem.tooSimilarOptionNames]: '%o: Option name %s1 has too similar names [%s2].',
-    [ErrorItem.mixedNamingConvention]: '%o: Name slot %n has mixed naming conventions [%s].',
+    [ErrorItem.tooSimilarOptionNames]: '%o: Option name %s1 has too similar names: %s2.',
+    [ErrorItem.mixedNamingConvention]: '%o: Name slot %n has mixed naming conventions: %s.',
     [ErrorItem.invalidNumericRange]: 'Option %o has invalid numeric range [%n].',
     [ErrorItem.invalidParamCount]: 'Option %o has invalid parameter count [%n].',
     [ErrorItem.variadicWithClusterLetter]:

--- a/packages/tsargp/test/validator/validator.names.spec.ts
+++ b/packages/tsargp/test/validator/validator.names.spec.ts
@@ -153,7 +153,7 @@ describe('OptionValidator', () => {
       const { warning } = validator.validate(flags);
       expect(warning).toHaveLength(1);
       expect(warning?.message).toEqual(
-        `: Option name 'flag1' has too similar names ['flag2', 'flag3'].\n`,
+        `: Option name 'flag1' has too similar names: 'flag2', 'flag3'.\n`,
       );
     });
 
@@ -177,9 +177,9 @@ describe('OptionValidator', () => {
       const { warning } = validator.validate(flags);
       expect(warning).toHaveLength(3);
       expect(warning?.message).toEqual(
-        `: Name slot 0 has mixed naming conventions ['lowercase: lower', 'UPPERCASE: UPPER', 'Capitalized: Capital'].\n` +
-          `: Name slot 1 has mixed naming conventions ['noDash: abc', '-singleDash: -def', '--doubleDash: --ghi'].\n` +
-          `: Name slot 2 has mixed naming conventions ['kebab-case: keb-ab', 'snake_case: sna_ke', 'colon:case: col:on'].\n`,
+        `: Name slot 0 has mixed naming conventions: 'lowercase: lower', 'UPPERCASE: UPPER', 'Capitalized: Capital'.\n` +
+          `: Name slot 1 has mixed naming conventions: 'noDash: abc', '-singleDash: -def', '--doubleDash: --ghi'.\n` +
+          `: Name slot 2 has mixed naming conventions: 'kebab-case: keb-ab', 'snake_case: sna_ke', 'colon:case: col:on'.\n`,
       );
     });
 
@@ -210,7 +210,7 @@ describe('OptionValidator', () => {
       const { warning } = validator.validate(flags);
       expect(warning).toHaveLength(1);
       expect(warning?.message).toEqual(
-        `command: Option name 'flag1' has too similar names ['flag2', 'flag3'].\n`,
+        `command: Option name 'flag1' has too similar names: 'flag2', 'flag3'.\n`,
       );
     });
   });


### PR DESCRIPTION
Fixed the `clear` command in the Demo page, which was a regression from the last release.

Closes #129 
