### PR TITLE
Issues/136

### DIFF
--- a/.changeset/forty-plums-wave.md
+++ b/.changeset/forty-plums-wave.md
@@ -1,0 +1,5 @@
+---
+'@trulysimple/tsargp-docs': patch
+---
+
+The Validator page was updated to document the new connective words for array elements and string quoting.

--- a/.changeset/ninety-phones-work.md
+++ b/.changeset/ninety-phones-work.md
@@ -1,0 +1,5 @@
+---
+'tsargp': minor
+---
+
+The connective words were extended to include array element separators and string quoting.

--- a/packages/docs/pages/docs/index.mdx
+++ b/packages/docs/pages/docs/index.mdx
@@ -115,7 +115,7 @@ Optionally, enable word completion:
   </Tabs.Tab>
 </Tabs>
 
-[^1]: ~32KB minified
+[^1]: ~33KB minified
 
 [SGR]: https://www.wikiwand.com/en/ANSI_escape_code#SGR_(Select_Graphic_Rendition)_parameters
 [meow]: https://www.npmjs.com/package/meow

--- a/packages/docs/pages/docs/library/validator.mdx
+++ b/packages/docs/pages/docs/library/validator.mdx
@@ -381,16 +381,23 @@ message, along with a description of the corresponding value:
 
 ### Connective words
 
-The `connectives` property specifies the connective words that are used to format options'
-requirements, in both error and help messages. It has the following optional properties, whose keys
-are enumerators from `ConnectiveWords`:
+The `connectives` property specifies connective words that are used to format some text elements
+that cannot be customized using phrases, such as option requirements, array element separators and
+string quoting. This is used in errors, warnings and help messages.
 
-- `and` - the word used to connect two logical expressions in conjunction
-- `or` - the word used to connect two logical expressions in disjunction
-- `not` - the word used to connect a logical expression in negation
-- `no` - the word used to connect a logical expression in non-existence
-- `equals` - the word used to connect two expressions in equality comparison
-- `notEquals` - the word used to connect two expressions in non-equality comparison
+It has the following optional properties, whose keys are enumerators from `ConnectiveWord`:
+
+- `and` - the word used to connect two logical expressions in conjunction (defaults to `'and'{:ts}`)
+- `or` - the word used to connect two logical expressions in disjunction (defaults to `'or'{:ts}`)
+- `not` - the word used to connect a logical expression in negation (defaults to `'not'{:ts}`)
+- `no` - the word used to connect a logical expression in non-existence (defaults to `'no'{:ts}`)
+- `equals` - the word used to connect two expressions in equality comparison (defaults to `'=='{:ts}`)
+- `notEquals` - the word used to connect two expressions in non-equality comparison (defaults to `'!='{:ts}`)
+- `optionAlt` - the word used to connect two option names in alternation (defaults to `'|'{:ts}`)
+- `optionSep` - the word used to connect two option names in succession (defaults to `','{:ts}`)
+- `stringSep` - the word used to connect two string values in succession (defaults to `','{:ts}`)
+- `numberSep` - the word used to connect two number values in succession (defaults to `','{:ts}`)
+- `stringQuote` - the quote character used to enclose a string value (defaults to `"'"{:ts}`)
 
 [value validation]: #value-validation
 [negation names]: options#negation-names

--- a/packages/tsargp/lib/enums.ts
+++ b/packages/tsargp/lib/enums.ts
@@ -1,7 +1,7 @@
 //--------------------------------------------------------------------------------------------------
 // Exports - NOTE: some enumerations are abbreviated for ease of use in client code.
 //--------------------------------------------------------------------------------------------------
-export { ControlSequence as cs, TypeFace as tf, Foreground as fg, Background as bg };
+export { ControlSequence as cs, TypeFace as tf, ForegroundColor as fg, BackgroundColor as bg };
 
 //--------------------------------------------------------------------------------------------------
 // Constants - NOTE: please add new enumerators at the _end_ of the enumeration.
@@ -253,7 +253,7 @@ export const enum HelpItem {
 /**
  * The kind of connective words used in option requirements.
  */
-export const enum ConnectiveWords {
+export const enum ConnectiveWord {
   /**
    * The word used to connect two logical expressions in conjunction.
    */
@@ -278,6 +278,26 @@ export const enum ConnectiveWords {
    * The word used to connect two expressions in non-equality comparison.
    */
   notEquals,
+  /**
+   * The word used to connect two option names in alternation.
+   */
+  optionAlt,
+  /**
+   * The word used to connect two option names in succession.
+   */
+  optionSep,
+  /**
+   * The word used to connect two string values in succession.
+   */
+  stringSep,
+  /**
+   * The word used to connect two number values in succession.
+   */
+  numberSep,
+  /**
+   * The quote character used to enclose a string value.
+   */
+  stringQuote,
 }
 
 /**
@@ -621,7 +641,7 @@ const enum TypeFace {
 /**
  * A predefined text foreground color.
  */
-const enum Foreground {
+const enum ForegroundColor {
   black = 30,
   red,
   green,
@@ -644,7 +664,7 @@ const enum Foreground {
 /**
  * A predefined text background color.
  */
-const enum Background {
+const enum BackgroundColor {
   black = 40,
   red,
   green,

--- a/packages/tsargp/lib/styles.ts
+++ b/packages/tsargp/lib/styles.ts
@@ -342,7 +342,7 @@ export class TerminalString {
   /**
    * The terminal string context.
    */
-  public context: TerminalContext;
+  private context: TerminalContext;
 
   /**
    * @returns The list of internal strings

--- a/packages/tsargp/lib/styles.ts
+++ b/packages/tsargp/lib/styles.ts
@@ -2,7 +2,7 @@
 // Imports and Exports
 //--------------------------------------------------------------------------------------------------
 import type { Alias, Concrete, Enumerate, URL, ValuesOf } from './utils';
-import { cs, tf, fg, bg } from './enums';
+import { cs, tf, fg, bg, ConnectiveWord } from './enums';
 import { env, max, overrides, regexps, selectAlternative } from './utils';
 
 export { sequence as seq, sgr as style, foreground as fg8, background as bg8, underline as ul8 };
@@ -59,9 +59,11 @@ const formatFunctions = {
    * @param value The string value
    * @param styles The format styles
    * @param result The resulting string
+   * @param flags The formatting flags
    */
-  s(value: string, styles, result) {
-    result.style(styles.string, `'${value}'`, styles.current ?? styles.text);
+  s(value: string, styles, result, flags) {
+    const quote = flags.connectives?.[ConnectiveWord.stringQuote] ?? `'`;
+    result.style(styles.string, `${quote}${value}${quote}`, styles.current ?? styles.text);
   },
   /**
    * The formatting function for number values.
@@ -278,7 +280,16 @@ export type FormattingFlags = {
    */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   readonly custom?: FormatCallback<any>;
+  /**
+   * The connective words.
+   */
+  readonly connectives?: ConnectiveWords;
 };
+
+/**
+ * The connective words.
+ */
+export type ConnectiveWords = Readonly<Record<ConnectiveWord, string>>;
 
 //--------------------------------------------------------------------------------------------------
 // Internal types
@@ -803,7 +814,7 @@ function splitItem(result: TerminalString, item: string, format?: FormatCallback
 function formatArgs(
   styles: FormatStyles,
   args: FormatArgs,
-  flags: FormattingFlags = { sep: ',' },
+  flags: FormattingFlags = {},
 ): FormatCallback {
   return function (this: TerminalString, spec: string) {
     const arg = spec.slice(1);

--- a/packages/tsargp/test/styles/styles.spec.ts
+++ b/packages/tsargp/test/styles/styles.spec.ts
@@ -163,17 +163,22 @@ describe('TerminalString', () => {
 
     it('should format array-valued arguments with separator', () => {
       const str1 = new TerminalString().split('type script');
-      const str2 = new TerminalString().format(styles, '%b %s %n %r %o %v %u %t %p', {
-        b: [true, false],
-        s: ['abc', 'def'],
-        n: [123, 456],
-        r: [/def/g, /123/i],
-        o: ['some name', 'other name'],
-        v: [() => 1, {}],
-        u: [new URL('https://abc'), new URL('ftp://def')],
-        t: ['some text', 'other text'],
-        p: [str1, str1],
-      });
+      const str2 = new TerminalString().format(
+        styles,
+        '%b %s %n %r %o %v %u %t %p',
+        {
+          b: [true, false],
+          s: ['abc', 'def'],
+          n: [123, 456],
+          r: [/def/g, /123/i],
+          o: ['some name', 'other name'],
+          v: [() => 1, {}],
+          u: [new URL('https://abc'), new URL('ftp://def')],
+          t: ['some text', 'other text'],
+          p: [str1, str1],
+        },
+        { sep: ',' },
+      );
       expect(str2.count).toEqual(22);
       expect(str2.strings).toEqual([
         'true,',

--- a/packages/tsargp/test/validator/validator.names.spec.ts
+++ b/packages/tsargp/test/validator/validator.names.spec.ts
@@ -137,43 +137,26 @@ describe('OptionValidator', () => {
       );
     });
 
-    it('should return a warning on option name too similar to other names', async () => {
+    it('should return a warning on mixed naming conventions in a nested command', async () => {
       const options = {
-        flag1: {
-          type: 'flag',
-          names: ['flag1'],
-        },
-        flag2: {
-          type: 'flag',
-          names: ['flag2'],
-        },
-        flag3: {
-          type: 'flag',
-          names: ['flag3'],
-        },
-      } as const satisfies Options;
-      const validator = new OptionValidator(options);
-      const flags: ValidationFlags = { detectNamingIssues: true };
-      const { warning } = await validator.validate(flags);
-      expect(warning).toHaveLength(1);
-      expect(warning?.message).toEqual(
-        `: Option name 'flag1' has too similar names: 'flag2', 'flag3'.\n`,
-      );
-    });
-
-    it('should return a warning on mixed naming conventions', async () => {
-      const options = {
-        flag1: {
-          type: 'flag',
-          names: ['lower', 'abc', 'keb-ab'],
-        },
-        flag2: {
-          type: 'flag',
-          names: ['UPPER', '-def', 'sna_ke'],
-        },
-        flag3: {
-          type: 'flag',
-          names: ['Capital', '--ghi', 'col:on'],
+        command: {
+          type: 'command',
+          names: ['-c'],
+          options: {
+            flag1: {
+              type: 'flag',
+              names: ['lower', 'abc', 'keb-ab'],
+            },
+            flag2: {
+              type: 'flag',
+              names: ['UPPER', '-def', 'sna_ke'],
+            },
+            flag3: {
+              type: 'flag',
+              names: ['Capital', '--ghi', 'col:on'],
+            },
+          },
+          exec() {},
         },
       } as const satisfies Options;
       const validator = new OptionValidator(options);
@@ -181,13 +164,13 @@ describe('OptionValidator', () => {
       const { warning } = await validator.validate(flags);
       expect(warning).toHaveLength(3);
       expect(warning?.message).toEqual(
-        `: Name slot 0 has mixed naming conventions: 'lowercase: lower', 'UPPERCASE: UPPER', 'Capitalized: Capital'.\n` +
-          `: Name slot 1 has mixed naming conventions: 'noDash: abc', '-singleDash: -def', '--doubleDash: --ghi'.\n` +
-          `: Name slot 2 has mixed naming conventions: 'kebab-case: keb-ab', 'snake_case: sna_ke', 'colon:case: col:on'.\n`,
+        `command: Name slot 0 has mixed naming conventions: 'lowercase: lower', 'UPPERCASE: UPPER', 'Capitalized: Capital'.\n` +
+          `command: Name slot 1 has mixed naming conventions: 'noDash: abc', '-singleDash: -def', '--doubleDash: --ghi'.\n` +
+          `command: Name slot 2 has mixed naming conventions: 'kebab-case: keb-ab', 'snake_case: sna_ke', 'colon:case: col:on'.\n`,
       );
     });
 
-    it('should return a warning on nested command option name too similar to other names', async () => {
+    it('should return a warning on option name too similar to other names in a nested command', async () => {
       const options = {
         command: {
           type: 'command',


### PR DESCRIPTION
Extended the connective words to include array element separators and string quoting. The new enumerators are: `optionAlt`, `optionSep`, `stringSep`, `numberSep` and `stringQuote`.

Renamed the `ConnectiveWords` enumeration to singular, and created another type for the object holding the words themselves.

Updated the Validator page to document the new connective words.

Closes #136 
