### PR TITLE
Issues/132

### DIFF
--- a/.changeset/tiny-beds-burn.md
+++ b/.changeset/tiny-beds-burn.md
@@ -2,4 +2,4 @@
 '@trulysimple/tsargp-docs': patch
 ---
 
-The Options page was updated to document the support for asynchronous options callback in the command option. The validator page was updated to document the new asynchronous behavior of the `validate` procedure.
+The Options page was updated to document the support for asynchronous options callback in the command option. The Validator page was updated to document the new asynchronous behavior of the `validate` procedure.

--- a/.changeset/tiny-beds-burn.md
+++ b/.changeset/tiny-beds-burn.md
@@ -1,0 +1,5 @@
+---
+'@trulysimple/tsargp-docs': patch
+---
+
+The Options page was updated to document the support for asynchronous options callback in the command option. The validator page was updated to document the new asynchronous behavior of the `validate` procedure.

--- a/.changeset/wet-hotels-sort.md
+++ b/.changeset/wet-hotels-sort.md
@@ -1,0 +1,5 @@
+---
+'tsargp': minor
+---
+
+Added support for asynchronous options callback in the command option. This allows the option to load definitions from a different module dynamically.

--- a/.changeset/wet-hotels-sort.md
+++ b/.changeset/wet-hotels-sort.md
@@ -2,4 +2,4 @@
 'tsargp': minor
 ---
 
-Added support for asynchronous options callback in the command option. This allows the option to load definitions from a different module dynamically.
+Added support for asynchronous `OptionsCallback` in the command option. This allows the option to load definitions from a different module dynamically.

--- a/packages/docs/components/play.tsx
+++ b/packages/docs/components/play.tsx
@@ -37,11 +37,11 @@ class PlayCommand extends Command<PlayProps> {
     super(props, 'init', 'play');
   }
 
-  private init() {
+  private async init() {
     const source = this.props.callbacks.getSource();
     const options = Function('tsargp', `'use strict';${source}`)(tsargp);
     const parser = new ArgumentParser(options);
-    const { warning } = parser.validate();
+    const { warning } = await parser.validate();
     if (warning) {
       this.println(warning.wrap(this.state.width));
     }
@@ -52,7 +52,7 @@ class PlayCommand extends Command<PlayProps> {
     try {
       if (line.startsWith('init')) {
         if (!compIndex) {
-          this.init();
+          await this.init();
         }
       } else if (this.parser) {
         const values = {};

--- a/packages/docs/pages/docs/index.mdx
+++ b/packages/docs/pages/docs/index.mdx
@@ -61,9 +61,9 @@ import options from './<your_cli_name>.options.js';
 
 try {
   const parser = new ArgumentParser(options);
-  parser.validate(); // validate the option definitions (you can skip this in production)
+  await parser.validate(); // validate the option definitions (you can skip this in production)
   const values = await parser.parse(); // use this to get the options' values
-  // await parser.parseInto(myValues); // use this for an existing object or class instance
+  // await parser.parseInto(myValues); // use this to fill an existing object or class instance
 } catch (err) {
   if (err instanceof Error) {
     console.error(`${err}`); // genuine errors

--- a/packages/docs/pages/docs/library/options.mdx
+++ b/packages/docs/pages/docs/library/options.mdx
@@ -691,9 +691,10 @@ Notes about this callback:
 
 #### Command options | callback
 
-The `options` attribute specifies the set of option definitions for the command, or a
-(non-asynchronous) callback that returns these definitions (which allows the implementation of
-[recursive commands]).
+The `options` attribute specifies the set of option definitions for the command. A callback may be
+used to provide these definitions, which allows the implementation of [recursive commands]. An
+asynchronous callback may be used to load option definitions from a different module, in which case
+you can return the result of the `import{:ts}` directive.
 
 <Callout type="warning">
   All incoming arguments will be parsed using the option definitions from this attribute, not those

--- a/packages/docs/pages/docs/library/options.mdx
+++ b/packages/docs/pages/docs/library/options.mdx
@@ -693,8 +693,8 @@ Notes about this callback:
 
 The `options` attribute specifies the set of option definitions for the command. A callback may be
 used to provide these definitions, which allows the implementation of [recursive commands]. An
-asynchronous callback may be used to load option definitions from a different module, in which case
-you can return the result of the `import{:ts}` directive.
+asynchronous callback may be used to dynamically load option definitions from a module, in which
+case you can return the result of the `import{:ts}` directive.
 
 <Callout type="warning">
   All incoming arguments will be parsed using the option definitions from this attribute, not those

--- a/packages/docs/pages/docs/library/parser.mdx
+++ b/packages/docs/pages/docs/library/parser.mdx
@@ -135,8 +135,8 @@ to deal with returned promises in a way that would make it hard to maintain (rem
 
 Besides, the asynchronous version has the benefit of allowing us to perform some operations, such as
 [requirements checking], concurrently. This should not be a drawback for most applications, since
-argument parsing is usually done at the top-level of a module or script, where the `await` primitive
-is available.
+argument parsing is usually done at the top-level of a module or script, where the `await{:ts}`
+directive is available.
 
 ### Argument sequence
 

--- a/packages/docs/pages/docs/library/validator.mdx
+++ b/packages/docs/pages/docs/library/validator.mdx
@@ -23,11 +23,18 @@ This method accepts a `ValidationFlags` argument with the following optional pro
 - `detectNamingIssues` -
   whether the validation procedure should try to detect inconsistencies across option names
 
-It returns a `ValidationResult` object with the following properties:
+It returns a promise that resolves to a `ValidationResult` object with the following properties:
 
 - `warning` -
   A compilation of warning messages that represent non-impeditive issues encountered in the option
   definitions. You may want to print it to see if they are important to your application.
+
+<Callout type="info">
+  This method is _asynchronous_, so you must use `await{:ts}` in order to resolve the returned
+  promise.
+</Callout>
+
+## Validation rules
 
 The following sections describe the various kinds of validation performed by the validator. Unless
 otherwise noted, any option definition that does not satisfy one of these restrictions will raise an

--- a/packages/tsargp/README.md
+++ b/packages/tsargp/README.md
@@ -42,9 +42,9 @@ import options from './<your_cli_name>.options.js';
 
 try {
   const parser = new ArgumentParser(options);
-  parser.validate(); // validate the option definitions (you can skip this in production)
+  await parser.validate(); // validate the option definitions (you can skip this in production)
   const values = await parser.parse(); // use this to get the options' values
-  // await parser.parseInto(myValues); // use this for an existing object or class instance
+  // await parser.parseInto(myValues); // use this to fill an existing object or class instance
 } catch (err) {
   if (err instanceof Error) {
     console.error(`${err}`); // genuine errors

--- a/packages/tsargp/lib/options.ts
+++ b/packages/tsargp/lib/options.ts
@@ -232,6 +232,11 @@ export type FunctionCallback = CustomCallback<
 export type CommandCallback = CustomCallback<ParseInfo<OpaqueOptionValues>, unknown>;
 
 /**
+ * A callback for a command's option definitions.
+ */
+export type OptionsCallback = () => Options | Promise<Options>;
+
+/**
  * Information about the current argument sequence in the parsing loop.
  * @template P The parameter data type
  */
@@ -586,7 +591,7 @@ export type WithCommand = {
    * The command's options.
    * It can be a callback that returns the options (for use with recursive commands).
    */
-  readonly options?: Options | (() => Options);
+  readonly options?: Options | OptionsCallback;
   /**
    * The prefix of cluster arguments.
    * If set, then eligible arguments that have this prefix will be considered a cluster.

--- a/packages/tsargp/test/parser/parser.spec.ts
+++ b/packages/tsargp/test/parser/parser.spec.ts
@@ -132,7 +132,7 @@ describe('ArgumentParser', () => {
         );
       });
 
-      it('should throw the help message of a nested command with filter', async () => {
+      it('should throw the help message of a nested command with filter and async options callback', async () => {
         const options = {
           help: {
             type: 'help',
@@ -154,7 +154,7 @@ describe('ArgumentParser', () => {
           command2: {
             type: 'command',
             names: ['cmd2'],
-            options: {
+            options: async () => ({
               flag: {
                 type: 'flag',
                 names: ['-f'],
@@ -165,7 +165,7 @@ describe('ArgumentParser', () => {
                 sections: [{ type: 'groups' }],
                 useFilter: true,
               },
-            },
+            }),
           },
         } as const satisfies Options;
         const parser = new ArgumentParser(options);
@@ -544,6 +544,24 @@ describe('ArgumentParser', () => {
           name: '-c',
           param: { flag: true },
         });
+      });
+
+      it('should handle a command option with an async options callback', async () => {
+        const options = {
+          command: {
+            type: 'command',
+            names: ['-c'],
+            options: async () => ({
+              flag: {
+                type: 'flag',
+                names: ['-f'],
+              },
+            }),
+            exec: () => 'abc',
+          },
+        } as const satisfies Options;
+        const parser = new ArgumentParser(options);
+        await expect(parser.parse(['-c', '-f'])).resolves.toEqual({ command: 'abc' });
       });
 
       it('should handle a command option with options with async callbacks', async () => {

--- a/packages/tsargp/test/validator/validator.cluster.spec.ts
+++ b/packages/tsargp/test/validator/validator.cluster.spec.ts
@@ -4,7 +4,7 @@ import '../utils.spec';
 
 describe('OptionValidator', () => {
   describe('validate', () => {
-    it('should throw an error on option with invalid cluster letter', () => {
+    it('should throw an error on option with invalid cluster letter', async () => {
       const options = {
         flag: {
           type: 'flag',
@@ -13,10 +13,12 @@ describe('OptionValidator', () => {
         },
       } as const satisfies Options;
       const validator = new OptionValidator(options);
-      expect(() => validator.validate()).toThrow(`Option flag has invalid cluster letter ' '.`);
+      await expect(validator.validate()).rejects.toThrow(
+        `Option flag has invalid cluster letter ' '.`,
+      );
     });
 
-    it('should throw an error on duplicate cluster letter in the same option', () => {
+    it('should throw an error on duplicate cluster letter in the same option', async () => {
       const options = {
         flag: {
           type: 'flag',
@@ -25,10 +27,12 @@ describe('OptionValidator', () => {
         },
       } as const satisfies Options;
       const validator = new OptionValidator(options);
-      expect(() => validator.validate()).toThrow(`Option flag has duplicate cluster letter 'a'.`);
+      await expect(validator.validate()).rejects.toThrow(
+        `Option flag has duplicate cluster letter 'a'.`,
+      );
     });
 
-    it('should throw an error on duplicate cluster letter across different options', () => {
+    it('should throw an error on duplicate cluster letter across different options', async () => {
       const options = {
         flag1: {
           type: 'flag',
@@ -42,10 +46,12 @@ describe('OptionValidator', () => {
         },
       } as const satisfies Options;
       const validator = new OptionValidator(options);
-      expect(() => validator.validate()).toThrow(`Option flag2 has duplicate cluster letter 'f'.`);
+      await expect(validator.validate()).rejects.toThrow(
+        `Option flag2 has duplicate cluster letter 'f'.`,
+      );
     });
 
-    it('should return a warning on string option with fallback value and cluster letters', () => {
+    it('should return a warning on string option with fallback value and cluster letters', async () => {
       const options = {
         string: {
           type: 'string',
@@ -55,14 +61,14 @@ describe('OptionValidator', () => {
         },
       } as const satisfies Options;
       const validator = new OptionValidator(options);
-      const { warning } = validator.validate();
+      const { warning } = await validator.validate();
       expect(warning).toHaveLength(1);
       expect(warning?.message).toEqual(
         `Variadic option string may only appear as the last option in a cluster.\n`,
       );
     });
 
-    it('should return a warning on variadic strings option with cluster letters', () => {
+    it('should return a warning on variadic strings option with cluster letters', async () => {
       const options = {
         strings: {
           type: 'strings',
@@ -71,14 +77,14 @@ describe('OptionValidator', () => {
         },
       } as const satisfies Options;
       const validator = new OptionValidator(options);
-      const { warning } = validator.validate();
+      const { warning } = await validator.validate();
       expect(warning).toHaveLength(1);
       expect(warning?.message).toEqual(
         `Variadic option strings may only appear as the last option in a cluster.\n`,
       );
     });
 
-    it('should return a warning on variadic function option with cluster letters (1)', () => {
+    it('should return a warning on variadic function option with cluster letters (1)', async () => {
       const options = {
         function: {
           type: 'function',
@@ -88,14 +94,14 @@ describe('OptionValidator', () => {
         },
       } as const satisfies Options;
       const validator = new OptionValidator(options);
-      const { warning } = validator.validate();
+      const { warning } = await validator.validate();
       expect(warning).toHaveLength(1);
       expect(warning?.message).toEqual(
         `Variadic option function may only appear as the last option in a cluster.\n`,
       );
     });
 
-    it('should return a warning on variadic function option with cluster letters (2)', () => {
+    it('should return a warning on variadic function option with cluster letters (2)', async () => {
       const options = {
         function: {
           type: 'function',
@@ -105,7 +111,7 @@ describe('OptionValidator', () => {
         },
       } as const satisfies Options;
       const validator = new OptionValidator(options);
-      const { warning } = validator.validate();
+      const { warning } = await validator.validate();
       expect(warning).toHaveLength(1);
       expect(warning?.message).toEqual(
         `Variadic option function may only appear as the last option in a cluster.\n`,

--- a/packages/tsargp/test/validator/validator.constraints.spec.ts
+++ b/packages/tsargp/test/validator/validator.constraints.spec.ts
@@ -4,7 +4,7 @@ import '../utils.spec';
 
 describe('OptionValidator', () => {
   describe('validate', () => {
-    it('should throw an error on boolean option with zero truth names', () => {
+    it('should throw an error on boolean option with zero truth names', async () => {
       const options = {
         boolean: {
           type: 'boolean',
@@ -13,10 +13,12 @@ describe('OptionValidator', () => {
         },
       } as const satisfies Options;
       const validator = new OptionValidator(options);
-      expect(() => validator.validate()).toThrow(`Option boolean has zero-length enumeration.`);
+      await expect(validator.validate()).rejects.toThrow(
+        `Option boolean has zero-length enumeration.`,
+      );
     });
 
-    it('should throw an error on boolean option with zero falsity names', () => {
+    it('should throw an error on boolean option with zero falsity names', async () => {
       const options = {
         boolean: {
           type: 'boolean',
@@ -25,10 +27,12 @@ describe('OptionValidator', () => {
         },
       } as const satisfies Options;
       const validator = new OptionValidator(options);
-      expect(() => validator.validate()).toThrow(`Option boolean has zero-length enumeration.`);
+      await expect(validator.validate()).rejects.toThrow(
+        `Option boolean has zero-length enumeration.`,
+      );
     });
 
-    it('should throw an error on boolean option with zero truth and falsity names', () => {
+    it('should throw an error on boolean option with zero truth and falsity names', async () => {
       const options = {
         boolean: {
           type: 'boolean',
@@ -38,10 +42,12 @@ describe('OptionValidator', () => {
         },
       } as const satisfies Options;
       const validator = new OptionValidator(options);
-      expect(() => validator.validate()).toThrow(`Option boolean has zero-length enumeration.`);
+      await expect(validator.validate()).rejects.toThrow(
+        `Option boolean has zero-length enumeration.`,
+      );
     });
 
-    it('should throw an error on string option with zero enumerated values', () => {
+    it('should throw an error on string option with zero enumerated values', async () => {
       const options = {
         string: {
           type: 'string',
@@ -50,10 +56,12 @@ describe('OptionValidator', () => {
         },
       } as const satisfies Options;
       const validator = new OptionValidator(options);
-      expect(() => validator.validate()).toThrow(`Option string has zero-length enumeration.`);
+      await expect(validator.validate()).rejects.toThrow(
+        `Option string has zero-length enumeration.`,
+      );
     });
 
-    it('should throw an error on number option with zero enumerated values', () => {
+    it('should throw an error on number option with zero enumerated values', async () => {
       const options = {
         number: {
           type: 'number',
@@ -62,10 +70,12 @@ describe('OptionValidator', () => {
         },
       } as const satisfies Options;
       const validator = new OptionValidator(options);
-      expect(() => validator.validate()).toThrow(`Option number has zero-length enumeration.`);
+      await expect(validator.validate()).rejects.toThrow(
+        `Option number has zero-length enumeration.`,
+      );
     });
 
-    it('should throw an error on strings option with zero enumerated values', () => {
+    it('should throw an error on strings option with zero enumerated values', async () => {
       const options = {
         strings: {
           type: 'strings',
@@ -74,10 +84,12 @@ describe('OptionValidator', () => {
         },
       } as const satisfies Options;
       const validator = new OptionValidator(options);
-      expect(() => validator.validate()).toThrow(`Option strings has zero-length enumeration.`);
+      await expect(validator.validate()).rejects.toThrow(
+        `Option strings has zero-length enumeration.`,
+      );
     });
 
-    it('should throw an error on numbers option with zero enumerated values', () => {
+    it('should throw an error on numbers option with zero enumerated values', async () => {
       const options = {
         numbers: {
           type: 'numbers',
@@ -86,10 +98,12 @@ describe('OptionValidator', () => {
         },
       } as const satisfies Options;
       const validator = new OptionValidator(options);
-      expect(() => validator.validate()).toThrow(`Option numbers has zero-length enumeration.`);
+      await expect(validator.validate()).rejects.toThrow(
+        `Option numbers has zero-length enumeration.`,
+      );
     });
 
-    it('should throw an error on string option with duplicate enumerated values', () => {
+    it('should throw an error on string option with duplicate enumerated values', async () => {
       const options = {
         string: {
           type: 'string',
@@ -98,10 +112,12 @@ describe('OptionValidator', () => {
         },
       } as const satisfies Options;
       const validator = new OptionValidator(options);
-      expect(() => validator.validate()).toThrow(`Option string has duplicate enumerator 'dup'.`);
+      await expect(validator.validate()).rejects.toThrow(
+        `Option string has duplicate enumerator 'dup'.`,
+      );
     });
 
-    it('should throw an error on number option with duplicate enumerated values', () => {
+    it('should throw an error on number option with duplicate enumerated values', async () => {
       const options = {
         number: {
           type: 'number',
@@ -110,10 +126,12 @@ describe('OptionValidator', () => {
         },
       } as const satisfies Options;
       const validator = new OptionValidator(options);
-      expect(() => validator.validate()).toThrow(`Option number has duplicate enumerator 1.`);
+      await expect(validator.validate()).rejects.toThrow(
+        `Option number has duplicate enumerator 1.`,
+      );
     });
 
-    it('should throw an error on strings option with duplicate enumerated values', () => {
+    it('should throw an error on strings option with duplicate enumerated values', async () => {
       const options = {
         strings: {
           type: 'strings',
@@ -122,10 +140,12 @@ describe('OptionValidator', () => {
         },
       } as const satisfies Options;
       const validator = new OptionValidator(options);
-      expect(() => validator.validate()).toThrow(`Option strings has duplicate enumerator 'dup'.`);
+      await expect(validator.validate()).rejects.toThrow(
+        `Option strings has duplicate enumerator 'dup'.`,
+      );
     });
 
-    it('should throw an error on numbers option with duplicate enumerated values', () => {
+    it('should throw an error on numbers option with duplicate enumerated values', async () => {
       const options = {
         numbers: {
           type: 'numbers',
@@ -134,10 +154,12 @@ describe('OptionValidator', () => {
         },
       } as const satisfies Options;
       const validator = new OptionValidator(options);
-      expect(() => validator.validate()).toThrow(`Option numbers has duplicate enumerator 1.`);
+      await expect(validator.validate()).rejects.toThrow(
+        `Option numbers has duplicate enumerator 1.`,
+      );
     });
 
-    it('should throw an error on boolean option with duplicate truth names', () => {
+    it('should throw an error on boolean option with duplicate truth names', async () => {
       const options = {
         boolean: {
           type: 'boolean',
@@ -146,10 +168,12 @@ describe('OptionValidator', () => {
         },
       } as const satisfies Options;
       const validator = new OptionValidator(options);
-      expect(() => validator.validate()).toThrow(`Option boolean has duplicate enumerator 'dup'.`);
+      await expect(validator.validate()).rejects.toThrow(
+        `Option boolean has duplicate enumerator 'dup'.`,
+      );
     });
 
-    it('should throw an error on boolean option with duplicate falsity names', () => {
+    it('should throw an error on boolean option with duplicate falsity names', async () => {
       const options = {
         boolean: {
           type: 'boolean',
@@ -158,10 +182,12 @@ describe('OptionValidator', () => {
         },
       } as const satisfies Options;
       const validator = new OptionValidator(options);
-      expect(() => validator.validate()).toThrow(`Option boolean has duplicate enumerator 'dup'.`);
+      await expect(validator.validate()).rejects.toThrow(
+        `Option boolean has duplicate enumerator 'dup'.`,
+      );
     });
 
-    it('should throw an error on boolean option with duplicate truth and falsity names', () => {
+    it('should throw an error on boolean option with duplicate truth and falsity names', async () => {
       const options = {
         boolean: {
           type: 'boolean',
@@ -171,10 +197,12 @@ describe('OptionValidator', () => {
         },
       } as const satisfies Options;
       const validator = new OptionValidator(options);
-      expect(() => validator.validate()).toThrow(`Option boolean has duplicate enumerator 'dup'.`);
+      await expect(validator.validate()).rejects.toThrow(
+        `Option boolean has duplicate enumerator 'dup'.`,
+      );
     });
 
-    it('should throw an error on number option with invalid range', () => {
+    it('should throw an error on number option with invalid range', async () => {
       const options = {
         number: {
           type: 'number',
@@ -183,10 +211,12 @@ describe('OptionValidator', () => {
         },
       } as const satisfies Options;
       const validator = new OptionValidator(options);
-      expect(() => validator.validate()).toThrow(`Option number has invalid numeric range [0, 0].`);
+      await expect(validator.validate()).rejects.toThrow(
+        `Option number has invalid numeric range [0, 0].`,
+      );
     });
 
-    it('should throw an error on number option with invalid range with NaN', () => {
+    it('should throw an error on number option with invalid range with NaN', async () => {
       const options = {
         number: {
           type: 'number',
@@ -195,12 +225,12 @@ describe('OptionValidator', () => {
         },
       } as const satisfies Options;
       const validator = new OptionValidator(options);
-      expect(() => validator.validate()).toThrow(
+      await expect(validator.validate()).rejects.toThrow(
         `Option number has invalid numeric range [0, NaN].`,
       );
     });
 
-    it('should throw an error on function option with invalid parameter count', () => {
+    it('should throw an error on function option with invalid parameter count', async () => {
       const options = {
         function: {
           type: 'function',
@@ -210,7 +240,7 @@ describe('OptionValidator', () => {
         },
       } as const satisfies Options;
       const validator = new OptionValidator(options);
-      expect(() => validator.validate()).toThrow(
+      await expect(validator.validate()).rejects.toThrow(
         `Option function has invalid parameter count [-1, 1].`,
       );
     });

--- a/packages/tsargp/test/validator/validator.names.spec.ts
+++ b/packages/tsargp/test/validator/validator.names.spec.ts
@@ -5,7 +5,7 @@ import '../utils.spec';
 
 describe('OptionValidator', () => {
   describe('validate', () => {
-    it('should ignore empty option names', () => {
+    it('should ignore empty option names', async () => {
       const options = {
         string: {
           type: 'string',
@@ -13,10 +13,10 @@ describe('OptionValidator', () => {
         },
       } as const satisfies Options;
       const validator = new OptionValidator(options);
-      expect(() => validator.validate()).not.toThrow();
+      await expect(validator.validate()).resolves.toMatchObject({});
     });
 
-    it('should accept a positional option with no name', () => {
+    it('should accept a positional option with no name', async () => {
       const options = {
         string: {
           type: 'string',
@@ -24,10 +24,10 @@ describe('OptionValidator', () => {
         },
       } as const satisfies Options;
       const validator = new OptionValidator(options);
-      expect(() => validator.validate()).not.toThrow();
+      await expect(validator.validate()).resolves.toMatchObject({});
     });
 
-    it('should accept a flag option with only a negation name', () => {
+    it('should accept a flag option with only a negation name', async () => {
       const options = {
         flag: {
           type: 'flag',
@@ -35,10 +35,10 @@ describe('OptionValidator', () => {
         },
       } as const satisfies Options;
       const validator = new OptionValidator(options);
-      expect(() => validator.validate()).not.toThrow();
+      await expect(validator.validate()).resolves.toMatchObject({});
     });
 
-    it('should throw an error on non-positional option with no name', () => {
+    it('should throw an error on non-positional option with no name', async () => {
       const options = {
         flag: {
           type: 'flag',
@@ -46,10 +46,10 @@ describe('OptionValidator', () => {
         },
       } as const satisfies Options;
       const validator = new OptionValidator(options);
-      expect(() => validator.validate()).toThrow(`Non-positional option flag has no name.`);
+      await expect(validator.validate()).rejects.toThrow(`Non-positional option flag has no name.`);
     });
 
-    it('should throw an error on option with invalid name', () => {
+    it('should throw an error on option with invalid name', async () => {
       const options = {
         flag: {
           type: 'flag',
@@ -57,10 +57,10 @@ describe('OptionValidator', () => {
         },
       } as const satisfies Options;
       const validator = new OptionValidator(options);
-      expect(() => validator.validate()).toThrow(`Option flag has invalid name 'a = b'.`);
+      await expect(validator.validate()).rejects.toThrow(`Option flag has invalid name 'a = b'.`);
     });
 
-    it('should throw an error on flag option with invalid negation name', () => {
+    it('should throw an error on flag option with invalid negation name', async () => {
       const options = {
         flag: {
           type: 'flag',
@@ -69,10 +69,10 @@ describe('OptionValidator', () => {
         },
       } as const satisfies Options;
       const validator = new OptionValidator(options);
-      expect(() => validator.validate()).toThrow(`Option flag has invalid name 'a = b'.`);
+      await expect(validator.validate()).rejects.toThrow(`Option flag has invalid name 'a = b'.`);
     });
 
-    it('should throw an error on option with invalid positional marker', () => {
+    it('should throw an error on option with invalid positional marker', async () => {
       const options = {
         boolean: {
           type: 'boolean',
@@ -80,10 +80,12 @@ describe('OptionValidator', () => {
         },
       } as const satisfies Options;
       const validator = new OptionValidator(options);
-      expect(() => validator.validate()).toThrow(`Option boolean has invalid name 'a = b'.`);
+      await expect(validator.validate()).rejects.toThrow(
+        `Option boolean has invalid name 'a = b'.`,
+      );
     });
 
-    it('should throw an error on duplicate option name in the same option', () => {
+    it('should throw an error on duplicate option name in the same option', async () => {
       const options = {
         flag: {
           type: 'flag',
@@ -91,10 +93,10 @@ describe('OptionValidator', () => {
         },
       } as const satisfies Options;
       const validator = new OptionValidator(options);
-      expect(() => validator.validate()).toThrow(`Option flag has duplicate name 'dup'.`);
+      await expect(validator.validate()).rejects.toThrow(`Option flag has duplicate name 'dup'.`);
     });
 
-    it('should throw an error on duplicate option name across options', () => {
+    it('should throw an error on duplicate option name across options', async () => {
       const options = {
         flag1: {
           type: 'flag',
@@ -106,10 +108,10 @@ describe('OptionValidator', () => {
         },
       } as const satisfies Options;
       const validator = new OptionValidator(options);
-      expect(() => validator.validate()).toThrow(`Option flag2 has duplicate name 'dup'.`);
+      await expect(validator.validate()).rejects.toThrow(`Option flag2 has duplicate name 'dup'.`);
     });
 
-    it('should throw an error on flag option with duplicate negation name', () => {
+    it('should throw an error on flag option with duplicate negation name', async () => {
       const options = {
         flag: {
           type: 'flag',
@@ -118,10 +120,10 @@ describe('OptionValidator', () => {
         },
       } as const satisfies Options;
       const validator = new OptionValidator(options);
-      expect(() => validator.validate()).toThrow(`Option flag has duplicate name 'dup'.`);
+      await expect(validator.validate()).rejects.toThrow(`Option flag has duplicate name 'dup'.`);
     });
 
-    it('should throw an error on option with duplicate positional marker', () => {
+    it('should throw an error on option with duplicate positional marker', async () => {
       const options = {
         boolean: {
           type: 'boolean',
@@ -130,10 +132,12 @@ describe('OptionValidator', () => {
         },
       } as const satisfies Options;
       const validator = new OptionValidator(options);
-      expect(() => validator.validate()).toThrow(`Option boolean has duplicate name 'dup'.`);
+      await expect(validator.validate()).rejects.toThrow(
+        `Option boolean has duplicate name 'dup'.`,
+      );
     });
 
-    it('should return a warning on option name too similar to other names', () => {
+    it('should return a warning on option name too similar to other names', async () => {
       const options = {
         flag1: {
           type: 'flag',
@@ -150,14 +154,14 @@ describe('OptionValidator', () => {
       } as const satisfies Options;
       const validator = new OptionValidator(options);
       const flags: ValidationFlags = { detectNamingIssues: true };
-      const { warning } = validator.validate(flags);
+      const { warning } = await validator.validate(flags);
       expect(warning).toHaveLength(1);
       expect(warning?.message).toEqual(
         `: Option name 'flag1' has too similar names: 'flag2', 'flag3'.\n`,
       );
     });
 
-    it('should return a warning on mixed naming conventions', () => {
+    it('should return a warning on mixed naming conventions', async () => {
       const options = {
         flag1: {
           type: 'flag',
@@ -174,7 +178,7 @@ describe('OptionValidator', () => {
       } as const satisfies Options;
       const validator = new OptionValidator(options);
       const flags: ValidationFlags = { detectNamingIssues: true };
-      const { warning } = validator.validate(flags);
+      const { warning } = await validator.validate(flags);
       expect(warning).toHaveLength(3);
       expect(warning?.message).toEqual(
         `: Name slot 0 has mixed naming conventions: 'lowercase: lower', 'UPPERCASE: UPPER', 'Capitalized: Capital'.\n` +
@@ -183,7 +187,7 @@ describe('OptionValidator', () => {
       );
     });
 
-    it('should return a warning on nested command option name too similar to other names', () => {
+    it('should return a warning on nested command option name too similar to other names', async () => {
       const options = {
         command: {
           type: 'command',
@@ -207,7 +211,7 @@ describe('OptionValidator', () => {
       } as const satisfies Options;
       const validator = new OptionValidator(options);
       const flags: ValidationFlags = { detectNamingIssues: true };
-      const { warning } = validator.validate(flags);
+      const { warning } = await validator.validate(flags);
       expect(warning).toHaveLength(1);
       expect(warning?.message).toEqual(
         `command: Option name 'flag1' has too similar names: 'flag2', 'flag3'.\n`,

--- a/packages/tsargp/test/validator/validator.requirements.spec.ts
+++ b/packages/tsargp/test/validator/validator.requirements.spec.ts
@@ -4,7 +4,7 @@ import '../utils.spec';
 
 describe('OptionValidator', () => {
   describe('validate', () => {
-    it('should throw an error on option required by itself', () => {
+    it('should throw an error on option required by itself', async () => {
       const options = {
         requires: {
           type: 'flag',
@@ -17,10 +17,10 @@ describe('OptionValidator', () => {
         },
       } as const satisfies Options;
       const validator = new OptionValidator(options);
-      expect(() => validator.validate()).toThrow(`Option requires requires itself.`);
+      await expect(validator.validate()).rejects.toThrow(`Option requires requires itself.`);
     });
 
-    it('should throw an error on unknown required option', () => {
+    it('should throw an error on unknown required option', async () => {
       const options = {
         requires: {
           type: 'flag',
@@ -33,10 +33,10 @@ describe('OptionValidator', () => {
         },
       } as const satisfies Options;
       const validator = new OptionValidator(options);
-      expect(() => validator.validate()).toThrow(`Unknown option unknown in requirement.`);
+      await expect(validator.validate()).rejects.toThrow(`Unknown option unknown in requirement.`);
     });
 
-    it('should throw an error on required help option', () => {
+    it('should throw an error on required help option', async () => {
       const options = {
         requires: {
           type: 'flag',
@@ -49,10 +49,10 @@ describe('OptionValidator', () => {
         },
       } as const satisfies Options;
       const validator = new OptionValidator(options);
-      expect(() => validator.validate()).toThrow(`Invalid option required in requirement.`);
+      await expect(validator.validate()).rejects.toThrow(`Invalid option required in requirement.`);
     });
 
-    it('should throw an error on required version option', () => {
+    it('should throw an error on required version option', async () => {
       const options = {
         requires: {
           type: 'flag',
@@ -66,10 +66,10 @@ describe('OptionValidator', () => {
         },
       } as const satisfies Options;
       const validator = new OptionValidator(options);
-      expect(() => validator.validate()).toThrow(`Invalid option required in requirement.`);
+      await expect(validator.validate()).rejects.toThrow(`Invalid option required in requirement.`);
     });
 
-    it('should throw an error on function option required with a value', () => {
+    it('should throw an error on function option required with a value', async () => {
       const options = {
         requires: {
           type: 'flag',
@@ -79,14 +79,14 @@ describe('OptionValidator', () => {
         required: {
           type: 'function',
           names: ['-f2'],
-          exec: () => {},
+          exec: async () => {},
         },
       } as const satisfies Options;
       const validator = new OptionValidator(options);
-      expect(() => validator.validate()).toThrow(`Invalid option required in requirement.`);
+      await expect(validator.validate()).rejects.toThrow(`Invalid option required in requirement.`);
     });
 
-    it('should throw an error on command option required with a value', () => {
+    it('should throw an error on command option required with a value', async () => {
       const options = {
         requires: {
           type: 'flag',
@@ -97,14 +97,14 @@ describe('OptionValidator', () => {
           type: 'command',
           names: ['-c'],
           options: {},
-          exec: () => {},
+          exec: async () => {},
         },
       } as const satisfies Options;
       const validator = new OptionValidator(options);
-      expect(() => validator.validate()).toThrow(`Invalid option required in requirement.`);
+      await expect(validator.validate()).rejects.toThrow(`Invalid option required in requirement.`);
     });
 
-    it('should throw an error on option required to be present despite being always required', () => {
+    it('should throw an error on option required to be present despite being always required', async () => {
       const options = {
         requires: {
           type: 'flag',
@@ -118,12 +118,12 @@ describe('OptionValidator', () => {
         },
       } as const satisfies Options;
       const validator = new OptionValidator(options);
-      expect(() => validator.validate()).toThrow(
+      await expect(validator.validate()).rejects.toThrow(
         `Invalid required value for option required. Option is always required or has a default value.`,
       );
     });
 
-    it('should throw an error on option required to be absent despite being always required', () => {
+    it('should throw an error on option required to be absent despite being always required', async () => {
       const options = {
         requires: {
           type: 'flag',
@@ -137,12 +137,12 @@ describe('OptionValidator', () => {
         },
       } as const satisfies Options;
       const validator = new OptionValidator(options);
-      expect(() => validator.validate()).toThrow(
+      await expect(validator.validate()).rejects.toThrow(
         `Invalid required value for option required. Option is always required or has a default value.`,
       );
     });
 
-    it('should throw an error on option required to be present despite having a default value', () => {
+    it('should throw an error on option required to be present despite having a default value', async () => {
       const options = {
         requires: {
           type: 'flag',
@@ -156,12 +156,12 @@ describe('OptionValidator', () => {
         },
       } as const satisfies Options;
       const validator = new OptionValidator(options);
-      expect(() => validator.validate()).toThrow(
+      await expect(validator.validate()).rejects.toThrow(
         `Invalid required value for option required. Option is always required or has a default value.`,
       );
     });
 
-    it('should throw an error on option required to be absent despite having a default value', () => {
+    it('should throw an error on option required to be absent despite having a default value', async () => {
       const options = {
         requires: {
           type: 'flag',
@@ -175,12 +175,12 @@ describe('OptionValidator', () => {
         },
       } as const satisfies Options;
       const validator = new OptionValidator(options);
-      expect(() => validator.validate()).toThrow(
+      await expect(validator.validate()).rejects.toThrow(
         `Invalid required value for option required. Option is always required or has a default value.`,
       );
     });
 
-    it('should allow a function option required to be present or absent', () => {
+    it('should allow a function option required to be present or absent', async () => {
       const options = {
         flag: {
           type: 'flag',
@@ -190,19 +190,19 @@ describe('OptionValidator', () => {
         required1: {
           type: 'function',
           names: ['-f2'],
-          exec: () => {},
+          exec: async () => {},
         },
         required2: {
           type: 'function',
           names: ['-f3'],
-          exec: () => {},
+          exec: async () => {},
         },
       } as const satisfies Options;
       const validator = new OptionValidator(options);
-      expect(() => validator.validate()).not.toThrow();
+      await expect(validator.validate()).resolves.toMatchObject({});
     });
 
-    it('should allow a command option required to be present or absent', () => {
+    it('should allow a command option required to be present or absent', async () => {
       const options = {
         flag: {
           type: 'flag',
@@ -213,20 +213,20 @@ describe('OptionValidator', () => {
           type: 'command',
           names: ['-c1'],
           options: {},
-          exec: () => {},
+          exec: async () => {},
         },
         required2: {
           type: 'command',
           names: ['-c2'],
           options: {},
-          exec: () => {},
+          exec: async () => {},
         },
       } as const satisfies Options;
       const validator = new OptionValidator(options);
-      expect(() => validator.validate()).not.toThrow();
+      await expect(validator.validate()).resolves.toMatchObject({});
     });
 
-    it('should allow a flag option required to be present or absent', () => {
+    it('should allow a flag option required to be present or absent', async () => {
       const options = {
         requires: {
           type: 'flag',
@@ -243,10 +243,10 @@ describe('OptionValidator', () => {
         },
       } as const satisfies Options;
       const validator = new OptionValidator(options);
-      expect(() => validator.validate()).not.toThrow();
+      await expect(validator.validate()).resolves.toMatchObject({});
     });
 
-    it('should allow a flag option required with a value', () => {
+    it('should allow a flag option required with a value', async () => {
       const options = {
         requires: {
           type: 'flag',
@@ -259,10 +259,10 @@ describe('OptionValidator', () => {
         },
       } as const satisfies Options;
       const validator = new OptionValidator(options);
-      expect(() => validator.validate()).not.toThrow();
+      await expect(validator.validate()).resolves.toMatchObject({});
     });
 
-    it('should throw an error on flag option required with an incompatible value', () => {
+    it('should throw an error on flag option required with an incompatible value', async () => {
       const options = {
         requires: {
           type: 'flag',
@@ -275,12 +275,12 @@ describe('OptionValidator', () => {
         },
       } as const satisfies Options;
       const validator = new OptionValidator(options);
-      expect(() => validator.validate()).toThrow(
+      await expect(validator.validate()).rejects.toThrow(
         `Incompatible required value <1> for option required. Should be of type 'boolean'.`,
       );
     });
 
-    it('should throw an error on boolean option required with an incompatible value', () => {
+    it('should throw an error on boolean option required with an incompatible value', async () => {
       const options = {
         requires: {
           type: 'flag',
@@ -293,12 +293,12 @@ describe('OptionValidator', () => {
         },
       } as const satisfies Options;
       const validator = new OptionValidator(options);
-      expect(() => validator.validate()).toThrow(
+      await expect(validator.validate()).rejects.toThrow(
         `Incompatible required value <1> for option required. Should be of type 'boolean'.`,
       );
     });
 
-    it('should throw an error on string option required with an incompatible value', () => {
+    it('should throw an error on string option required with an incompatible value', async () => {
       const options = {
         requires: {
           type: 'flag',
@@ -311,12 +311,12 @@ describe('OptionValidator', () => {
         },
       } as const satisfies Options;
       const validator = new OptionValidator(options);
-      expect(() => validator.validate()).toThrow(
+      await expect(validator.validate()).rejects.toThrow(
         `Incompatible required value <1> for option required. Should be of type 'string'.`,
       );
     });
 
-    it('should throw an error on number option required with an incompatible value', () => {
+    it('should throw an error on number option required with an incompatible value', async () => {
       const options = {
         requires: {
           type: 'flag',
@@ -329,12 +329,12 @@ describe('OptionValidator', () => {
         },
       } as const satisfies Options;
       const validator = new OptionValidator(options);
-      expect(() => validator.validate()).toThrow(
+      await expect(validator.validate()).rejects.toThrow(
         `Incompatible required value <1> for option required. Should be of type 'number'.`,
       );
     });
 
-    it('should throw an error on strings option required with an incompatible value', () => {
+    it('should throw an error on strings option required with an incompatible value', async () => {
       const options = {
         requires: {
           type: 'flag',
@@ -347,12 +347,12 @@ describe('OptionValidator', () => {
         },
       } as const satisfies Options;
       const validator = new OptionValidator(options);
-      expect(() => validator.validate()).toThrow(
+      await expect(validator.validate()).rejects.toThrow(
         `Incompatible required value <1> for option required. Should be of type 'object'.`,
       );
     });
 
-    it('should throw an error on strings option required with an incompatible array element', () => {
+    it('should throw an error on strings option required with an incompatible array element', async () => {
       const options = {
         requires: {
           type: 'flag',
@@ -365,12 +365,12 @@ describe('OptionValidator', () => {
         },
       } as const satisfies Options;
       const validator = new OptionValidator(options);
-      expect(() => validator.validate()).toThrow(
+      await expect(validator.validate()).rejects.toThrow(
         `Incompatible required value <1> for option required. Should be of type 'string'.`,
       );
     });
 
-    it('should throw an error on numbers option required with an incompatible value', () => {
+    it('should throw an error on numbers option required with an incompatible value', async () => {
       const options = {
         requires: {
           type: 'flag',
@@ -383,12 +383,12 @@ describe('OptionValidator', () => {
         },
       } as const satisfies Options;
       const validator = new OptionValidator(options);
-      expect(() => validator.validate()).toThrow(
+      await expect(validator.validate()).rejects.toThrow(
         `Incompatible required value <1> for option required. Should be of type 'object'.`,
       );
     });
 
-    it('should throw an error on numbers option required with an incompatible array element', () => {
+    it('should throw an error on numbers option required with an incompatible array element', async () => {
       const options = {
         requires: {
           type: 'flag',
@@ -401,12 +401,12 @@ describe('OptionValidator', () => {
         },
       } as const satisfies Options;
       const validator = new OptionValidator(options);
-      expect(() => validator.validate()).toThrow(
+      await expect(validator.validate()).rejects.toThrow(
         `Incompatible required value <1> for option required. Should be of type 'number'.`,
       );
     });
 
-    it('should throw an error on option required by its own presence', () => {
+    it('should throw an error on option required by its own presence', async () => {
       const options = {
         requires: {
           type: 'flag',
@@ -419,10 +419,10 @@ describe('OptionValidator', () => {
         },
       } as const satisfies Options;
       const validator = new OptionValidator(options);
-      expect(() => validator.validate()).toThrow(`Option requires requires itself.`);
+      await expect(validator.validate()).rejects.toThrow(`Option requires requires itself.`);
     });
 
-    it('should throw an error on option required if an unknown option is present', () => {
+    it('should throw an error on option required if an unknown option is present', async () => {
       const options = {
         requires: {
           type: 'flag',
@@ -435,10 +435,10 @@ describe('OptionValidator', () => {
         },
       } as const satisfies Options;
       const validator = new OptionValidator(options);
-      expect(() => validator.validate()).toThrow(`Unknown option unknown in requirement.`);
+      await expect(validator.validate()).rejects.toThrow(`Unknown option unknown in requirement.`);
     });
 
-    it('should throw an error on option required if a help option is present', () => {
+    it('should throw an error on option required if a help option is present', async () => {
       const options = {
         requires: {
           type: 'flag',
@@ -451,10 +451,10 @@ describe('OptionValidator', () => {
         },
       } as const satisfies Options;
       const validator = new OptionValidator(options);
-      expect(() => validator.validate()).toThrow(`Invalid option other in requirement.`);
+      await expect(validator.validate()).rejects.toThrow(`Invalid option other in requirement.`);
     });
 
-    it('should throw an error on option required if a version option is present', () => {
+    it('should throw an error on option required if a version option is present', async () => {
       const options = {
         requires: {
           type: 'flag',
@@ -468,10 +468,10 @@ describe('OptionValidator', () => {
         },
       } as const satisfies Options;
       const validator = new OptionValidator(options);
-      expect(() => validator.validate()).toThrow(`Invalid option other in requirement.`);
+      await expect(validator.validate()).rejects.toThrow(`Invalid option other in requirement.`);
     });
 
-    it('should throw an error on option required if a function option has a value', () => {
+    it('should throw an error on option required if a function option has a value', async () => {
       const options = {
         requires: {
           type: 'flag',
@@ -481,14 +481,14 @@ describe('OptionValidator', () => {
         other: {
           type: 'function',
           names: ['-f2'],
-          exec: () => {},
+          exec: async () => {},
         },
       } as const satisfies Options;
       const validator = new OptionValidator(options);
-      expect(() => validator.validate()).toThrow(`Invalid option other in requirement.`);
+      await expect(validator.validate()).rejects.toThrow(`Invalid option other in requirement.`);
     });
 
-    it('should throw an error on option required if a command option has a value', () => {
+    it('should throw an error on option required if a command option has a value', async () => {
       const options = {
         requires: {
           type: 'flag',
@@ -499,14 +499,14 @@ describe('OptionValidator', () => {
           type: 'command',
           names: ['-c'],
           options: {},
-          exec: () => {},
+          exec: async () => {},
         },
       } as const satisfies Options;
       const validator = new OptionValidator(options);
-      expect(() => validator.validate()).toThrow(`Invalid option other in requirement.`);
+      await expect(validator.validate()).rejects.toThrow(`Invalid option other in requirement.`);
     });
 
-    it('should throw an error on option required if another is present despite being always required', () => {
+    it('should throw an error on option required if another is present despite being always required', async () => {
       const options = {
         requires: {
           type: 'flag',
@@ -520,12 +520,12 @@ describe('OptionValidator', () => {
         },
       } as const satisfies Options;
       const validator = new OptionValidator(options);
-      expect(() => validator.validate()).toThrow(
+      await expect(validator.validate()).rejects.toThrow(
         `Invalid required value for option other. Option is always required or has a default value.`,
       );
     });
 
-    it('should throw an error on option required if another is absent despite being always required', () => {
+    it('should throw an error on option required if another is absent despite being always required', async () => {
       const options = {
         requires: {
           type: 'flag',
@@ -539,12 +539,12 @@ describe('OptionValidator', () => {
         },
       } as const satisfies Options;
       const validator = new OptionValidator(options);
-      expect(() => validator.validate()).toThrow(
+      await expect(validator.validate()).rejects.toThrow(
         `Invalid required value for option other. Option is always required or has a default value.`,
       );
     });
 
-    it('should throw an error on option required if another is present despite having a default value', () => {
+    it('should throw an error on option required if another is present despite having a default value', async () => {
       const options = {
         requires: {
           type: 'flag',
@@ -558,12 +558,12 @@ describe('OptionValidator', () => {
         },
       } as const satisfies Options;
       const validator = new OptionValidator(options);
-      expect(() => validator.validate()).toThrow(
+      await expect(validator.validate()).rejects.toThrow(
         `Invalid required value for option other. Option is always required or has a default value.`,
       );
     });
 
-    it('should throw an error on option required if another is absent despite having a default value', () => {
+    it('should throw an error on option required if another is absent despite having a default value', async () => {
       const options = {
         requires: {
           type: 'flag',
@@ -577,12 +577,12 @@ describe('OptionValidator', () => {
         },
       } as const satisfies Options;
       const validator = new OptionValidator(options);
-      expect(() => validator.validate()).toThrow(
+      await expect(validator.validate()).rejects.toThrow(
         `Invalid required value for option other. Option is always required or has a default value.`,
       );
     });
 
-    it('should allow an option required if a function option is present or absent', () => {
+    it('should allow an option required if a function option is present or absent', async () => {
       const options = {
         requires: {
           type: 'flag',
@@ -592,19 +592,19 @@ describe('OptionValidator', () => {
         other1: {
           type: 'function',
           names: ['-f2'],
-          exec: () => {},
+          exec: async () => {},
         },
         other2: {
           type: 'function',
           names: ['-f3'],
-          exec: () => {},
+          exec: async () => {},
         },
       } as const satisfies Options;
       const validator = new OptionValidator(options);
-      expect(() => validator.validate()).not.toThrow();
+      await expect(validator.validate()).resolves.toMatchObject({});
     });
 
-    it('should allow an option required if a command option is present or absent', () => {
+    it('should allow an option required if a command option is present or absent', async () => {
       const options = {
         requires: {
           type: 'flag',
@@ -615,20 +615,20 @@ describe('OptionValidator', () => {
           type: 'command',
           names: ['-c1'],
           options: {},
-          exec: () => {},
+          exec: async () => {},
         },
         other2: {
           type: 'command',
           names: ['-c2'],
           options: {},
-          exec: () => {},
+          exec: async () => {},
         },
       } as const satisfies Options;
       const validator = new OptionValidator(options);
-      expect(() => validator.validate()).not.toThrow();
+      await expect(validator.validate()).resolves.toMatchObject({});
     });
 
-    it('should allow an option required if a flag option is present or absent', () => {
+    it('should allow an option required if a flag option is present or absent', async () => {
       const options = {
         requires: {
           type: 'flag',
@@ -645,10 +645,10 @@ describe('OptionValidator', () => {
         },
       } as const satisfies Options;
       const validator = new OptionValidator(options);
-      expect(() => validator.validate()).not.toThrow();
+      await expect(validator.validate()).resolves.toMatchObject({});
     });
 
-    it('should allow an option required if a flag option has a value', () => {
+    it('should allow an option required if a flag option has a value', async () => {
       const options = {
         requires: {
           type: 'flag',
@@ -661,10 +661,10 @@ describe('OptionValidator', () => {
         },
       } as const satisfies Options;
       const validator = new OptionValidator(options);
-      expect(() => validator.validate()).not.toThrow();
+      await expect(validator.validate()).resolves.toMatchObject({});
     });
 
-    it('should throw an error on option required if a flag option has an incompatible value', () => {
+    it('should throw an error on option required if a flag option has an incompatible value', async () => {
       const options = {
         requires: {
           type: 'flag',
@@ -677,12 +677,12 @@ describe('OptionValidator', () => {
         },
       } as const satisfies Options;
       const validator = new OptionValidator(options);
-      expect(() => validator.validate()).toThrow(
+      await expect(validator.validate()).rejects.toThrow(
         `Incompatible required value <1> for option other. Should be of type 'boolean'.`,
       );
     });
 
-    it('should throw an error on option required if a boolean option has an incompatible value', () => {
+    it('should throw an error on option required if a boolean option has an incompatible value', async () => {
       const options = {
         requires: {
           type: 'flag',
@@ -695,12 +695,12 @@ describe('OptionValidator', () => {
         },
       } as const satisfies Options;
       const validator = new OptionValidator(options);
-      expect(() => validator.validate()).toThrow(
+      await expect(validator.validate()).rejects.toThrow(
         `Incompatible required value <1> for option other. Should be of type 'boolean'.`,
       );
     });
 
-    it('should throw an error on option required if a string option has an incompatible value', () => {
+    it('should throw an error on option required if a string option has an incompatible value', async () => {
       const options = {
         requires: {
           type: 'flag',
@@ -713,12 +713,12 @@ describe('OptionValidator', () => {
         },
       } as const satisfies Options;
       const validator = new OptionValidator(options);
-      expect(() => validator.validate()).toThrow(
+      await expect(validator.validate()).rejects.toThrow(
         `Incompatible required value <1> for option other. Should be of type 'string'.`,
       );
     });
 
-    it('should throw an error on option required if a number option has an incompatible value', () => {
+    it('should throw an error on option required if a number option has an incompatible value', async () => {
       const options = {
         requires: {
           type: 'flag',
@@ -731,12 +731,12 @@ describe('OptionValidator', () => {
         },
       } as const satisfies Options;
       const validator = new OptionValidator(options);
-      expect(() => validator.validate()).toThrow(
+      await expect(validator.validate()).rejects.toThrow(
         `Incompatible required value <1> for option other. Should be of type 'number'.`,
       );
     });
 
-    it('should throw an error on option required if a strings option has an incompatible value', () => {
+    it('should throw an error on option required if a strings option has an incompatible value', async () => {
       const options = {
         requires: {
           type: 'flag',
@@ -749,12 +749,12 @@ describe('OptionValidator', () => {
         },
       } as const satisfies Options;
       const validator = new OptionValidator(options);
-      expect(() => validator.validate()).toThrow(
+      await expect(validator.validate()).rejects.toThrow(
         `Incompatible required value <1> for option other. Should be of type 'object'.`,
       );
     });
 
-    it('should throw an error on option required if a strings option has an incompatible array element', () => {
+    it('should throw an error on option required if a strings option has an incompatible array element', async () => {
       const options = {
         requires: {
           type: 'flag',
@@ -767,12 +767,12 @@ describe('OptionValidator', () => {
         },
       } as const satisfies Options;
       const validator = new OptionValidator(options);
-      expect(() => validator.validate()).toThrow(
+      await expect(validator.validate()).rejects.toThrow(
         `Incompatible required value <1> for option other. Should be of type 'string'.`,
       );
     });
 
-    it('should throw an error on option required if a numbers option has an incompatible value', () => {
+    it('should throw an error on option required if a numbers option has an incompatible value', async () => {
       const options = {
         requires: {
           type: 'flag',
@@ -785,12 +785,12 @@ describe('OptionValidator', () => {
         },
       } as const satisfies Options;
       const validator = new OptionValidator(options);
-      expect(() => validator.validate()).toThrow(
+      await expect(validator.validate()).rejects.toThrow(
         `Incompatible required value <1> for option other. Should be of type 'object'.`,
       );
     });
 
-    it('should throw an error on option required if a numbers option has an incompatible array element', () => {
+    it('should throw an error on option required if a numbers option has an incompatible array element', async () => {
       const options = {
         requires: {
           type: 'flag',
@@ -803,7 +803,7 @@ describe('OptionValidator', () => {
         },
       } as const satisfies Options;
       const validator = new OptionValidator(options);
-      expect(() => validator.validate()).toThrow(
+      await expect(validator.validate()).rejects.toThrow(
         `Incompatible required value <1> for option other. Should be of type 'number'.`,
       );
     });

--- a/packages/tsargp/test/validator/validator.spec.ts
+++ b/packages/tsargp/test/validator/validator.spec.ts
@@ -10,7 +10,7 @@ describe('OptionValidator', () => {
   });
 
   describe('validate', () => {
-    it('should throw an error on boolean option with empty positional marker', () => {
+    it('should throw an error on boolean option with empty positional marker', async () => {
       const options = {
         boolean: {
           type: 'boolean',
@@ -19,10 +19,12 @@ describe('OptionValidator', () => {
         },
       } as const satisfies Options;
       const validator = new OptionValidator(options);
-      expect(() => validator.validate()).toThrow(`Option boolean has empty positional marker.`);
+      await expect(validator.validate()).rejects.toThrow(
+        `Option boolean has empty positional marker.`,
+      );
     });
 
-    it('should throw an error on duplicate positional option', () => {
+    it('should throw an error on duplicate positional option', async () => {
       const options = {
         boolean1: {
           type: 'boolean',
@@ -34,12 +36,12 @@ describe('OptionValidator', () => {
         },
       } as const satisfies Options;
       const validator = new OptionValidator(options);
-      expect(() => validator.validate()).toThrow(
+      await expect(validator.validate()).rejects.toThrow(
         `Duplicate positional option boolean2: previous was boolean1.`,
       );
     });
 
-    it('should throw an error on version option with empty version', () => {
+    it('should throw an error on version option with empty version', async () => {
       const options = {
         version: {
           type: 'version',
@@ -48,10 +50,10 @@ describe('OptionValidator', () => {
         },
       } as const satisfies Options;
       const validator = new OptionValidator(options);
-      expect(() => validator.validate()).toThrow(`Option version has empty version.`);
+      await expect(validator.validate()).rejects.toThrow(`Option version has empty version.`);
     });
 
-    it('should validate nested command options recursively', () => {
+    it('should validate nested command options recursively', async () => {
       const options = {
         command: {
           type: 'command',
@@ -68,12 +70,12 @@ describe('OptionValidator', () => {
         },
       } as const satisfies Options;
       const validator = new OptionValidator(options);
-      expect(() => validator.validate()).toThrow(
+      await expect(validator.validate()).rejects.toThrow(
         `Non-positional option command.command.flag has no name.`,
       );
     });
 
-    it('should avoid circular references while evaluating nested command options', () => {
+    it('should avoid circular references while evaluating nested command options', async () => {
       const options = {
         command: {
           type: 'command',
@@ -90,7 +92,7 @@ describe('OptionValidator', () => {
         },
       } as const satisfies Options;
       const validator = new OptionValidator(options);
-      expect(() => validator.validate()).not.toThrow();
+      await expect(validator.validate()).resolves.toMatchObject({});
     });
   });
 });

--- a/packages/tsargp/test/validator/validator.value.spec.ts
+++ b/packages/tsargp/test/validator/validator.value.spec.ts
@@ -4,7 +4,7 @@ import '../utils.spec';
 
 describe('OptionValidator', () => {
   describe('validate', () => {
-    it('should ignore default and fallback callbacks on a string option', () => {
+    it('should ignore default and fallback callbacks on a string option', async () => {
       const options = {
         string: {
           type: 'string',
@@ -15,10 +15,10 @@ describe('OptionValidator', () => {
         },
       } as const satisfies Options;
       const validator = new OptionValidator(options);
-      expect(() => validator.validate()).not.toThrow();
+      await expect(validator.validate()).resolves.toMatchObject({});
     });
 
-    it('should ignore default value on a non-niladic function option', () => {
+    it('should ignore default value on a non-niladic function option', async () => {
       const options = {
         function: {
           type: 'function',
@@ -28,10 +28,10 @@ describe('OptionValidator', () => {
         },
       } as const satisfies Options;
       const validator = new OptionValidator(options);
-      expect(() => validator.validate()).not.toThrow();
+      await expect(validator.validate()).resolves.toMatchObject({});
     });
 
-    it('should throw an error on string example value not matching regex', () => {
+    it('should throw an error on string example value not matching regex', async () => {
       const options = {
         string: {
           type: 'string',
@@ -41,12 +41,12 @@ describe('OptionValidator', () => {
         },
       } as const satisfies Options;
       const validator = new OptionValidator(options);
-      expect(() => validator.validate()).toThrow(
+      await expect(validator.validate()).rejects.toThrow(
         `Invalid parameter to string: 'abc'. Value must match the regex /\\d+/s.`,
       );
     });
 
-    it('should throw an error on string default value not matching regex', () => {
+    it('should throw an error on string default value not matching regex', async () => {
       const options = {
         string: {
           type: 'string',
@@ -56,12 +56,12 @@ describe('OptionValidator', () => {
         },
       } as const satisfies Options;
       const validator = new OptionValidator(options);
-      expect(() => validator.validate()).toThrow(
+      await expect(validator.validate()).rejects.toThrow(
         `Invalid parameter to string: 'abc'. Value must match the regex /\\d+/s.`,
       );
     });
 
-    it('should throw an error on string fallback value not matching regex', () => {
+    it('should throw an error on string fallback value not matching regex', async () => {
       const options = {
         string: {
           type: 'string',
@@ -71,12 +71,12 @@ describe('OptionValidator', () => {
         },
       } as const satisfies Options;
       const validator = new OptionValidator(options);
-      expect(() => validator.validate()).toThrow(
+      await expect(validator.validate()).rejects.toThrow(
         `Invalid parameter to string: 'abc'. Value must match the regex /\\d+/s.`,
       );
     });
 
-    it('should throw an error on string required value not matching regex', () => {
+    it('should throw an error on string required value not matching regex', async () => {
       const options = {
         requires: {
           type: 'flag',
@@ -90,12 +90,12 @@ describe('OptionValidator', () => {
         },
       } as const satisfies Options;
       const validator = new OptionValidator(options);
-      expect(() => validator.validate()).toThrow(
+      await expect(validator.validate()).rejects.toThrow(
         `Invalid parameter to required: 'abc'. Value must match the regex /\\d+/s.`,
       );
     });
 
-    it('should throw an error on string example value not in enumeration', () => {
+    it('should throw an error on string example value not in enumeration', async () => {
       const options = {
         string: {
           type: 'string',
@@ -105,12 +105,12 @@ describe('OptionValidator', () => {
         },
       } as const satisfies Options;
       const validator = new OptionValidator(options);
-      expect(() => validator.validate()).toThrow(
+      await expect(validator.validate()).rejects.toThrow(
         `Invalid parameter to string: 'abc'. Possible values are {'one', 'two'}.`,
       );
     });
 
-    it('should throw an error on string default value not in enumeration', () => {
+    it('should throw an error on string default value not in enumeration', async () => {
       const options = {
         string: {
           type: 'string',
@@ -120,12 +120,12 @@ describe('OptionValidator', () => {
         },
       } as const satisfies Options;
       const validator = new OptionValidator(options);
-      expect(() => validator.validate()).toThrow(
+      await expect(validator.validate()).rejects.toThrow(
         `Invalid parameter to string: 'abc'. Possible values are {'one', 'two'}.`,
       );
     });
 
-    it('should throw an error on string fallback value not in enumeration', () => {
+    it('should throw an error on string fallback value not in enumeration', async () => {
       const options = {
         string: {
           type: 'string',
@@ -135,12 +135,12 @@ describe('OptionValidator', () => {
         },
       } as const satisfies Options;
       const validator = new OptionValidator(options);
-      expect(() => validator.validate()).toThrow(
+      await expect(validator.validate()).rejects.toThrow(
         `Invalid parameter to string: 'abc'. Possible values are {'one', 'two'}.`,
       );
     });
 
-    it('should throw an error on string required value not in enumeration', () => {
+    it('should throw an error on string required value not in enumeration', async () => {
       const options = {
         requires: {
           type: 'flag',
@@ -154,12 +154,12 @@ describe('OptionValidator', () => {
         },
       } as const satisfies Options;
       const validator = new OptionValidator(options);
-      expect(() => validator.validate()).toThrow(
+      await expect(validator.validate()).rejects.toThrow(
         `Invalid parameter to required: 'abc'. Possible values are {'one', 'two'}.`,
       );
     });
 
-    it('should throw an error on number example value not in range', () => {
+    it('should throw an error on number example value not in range', async () => {
       const options = {
         number: {
           type: 'number',
@@ -169,12 +169,12 @@ describe('OptionValidator', () => {
         },
       } as const satisfies Options;
       const validator = new OptionValidator(options);
-      expect(() => validator.validate()).toThrow(
+      await expect(validator.validate()).rejects.toThrow(
         `Invalid parameter to number: -3. Value must be in the range [0, Infinity].`,
       );
     });
 
-    it('should throw an error on number default value not in range', () => {
+    it('should throw an error on number default value not in range', async () => {
       const options = {
         number: {
           type: 'number',
@@ -184,12 +184,12 @@ describe('OptionValidator', () => {
         },
       } as const satisfies Options;
       const validator = new OptionValidator(options);
-      expect(() => validator.validate()).toThrow(
+      await expect(validator.validate()).rejects.toThrow(
         `Invalid parameter to number: -3. Value must be in the range [0, Infinity].`,
       );
     });
 
-    it('should throw an error on number fallback value not in range', () => {
+    it('should throw an error on number fallback value not in range', async () => {
       const options = {
         number: {
           type: 'number',
@@ -199,12 +199,12 @@ describe('OptionValidator', () => {
         },
       } as const satisfies Options;
       const validator = new OptionValidator(options);
-      expect(() => validator.validate()).toThrow(
+      await expect(validator.validate()).rejects.toThrow(
         `Invalid parameter to number: -3. Value must be in the range [0, Infinity].`,
       );
     });
 
-    it('should throw an error on number required value not in range', () => {
+    it('should throw an error on number required value not in range', async () => {
       const options = {
         requires: {
           type: 'flag',
@@ -218,12 +218,12 @@ describe('OptionValidator', () => {
         },
       } as const satisfies Options;
       const validator = new OptionValidator(options);
-      expect(() => validator.validate()).toThrow(
+      await expect(validator.validate()).rejects.toThrow(
         `Invalid parameter to required: -3. Value must be in the range [0, Infinity].`,
       );
     });
 
-    it('should throw an error on number example value not in enumeration', () => {
+    it('should throw an error on number example value not in enumeration', async () => {
       const options = {
         number: {
           type: 'number',
@@ -233,12 +233,12 @@ describe('OptionValidator', () => {
         },
       } as const satisfies Options;
       const validator = new OptionValidator(options);
-      expect(() => validator.validate()).toThrow(
+      await expect(validator.validate()).rejects.toThrow(
         `Invalid parameter to number: 3. Possible values are {1, 2}.`,
       );
     });
 
-    it('should throw an error on number default value not in enumeration', () => {
+    it('should throw an error on number default value not in enumeration', async () => {
       const options = {
         number: {
           type: 'number',
@@ -248,12 +248,12 @@ describe('OptionValidator', () => {
         },
       } as const satisfies Options;
       const validator = new OptionValidator(options);
-      expect(() => validator.validate()).toThrow(
+      await expect(validator.validate()).rejects.toThrow(
         `Invalid parameter to number: 3. Possible values are {1, 2}.`,
       );
     });
 
-    it('should throw an error on number fallback value not in enumeration', () => {
+    it('should throw an error on number fallback value not in enumeration', async () => {
       const options = {
         number: {
           type: 'number',
@@ -263,12 +263,12 @@ describe('OptionValidator', () => {
         },
       } as const satisfies Options;
       const validator = new OptionValidator(options);
-      expect(() => validator.validate()).toThrow(
+      await expect(validator.validate()).rejects.toThrow(
         `Invalid parameter to number: 3. Possible values are {1, 2}.`,
       );
     });
 
-    it('should throw an error on number required value not in enumeration', () => {
+    it('should throw an error on number required value not in enumeration', async () => {
       const options = {
         requires: {
           type: 'flag',
@@ -282,12 +282,12 @@ describe('OptionValidator', () => {
         },
       } as const satisfies Options;
       const validator = new OptionValidator(options);
-      expect(() => validator.validate()).toThrow(
+      await expect(validator.validate()).rejects.toThrow(
         `Invalid parameter to required: 3. Possible values are {1, 2}.`,
       );
     });
 
-    it('should throw an error on strings example value not matching regex', () => {
+    it('should throw an error on strings example value not matching regex', async () => {
       const options = {
         strings: {
           type: 'strings',
@@ -297,12 +297,12 @@ describe('OptionValidator', () => {
         },
       } as const satisfies Options;
       const validator = new OptionValidator(options);
-      expect(() => validator.validate()).toThrow(
+      await expect(validator.validate()).rejects.toThrow(
         `Invalid parameter to strings: 'abc'. Value must match the regex /\\d+/s.`,
       );
     });
 
-    it('should throw an error on strings default value not matching regex', () => {
+    it('should throw an error on strings default value not matching regex', async () => {
       const options = {
         strings: {
           type: 'strings',
@@ -312,12 +312,12 @@ describe('OptionValidator', () => {
         },
       } as const satisfies Options;
       const validator = new OptionValidator(options);
-      expect(() => validator.validate()).toThrow(
+      await expect(validator.validate()).rejects.toThrow(
         `Invalid parameter to strings: 'abc'. Value must match the regex /\\d+/s.`,
       );
     });
 
-    it('should throw an error on strings fallback value not matching regex', () => {
+    it('should throw an error on strings fallback value not matching regex', async () => {
       const options = {
         strings: {
           type: 'strings',
@@ -327,12 +327,12 @@ describe('OptionValidator', () => {
         },
       } as const satisfies Options;
       const validator = new OptionValidator(options);
-      expect(() => validator.validate()).toThrow(
+      await expect(validator.validate()).rejects.toThrow(
         `Invalid parameter to strings: 'abc'. Value must match the regex /\\d+/s.`,
       );
     });
 
-    it('should throw an error on strings required value not matching regex', () => {
+    it('should throw an error on strings required value not matching regex', async () => {
       const options = {
         requires: {
           type: 'flag',
@@ -346,12 +346,12 @@ describe('OptionValidator', () => {
         },
       } as const satisfies Options;
       const validator = new OptionValidator(options);
-      expect(() => validator.validate()).toThrow(
+      await expect(validator.validate()).rejects.toThrow(
         `Invalid parameter to required: 'abc'. Value must match the regex /\\d+/s.`,
       );
     });
 
-    it('should throw an error on strings example value not in enumeration', () => {
+    it('should throw an error on strings example value not in enumeration', async () => {
       const options = {
         strings: {
           type: 'strings',
@@ -361,12 +361,12 @@ describe('OptionValidator', () => {
         },
       } as const satisfies Options;
       const validator = new OptionValidator(options);
-      expect(() => validator.validate()).toThrow(
+      await expect(validator.validate()).rejects.toThrow(
         `Invalid parameter to strings: 'abc'. Possible values are {'one', 'two'}.`,
       );
     });
 
-    it('should throw an error on strings default value not in enumeration', () => {
+    it('should throw an error on strings default value not in enumeration', async () => {
       const options = {
         strings: {
           type: 'strings',
@@ -376,12 +376,12 @@ describe('OptionValidator', () => {
         },
       } as const satisfies Options;
       const validator = new OptionValidator(options);
-      expect(() => validator.validate()).toThrow(
+      await expect(validator.validate()).rejects.toThrow(
         `Invalid parameter to strings: 'abc'. Possible values are {'one', 'two'}.`,
       );
     });
 
-    it('should throw an error on strings fallback value not in enumeration', () => {
+    it('should throw an error on strings fallback value not in enumeration', async () => {
       const options = {
         strings: {
           type: 'strings',
@@ -391,12 +391,12 @@ describe('OptionValidator', () => {
         },
       } as const satisfies Options;
       const validator = new OptionValidator(options);
-      expect(() => validator.validate()).toThrow(
+      await expect(validator.validate()).rejects.toThrow(
         `Invalid parameter to strings: 'abc'. Possible values are {'one', 'two'}.`,
       );
     });
 
-    it('should throw an error on strings required value not in enumeration', () => {
+    it('should throw an error on strings required value not in enumeration', async () => {
       const options = {
         requires: {
           type: 'flag',
@@ -410,12 +410,12 @@ describe('OptionValidator', () => {
         },
       } as const satisfies Options;
       const validator = new OptionValidator(options);
-      expect(() => validator.validate()).toThrow(
+      await expect(validator.validate()).rejects.toThrow(
         `Invalid parameter to required: 'abc'. Possible values are {'one', 'two'}.`,
       );
     });
 
-    it('should throw an error on strings example value with too many values', () => {
+    it('should throw an error on strings example value with too many values', async () => {
       const options = {
         strings: {
           type: 'strings',
@@ -425,12 +425,12 @@ describe('OptionValidator', () => {
         },
       } as const satisfies Options;
       const validator = new OptionValidator(options);
-      expect(() => validator.validate()).toThrow(
+      await expect(validator.validate()).rejects.toThrow(
         `Option strings has too many values (3). Should have at most 2.`,
       );
     });
 
-    it('should throw an error on strings default value with too many values', () => {
+    it('should throw an error on strings default value with too many values', async () => {
       const options = {
         strings: {
           type: 'strings',
@@ -440,12 +440,12 @@ describe('OptionValidator', () => {
         },
       } as const satisfies Options;
       const validator = new OptionValidator(options);
-      expect(() => validator.validate()).toThrow(
+      await expect(validator.validate()).rejects.toThrow(
         `Option strings has too many values (3). Should have at most 2.`,
       );
     });
 
-    it('should throw an error on strings fallback value with too many values', () => {
+    it('should throw an error on strings fallback value with too many values', async () => {
       const options = {
         strings: {
           type: 'strings',
@@ -455,12 +455,12 @@ describe('OptionValidator', () => {
         },
       } as const satisfies Options;
       const validator = new OptionValidator(options);
-      expect(() => validator.validate()).toThrow(
+      await expect(validator.validate()).rejects.toThrow(
         `Option strings has too many values (3). Should have at most 2.`,
       );
     });
 
-    it('should throw an error on strings required value with too many values', () => {
+    it('should throw an error on strings required value with too many values', async () => {
       const options = {
         requires: {
           type: 'flag',
@@ -474,12 +474,12 @@ describe('OptionValidator', () => {
         },
       } as const satisfies Options;
       const validator = new OptionValidator(options);
-      expect(() => validator.validate()).toThrow(
+      await expect(validator.validate()).rejects.toThrow(
         `Option required has too many values (3). Should have at most 2.`,
       );
     });
 
-    it('should throw an error on numbers example value not in range', () => {
+    it('should throw an error on numbers example value not in range', async () => {
       const options = {
         numbers: {
           type: 'numbers',
@@ -489,12 +489,12 @@ describe('OptionValidator', () => {
         },
       } as const satisfies Options;
       const validator = new OptionValidator(options);
-      expect(() => validator.validate()).toThrow(
+      await expect(validator.validate()).rejects.toThrow(
         `Invalid parameter to numbers: -3. Value must be in the range [0, Infinity].`,
       );
     });
 
-    it('should throw an error on numbers default value not in range', () => {
+    it('should throw an error on numbers default value not in range', async () => {
       const options = {
         numbers: {
           type: 'numbers',
@@ -504,12 +504,12 @@ describe('OptionValidator', () => {
         },
       } as const satisfies Options;
       const validator = new OptionValidator(options);
-      expect(() => validator.validate()).toThrow(
+      await expect(validator.validate()).rejects.toThrow(
         `Invalid parameter to numbers: -3. Value must be in the range [0, Infinity].`,
       );
     });
 
-    it('should throw an error on numbers fallback value not in range', () => {
+    it('should throw an error on numbers fallback value not in range', async () => {
       const options = {
         numbers: {
           type: 'numbers',
@@ -519,12 +519,12 @@ describe('OptionValidator', () => {
         },
       } as const satisfies Options;
       const validator = new OptionValidator(options);
-      expect(() => validator.validate()).toThrow(
+      await expect(validator.validate()).rejects.toThrow(
         `Invalid parameter to numbers: -3. Value must be in the range [0, Infinity].`,
       );
     });
 
-    it('should throw an error on numbers required value not in range', () => {
+    it('should throw an error on numbers required value not in range', async () => {
       const options = {
         requires: {
           type: 'flag',
@@ -538,12 +538,12 @@ describe('OptionValidator', () => {
         },
       } as const satisfies Options;
       const validator = new OptionValidator(options);
-      expect(() => validator.validate()).toThrow(
+      await expect(validator.validate()).rejects.toThrow(
         `Invalid parameter to required: -3. Value must be in the range [0, Infinity].`,
       );
     });
 
-    it('should throw an error on numbers example value not in enumeration', () => {
+    it('should throw an error on numbers example value not in enumeration', async () => {
       const options = {
         numbers: {
           type: 'numbers',
@@ -553,12 +553,12 @@ describe('OptionValidator', () => {
         },
       } as const satisfies Options;
       const validator = new OptionValidator(options);
-      expect(() => validator.validate()).toThrow(
+      await expect(validator.validate()).rejects.toThrow(
         `Invalid parameter to numbers: 3. Possible values are {1, 2}.`,
       );
     });
 
-    it('should throw an error on numbers default value not in enumeration', () => {
+    it('should throw an error on numbers default value not in enumeration', async () => {
       const options = {
         numbers: {
           type: 'numbers',
@@ -568,12 +568,12 @@ describe('OptionValidator', () => {
         },
       } as const satisfies Options;
       const validator = new OptionValidator(options);
-      expect(() => validator.validate()).toThrow(
+      await expect(validator.validate()).rejects.toThrow(
         `Invalid parameter to numbers: 3. Possible values are {1, 2}.`,
       );
     });
 
-    it('should throw an error on numbers fallback value not in enumeration', () => {
+    it('should throw an error on numbers fallback value not in enumeration', async () => {
       const options = {
         numbers: {
           type: 'numbers',
@@ -583,12 +583,12 @@ describe('OptionValidator', () => {
         },
       } as const satisfies Options;
       const validator = new OptionValidator(options);
-      expect(() => validator.validate()).toThrow(
+      await expect(validator.validate()).rejects.toThrow(
         `Invalid parameter to numbers: 3. Possible values are {1, 2}.`,
       );
     });
 
-    it('should throw an error on numbers required value not in enumeration', () => {
+    it('should throw an error on numbers required value not in enumeration', async () => {
       const options = {
         requires: {
           type: 'flag',
@@ -602,12 +602,12 @@ describe('OptionValidator', () => {
         },
       } as const satisfies Options;
       const validator = new OptionValidator(options);
-      expect(() => validator.validate()).toThrow(
+      await expect(validator.validate()).rejects.toThrow(
         `Invalid parameter to required: 3. Possible values are {1, 2}.`,
       );
     });
 
-    it('should throw an error on numbers example value with too many values', () => {
+    it('should throw an error on numbers example value with too many values', async () => {
       const options = {
         numbers: {
           type: 'numbers',
@@ -617,12 +617,12 @@ describe('OptionValidator', () => {
         },
       } as const satisfies Options;
       const validator = new OptionValidator(options);
-      expect(() => validator.validate()).toThrow(
+      await expect(validator.validate()).rejects.toThrow(
         `Option numbers has too many values (3). Should have at most 2.`,
       );
     });
 
-    it('should throw an error on numbers default value with too many values', () => {
+    it('should throw an error on numbers default value with too many values', async () => {
       const options = {
         numbers: {
           type: 'numbers',
@@ -632,12 +632,12 @@ describe('OptionValidator', () => {
         },
       } as const satisfies Options;
       const validator = new OptionValidator(options);
-      expect(() => validator.validate()).toThrow(
+      await expect(validator.validate()).rejects.toThrow(
         `Option numbers has too many values (3). Should have at most 2.`,
       );
     });
 
-    it('should throw an error on numbers fallback value with too many values', () => {
+    it('should throw an error on numbers fallback value with too many values', async () => {
       const options = {
         numbers: {
           type: 'numbers',
@@ -647,12 +647,12 @@ describe('OptionValidator', () => {
         },
       } as const satisfies Options;
       const validator = new OptionValidator(options);
-      expect(() => validator.validate()).toThrow(
+      await expect(validator.validate()).rejects.toThrow(
         `Option numbers has too many values (3). Should have at most 2.`,
       );
     });
 
-    it('should throw an error on numbers required value with too many values', () => {
+    it('should throw an error on numbers required value with too many values', async () => {
       const options = {
         requires: {
           type: 'flag',
@@ -666,7 +666,7 @@ describe('OptionValidator', () => {
         },
       } as const satisfies Options;
       const validator = new OptionValidator(options);
-      expect(() => validator.validate()).toThrow(
+      await expect(validator.validate()).rejects.toThrow(
         `Option required has too many values (3). Should have at most 2.`,
       );
     });


### PR DESCRIPTION
Implemented handling of asynchronous `OptionsCallback` for the command option. This allows loading option definitions from a different module using a dynamic `import`. This required the `validate` method to return a promise.

Updated the Options page to document the support for this new feature in the "Command option" section. Also updated the Validator page to document the new asynchronous behavior of the `validate` procedure.

Closes #132 
