### PR TITLE
Issues/139

### DIFF
--- a/.changeset/famous-trees-smell.md
+++ b/.changeset/famous-trees-smell.md
@@ -1,0 +1,5 @@
+---
+'@trulysimple/tsargp-docs': patch
+---
+
+The Options page was updated to document the `config` and `format` attributes of help options. The Formatter page was updated to document the new organization of formatter classes.

--- a/.changeset/wild-months-bake.md
+++ b/.changeset/wild-months-bake.md
@@ -1,0 +1,5 @@
+---
+'tsargp': minor
+---
+
+The `HelpFormat` type was introduced, as well as a `JsonFormatter` class that handles formatting of help messages in JSON format.

--- a/packages/docs/components/calc.tsx
+++ b/packages/docs/components/calc.tsx
@@ -2,7 +2,7 @@
 // Imports and Exports
 //--------------------------------------------------------------------------------------------------
 import React from 'react';
-import { ArgumentParser, ErrorMessage, HelpMessage } from 'tsargp';
+import { ArgumentParser, ErrorMessage, AnsiMessage } from 'tsargp';
 import { type Props, Command } from './classes/command';
 
 // @ts-expect-error since tsargp examples do not export types
@@ -26,7 +26,7 @@ class CalcCommand extends Command {
     } catch (err) {
       if (err instanceof ErrorMessage) {
         throw err.msg.wrap(this.state.width);
-      } else if (err instanceof HelpMessage) {
+      } else if (err instanceof AnsiMessage) {
         throw err.wrap(this.state.width);
       }
       throw err;

--- a/packages/docs/components/demo.tsx
+++ b/packages/docs/components/demo.tsx
@@ -2,7 +2,7 @@
 // Imports and Exports
 //--------------------------------------------------------------------------------------------------
 import React from 'react';
-import { ArgumentParser, ErrorMessage, HelpMessage } from 'tsargp';
+import { ArgumentParser, ErrorMessage, AnsiMessage } from 'tsargp';
 import { type Props, Command } from './classes/command';
 
 // @ts-expect-error since tsargp examples do not export types
@@ -34,7 +34,7 @@ class DemoCommand extends Command {
     } catch (err) {
       if (err instanceof ErrorMessage) {
         throw err.msg.wrap(this.state.width);
-      } else if (err instanceof HelpMessage) {
+      } else if (err instanceof AnsiMessage) {
         throw err.wrap(this.state.width);
       }
       throw err;

--- a/packages/docs/components/play.tsx
+++ b/packages/docs/components/play.tsx
@@ -2,7 +2,7 @@
 // Imports and Exports
 //--------------------------------------------------------------------------------------------------
 import React from 'react';
-import { ArgumentParser, AnsiFormatter, ErrorMessage, HelpMessage } from 'tsargp';
+import { ArgumentParser, AnsiFormatter, ErrorMessage, AnsiMessage } from 'tsargp';
 import { style, req, fg8, bg8, ul8, ul } from 'tsargp';
 import { HelpItem, ErrorItem, ConnectiveWord, tf, fg, bg } from 'tsargp/enums';
 import { type Props, Command } from './classes/command';
@@ -83,7 +83,7 @@ class PlayCommand extends Command<PlayProps> {
     } catch (err) {
       if (err instanceof ErrorMessage) {
         throw err.msg.wrap(this.state.width);
-      } else if (err instanceof HelpMessage) {
+      } else if (err instanceof AnsiMessage) {
         throw err.wrap(this.state.width);
       }
       throw err;

--- a/packages/docs/components/play.tsx
+++ b/packages/docs/components/play.tsx
@@ -2,13 +2,14 @@
 // Imports and Exports
 //--------------------------------------------------------------------------------------------------
 import React from 'react';
-import { ArgumentParser, ErrorMessage, HelpMessage } from 'tsargp';
+import { ArgumentParser, AnsiFormatter, ErrorMessage, HelpMessage } from 'tsargp';
 import { style, req, fg8, bg8, ul8, ul } from 'tsargp';
 import { HelpItem, ErrorItem, ConnectiveWord, tf, fg, bg } from 'tsargp/enums';
 import { type Props, Command } from './classes/command';
 
 const tsargp = {
   ArgumentParser,
+  AnsiFormatter,
   req,
   tf,
   fg,

--- a/packages/docs/pages/docs/guides/help.mdx
+++ b/packages/docs/pages/docs/guides/help.mdx
@@ -54,14 +54,14 @@ export default {
 } as const satisfies Options;
 ```
 
-You may also want to customize the help message format, e.g.:
+You may also want to customize the formatter configuration, e.g.:
 
 ```ts
 import { type Options, HelpItem, style, tf } from 'tsargp';
 export default {
   help: {
     // ...
-    format: {
+    config: {
       names: { indent: 4 }, // indent option names by 4 spaces
       descr: { breaks: 1 }, // line feed before option descriptions
       param: { hidden: true }, // hide option parameter/examples

--- a/packages/docs/pages/docs/index.mdx
+++ b/packages/docs/pages/docs/index.mdx
@@ -115,7 +115,7 @@ Optionally, enable word completion:
   </Tabs.Tab>
 </Tabs>
 
-[^1]: ~33KB minified
+[^1]: ~34KB minified
 
 [SGR]: https://www.wikiwand.com/en/ANSI_escape_code#SGR_(Select_Graphic_Rendition)_parameters
 [meow]: https://www.npmjs.com/package/meow

--- a/packages/docs/pages/docs/library/formatter.mdx
+++ b/packages/docs/pages/docs/library/formatter.mdx
@@ -6,13 +6,13 @@ import { Callout } from 'nextra/components';
 
 # Formatter
 
-The `HelpFormatter` class is the base class for components that handle formatting of help messages.
-The concrete classes can be instantiated with a [validator] instance and provide methods to format
-help messages.
+The `HelpFormatter` is an interface for components that handle formatting of help messages. Concrete
+classes implementing this interface can be instantiated with a [validator] instance and provide
+methods to format help messages.
 
 ## Help format
 
-There are four concrete classes of formatter, each one handling a different help message format:
+There are two concrete classes of formatter, each one handling a different help message format:
 
 - `AnsiFormatter` -
   formats help messages in ANSI format, i.e., they may contain escape sequences and are meant to be
@@ -20,11 +20,6 @@ There are four concrete classes of formatter, each one handling a different help
 - `JsonFormatter` -
   formats help messages in JSON format, i.e., they are meant to be processed by introspection tools
   and other applications
-- `MdFormatter` -
-  formats help messages in Markdown format, i.e., they are meant to be processed by documentation
-  tools, or to be versioned with the code
-- `CsvFormatter` -
-  formats help messages in CSV format, i.e., they are meant to be processed by other applications
 
 <Callout type="warning">
   Everything contained in this page relates to the `AnsiFormatter` class.

--- a/packages/docs/pages/docs/library/formatter.mdx
+++ b/packages/docs/pages/docs/library/formatter.mdx
@@ -6,12 +6,13 @@ import { Callout } from 'nextra/components';
 
 # Formatter
 
-The formatter classes are the components that handle formatting of help messages. They can be
-instantiated with a [validator] instance and provide methods to format help messages.
+The `HelpFormatter` class is the base class for components that handle formatting of help messages.
+The concrete classes can be instantiated with a [validator] instance and provide methods to format
+help messages.
 
 ## Help format
 
-There are four classes of formatter, each one handling a different help format:
+There are four concrete classes of formatter, each one handling a different help message format:
 
 - `AnsiFormatter` -
   formats help messages in ANSI format, i.e., they may contain escape sequences and are meant to be

--- a/packages/docs/pages/docs/library/formatter.mdx
+++ b/packages/docs/pages/docs/library/formatter.mdx
@@ -7,8 +7,8 @@ import { Callout } from 'nextra/components';
 # Formatter
 
 The `HelpFormatter` is an interface for components that handle formatting of help messages. Concrete
-classes implementing this interface can be instantiated with a [validator] instance and provide
-methods to format help messages.
+classes implementing it can be instantiated with a [validator] instance and provide methods to
+format help messages.
 
 ## Help format
 

--- a/packages/docs/pages/docs/library/formatter.mdx
+++ b/packages/docs/pages/docs/library/formatter.mdx
@@ -6,8 +6,28 @@ import { Callout } from 'nextra/components';
 
 # Formatter
 
-The `HelpFormatter` class is the component that handles the formatting of help messages. It can be
-instantiated with a [validator] instance and provides methods to format help messages.
+The formatter classes are the components that handle formatting of help messages. They can be
+instantiated with a [validator] instance and provide methods to format help messages.
+
+## Help format
+
+There are four classes of formatter, each one handling a different help format:
+
+- `AnsiFormatter` -
+  formats help messages in ANSI format, i.e., they may contain escape sequences and are meant to be
+  printed in a terminal
+- `JsonFormatter` -
+  formats help messages in JSON format, i.e., they are meant to be processed by introspection tools
+  and other applications
+- `MdFormatter` -
+  formats help messages in Markdown format, i.e., they are meant to be processed by documentation
+  tools, or to be versioned with the code
+- `CsvFormatter` -
+  formats help messages in CSV format, i.e., they are meant to be processed by other applications
+
+<Callout type="warning">
+  Everything contained in this page relates to the `AnsiFormatter` class.
+</Callout>
 
 ## Help message
 
@@ -166,7 +186,7 @@ properties], it has the following properties:
 - `filter` - a list of group names to include or exclude (defaults to including all groups)
 - `exclude` - whether the filter should exclude (defaults to `false{:ts}`)
 
-## Help format
+## Formatter configuration
 
 In addition to the validator instance, the formatter constructor accepts a `FormatterConfig` object
 that can be used to customize the format of help entries in option groups. This configuration will

--- a/packages/docs/pages/docs/library/options.mdx
+++ b/packages/docs/pages/docs/library/options.mdx
@@ -498,8 +498,8 @@ The `config` attribute specifies a custom [formatter configuration].
 
 #### Help format
 
-The `format` attribute specifies the [help format]. Can be one of `'ansi'{:ts}` (the default),
-`'json'{:ts}`, `'md'{:ts}` or `'csv'{:ts}`.
+The `format` attribute specifies the [help format]. Can be one of `'ansi'{:ts}` (the default) or
+`'json'{:ts}`.
 
 #### Help sections
 

--- a/packages/docs/pages/docs/library/options.mdx
+++ b/packages/docs/pages/docs/library/options.mdx
@@ -486,15 +486,20 @@ Niladic options do not expect any parameter on the command-line. With the notabl
 ### Help option
 
 The **help** option is a convenient specialization of the [function option] that handles the
-formatting of help messages. Internally, it instantiates a [help formatter] class with the provided
+formatting of help messages. Internally, it instantiates a [formatter] class with the provided
 configuration, obtains a formatted message and throws it. The application is responsible for
 catching this message and printing it in a terminal.
 
 In addition to the set of [basic attributes], this option has the attributes described below.
 
+#### Formatter config
+
+The `config` attribute specifies a custom [formatter configuration].
+
 #### Help format
 
-The `format` attribute specifies a custom [formatter configuration].
+The `format` attribute specifies the [help format]. Can be one of `'ansi'{:ts}` (the default),
+`'json'{:ts}`, `'md'{:ts}` or `'csv'{:ts}`.
 
 #### Help sections
 
@@ -900,7 +905,7 @@ attributes:
 [parameter count]: #parameter-count
 [enable filter]: #enable-filter
 [skip count]: #skip-count
-[help formatter]: formatter
+[formatter]: formatter
 [commands guide]: ../guides/commands
 [recursive commands]: ../guides/commands#advanced-features
 [styling]: styles#styling-attributes
@@ -909,7 +914,8 @@ attributes:
 [warning message]: styles#warning-message
 [word completion]: parser#word-completion
 [completion algorithm]: parser#completion-algorithm
-[formatter configuration]: formatter#help-format
+[formatter configuration]: formatter#formatter-configuration
+[help format]: formatter#help-format
 [help sections]: formatter#help-sections
 [usage section]: formatter#usage-section
 [groups section]: formatter#groups-section

--- a/packages/docs/pages/docs/library/styles.mdx
+++ b/packages/docs/pages/docs/library/styles.mdx
@@ -242,12 +242,29 @@ A terminal string has an optional flag that indicates whether the text should be
 terminal's right boundary when being wrapped. This feature is used by the formatter in the help
 message's [description column].
 
-## Terminal messages
+## Messages
 
-The `TerminalMessage` is a base class that wraps a list of terminal strings. It provides a `wrap`
-method to get a normal string compiled from the list. This method accepts two optional parameters:
+There are different kinds of text content that an application might print in a terminal. We call
+them "messages" and provide a specific class for each kind of message that the library may produce.
+For convenience, all message classes have a `toString` method and a `message` property, both of
+which can be used to obtain a normal `string{:ts}`.
 
-- `width` - the terminal width (defaults to `0{:ts}`, i.e., no wrapping)
+<Callout type="default">
+  All messages produced by the library are instances of one of the classes described below. So you
+  can check the kind of a captured message through `instanceof{:ts}`.
+</Callout>
+
+### User-facing messages
+
+These messages are meant to be consumed by humans. Each kind of message uses a default terminal
+width to render the resulting string. They are described below.
+
+#### ANSI message
+
+The `AnsiMessage` is a base class that wraps a list of terminal strings. It provides a `wrap` method
+to get a normal string compiled from the list. This method accepts two optional parameters:
+
+- `width` - the terminal width
 - `emitStyles` - whether styles should be emitted
 
 The default value of `emitStyles` depends on a few environment variables:
@@ -266,55 +283,46 @@ preserve the disposition of wrapped text.
   manipulate them before converting the message to string.
 </Callout>
 
-### Default width
-
-In addition to providing a `wrap` method, the terminal message overrides the `toString` method and
-has a convenient `message` property, both of which can be used to obtain a string wrapped with a
-default terminal width.
-
-The default width depends on the kind of message: in the case of `TerminalMessage`, it is the width
-of the standard _output_ stream (`process.stdout.columns{:ts}`). Therefore, this kind of message
-should be printed with `console.log` or equivalent, unless you are calling `wrap` directly.
+The default terminal width used by this class is that of the standard _output_ stream
+(`process.stdout.columns{:ts}`). Therefore, this kind of message should be printed with
+`console.log` or equivalent, unless you are calling `wrap` directly.
 
 <Callout type="info">
   When redirecting the output of a command (e.g., writing to a file or piping to another command),
-  the associated stream will not have a `columns` property. Hence, if `stdout` is being redirected,
-  the default value used by the above procedure will be `undefined{:ts}` (thus disabling wrapping
-  and, possibly, omitting styles).
+  the associated stream will not have a `columns` property, thus disabling wrapping and, possibly,
+  omitting styles.
 </Callout>
 
-### Help message
+#### Warning message
 
-The `HelpMessage` class is analog to the above one, but used specifically for help messages. It
-should be printed with `console.log` or equivalent.
+The `WarnMessage` class is a specialization of the ANSI message that uses the width of the standard
+_error_ stream (`process.stderr.columns{:ts}`) by default. It should be printed with `console.error`
+or equivalent.
 
-### Warning message
-
-The `WarnMessage` class is a specialization of a terminal message that uses the width of the
-standard _error_ stream (`process.stderr.columns{:ts}`) by default. It should be printed with
-`console.error` or equivalent.
-
-### Error message
+#### Error message
 
 The `ErrorMessage` class is a specialization of a warning message that actually derives from the
 standard `Error` class. It should be printed with `console.error` or equivalent.
 
-### Completion message
-
-The `CompletionMessage` class represents a list of completion words. It has no wrapping: instead,
-it produces a string with words separated by line feeds. It should be printed with `console.log` or
-equivalent.
-
-### Version message
+#### Version message
 
 A version message is a plain `string{:ts}`, so it has no wrapping. However, it may be remodeled in
 future versions of the library to accommodate new features. It should be printed with `console.log`
 or equivalent.
 
-<Callout type="default">
-  Messages produced by the library are instances of one of the classes described above. So you
-  can check the kind of a captured message through `instanceof{:ts}`.
-</Callout>
+### Machine-readable messages
+
+#### JSON message
+
+The `JsonMessage` class represents a message in the JSON format. It is intended for consumption by
+introspection tools and other text-processing applications. It should be printed with
+`console.log` or equivalent.
+
+#### Completion message
+
+The `CompMessage` class represents a list of completion words. It is meant to be consumed by the
+completion builtins. It produces a string with words separated by line feeds and should be printed
+with `console.log` or equivalent.
 
 [parser]: parser
 [validator]: validator

--- a/packages/docs/pages/play.mdx
+++ b/packages/docs/pages/play.mdx
@@ -5,7 +5,7 @@ export const Play = dynamic(() => import('@components/play'), { ssr: false });
 export const Code = dynamic(() => import('@components/code'), { ssr: false });
 export const callbacks = {};
 export const initialDoc = `const {
-  ArgumentParser, HelpItem, ErrorItem, ConnectiveWord,
+  ArgumentParser, AnsiFormatter, HelpItem, ErrorItem, ConnectiveWord,
   req, tf, fg, bg, ul, style, fg8, bg8, ul8,
 } = tsargp;
 // Define your options here. Only plain JavaScript is allowed.

--- a/packages/docs/typedoc.json
+++ b/packages/docs/typedoc.json
@@ -8,6 +8,7 @@
   "excludeExternals": true,
   "treatWarningsAsErrors": true,
   "intentionallyNotExported": [
+    "helpFormats",
     "HelpEntry",
     "HelpContext",
     "TerminalContext",

--- a/packages/tsargp/examples/demo.options.ts
+++ b/packages/tsargp/examples/demo.options.ts
@@ -91,6 +91,7 @@ Report a bug: ${style(tf.faint)}https://github.com/trulysimple/tsargp/issues`,
     ],
     useFilter: true,
     useNested: true,
+    useFormat: true,
   },
   /**
    * A version option that throws the package version.

--- a/packages/tsargp/lib/options.ts
+++ b/packages/tsargp/lib/options.ts
@@ -1,7 +1,7 @@
 //--------------------------------------------------------------------------------------------------
 // Imports
 //--------------------------------------------------------------------------------------------------
-import type { FormatterConfig, HelpSections } from './formatter';
+import type { FormatterConfig, HelpFormat, HelpSections } from './formatter';
 import type { HelpMessage, Style } from './styles';
 import type { Resolve, URL, KeyHaving, Range } from './utils';
 
@@ -521,7 +521,11 @@ export type WithHelp = {
   /**
    * The formatter configuration.
    */
-  readonly format?: FormatterConfig;
+  readonly config?: FormatterConfig;
+  /**
+   * The help format. (Defaults to 'ansi')
+   */
+  readonly format?: HelpFormat;
   /**
    * The help sections to be rendered.
    */

--- a/packages/tsargp/lib/options.ts
+++ b/packages/tsargp/lib/options.ts
@@ -523,10 +523,6 @@ export type WithHelp = {
    */
   readonly config?: FormatterConfig;
   /**
-   * The help format. (Defaults to 'ansi')
-   */
-  readonly format?: HelpFormat;
-  /**
    * The help sections to be rendered.
    */
   readonly sections?: HelpSections;
@@ -535,9 +531,17 @@ export type WithHelp = {
    */
   readonly useFilter?: true;
   /**
-   * Whether to throw the help of a nested command whose names include the next argument.
+   * Whether to use the next argument as the name of a command for which the help should be created.
    */
   readonly useNested?: true;
+  /**
+   * Whether to use the next argument as the name of a help format.
+   */
+  readonly useFormat?: true;
+  /**
+   * The help format. (Defaults to 'ansi')
+   */
+  format?: HelpFormat;
 };
 
 /**

--- a/packages/tsargp/lib/parser.ts
+++ b/packages/tsargp/lib/parser.ts
@@ -21,7 +21,7 @@ import type {
 } from './validator';
 
 import { ConnectiveWord, ErrorItem } from './enums';
-import { HelpFormatter, HelpSections } from './formatter';
+import { AnsiFormatter, HelpSections } from './formatter';
 import { RequiresAll, RequiresNot, RequiresOne, isOpt, getParamCount } from './options';
 import { format, HelpMessage, WarnMessage, CompletionMessage, TerminalString } from './styles';
 import { areEqual, findSimilar, getArgs, isTrue, max, findInObject, env } from './utils';
@@ -849,11 +849,11 @@ async function handleHelp(
       }
     }
   }
-  const format = option.format ?? {};
+  const config = option.config ?? {};
   if (option.useFilter) {
-    format.filter = rest;
+    config.filter = rest;
   }
-  const formatter = new HelpFormatter(validator, format);
+  const formatter = new AnsiFormatter(validator, config);
   const sections = option.sections ?? defaultSections;
   return formatter.formatSections(sections, progName);
 }

--- a/packages/tsargp/lib/parser.ts
+++ b/packages/tsargp/lib/parser.ts
@@ -157,7 +157,6 @@ export class ArgumentParser<T extends Options = Options> {
     values: OptionValues<T>,
     cmdLine = env('COMP_LINE') ?? env('BUFFER') ?? process?.argv.slice(2) ?? [],
     flags: ParsingFlags = {
-      progName: process?.argv[1].split(/[\\/]/).at(-1),
       compIndex: Number(env('COMP_POINT') ?? env('CURSOR')) || env('BUFFER')?.length,
     },
   ): Promise<ParsingResult> {
@@ -204,7 +203,7 @@ async function doParse(
   values: OpaqueOptionValues,
   args: Array<string>,
   completing: boolean,
-  progName?: string,
+  progName = process?.argv[1].split(/[\\/]/).at(-1),
   clusterPrefix?: string,
 ): Promise<ParsingResult> {
   if (!completing && progName && process?.title) {

--- a/packages/tsargp/lib/parser.ts
+++ b/packages/tsargp/lib/parser.ts
@@ -22,7 +22,7 @@ import type {
 } from './validator';
 
 import { ConnectiveWord, ErrorItem } from './enums';
-import { HelpFormatter, isHelpFormat } from './formatter';
+import { createFormatter, isHelpFormat } from './formatter';
 import { RequiresAll, RequiresNot, RequiresOne, isOpt, getParamCount } from './options';
 import { format, WarnMessage, CompMessage, TerminalString } from './styles';
 import { areEqual, findSimilar, getArgs, isTrue, max, findInObject, env } from './utils';
@@ -860,7 +860,7 @@ async function handleHelp(
   if (option.useFilter) {
     config.filter = rest;
   }
-  const formatter = HelpFormatter.create(validator, config, option.format);
+  const formatter = createFormatter(validator, config, option.format);
   const sections = option.sections ?? defaultSections;
   return formatter.formatSections(sections, progName);
 }

--- a/packages/tsargp/lib/styles.ts
+++ b/packages/tsargp/lib/styles.ts
@@ -342,7 +342,7 @@ export class TerminalString {
   /**
    * The terminal string context.
    */
-  private context: TerminalContext;
+  private readonly context: TerminalContext;
 
   /**
    * @returns The list of internal strings

--- a/packages/tsargp/lib/styles.ts
+++ b/packages/tsargp/lib/styles.ts
@@ -689,18 +689,12 @@ export class AnsiMessage extends Array<TerminalString> {
 /**
  * A JSON message.
  */
-export class JsonMessage {
-  /**
-   * Creates a JSON message.
-   * @param value The JSON value
-   */
-  constructor(private readonly value: object = {}) {}
-
+export class JsonMessage extends Array<object> {
   /**
    * @returns The wrapped message
    */
   toString(): string {
-    return JSON.stringify(this.value);
+    return JSON.stringify(this);
   }
 
   /**

--- a/packages/tsargp/lib/styles.ts
+++ b/packages/tsargp/lib/styles.ts
@@ -43,6 +43,7 @@ const underlineStyle = {
 
 /**
  * The formatting functions.
+ * @internal
  */
 const formatFunctions = {
   /**
@@ -203,9 +204,14 @@ export type FormatCallback<T = string> = (this: TerminalString, arg: T) => void;
 export type FormatArgs = Record<string, unknown>;
 
 /**
+ * A help message.
+ */
+export type HelpMessage = AnsiMessage | JsonMessage;
+
+/**
  * A message that can be printed on a terminal.
  */
-export type Message = ErrorMessage | HelpMessage | WarnMessage | CompletionMessage;
+export type Message = ErrorMessage | HelpMessage | WarnMessage | CompMessage;
 
 /**
  * A set of styles for terminal messages.
@@ -644,9 +650,9 @@ export class TerminalString {
 }
 
 /**
- * A terminal message. Used as base for other message classes.
+ * An ANSI message. Used as base for other message classes.
  */
-export class TerminalMessage extends Array<TerminalString> {
+export class AnsiMessage extends Array<TerminalString> {
   /**
    * Wraps the help message to a specified width.
    * @param width The terminal width (or zero to avoid wrapping)
@@ -681,14 +687,34 @@ export class TerminalMessage extends Array<TerminalString> {
 }
 
 /**
- * A help message.
+ * A JSON message.
  */
-export class HelpMessage extends TerminalMessage {}
+export class JsonMessage {
+  /**
+   * Creates a JSON message.
+   * @param value The JSON value
+   */
+  constructor(private readonly value: object = {}) {}
+
+  /**
+   * @returns The wrapped message
+   */
+  toString(): string {
+    return JSON.stringify(this.value);
+  }
+
+  /**
+   * @returns The wrapped message
+   */
+  get message(): string {
+    return this.toString();
+  }
+}
 
 /**
  * A warning message.
  */
-export class WarnMessage extends TerminalMessage {
+export class WarnMessage extends AnsiMessage {
   /**
    * @returns The wrapped message
    */
@@ -704,7 +730,7 @@ export class ErrorMessage extends Error {
   /**
    * The terminal message.
    */
-  readonly msg: TerminalMessage;
+  readonly msg: AnsiMessage;
 
   /**
    * Creates an error message
@@ -734,7 +760,7 @@ export class ErrorMessage extends Error {
 /**
  * A completion message.
  */
-export class CompletionMessage extends Array<string> {
+export class CompMessage extends Array<string> {
   /**
    * @returns The wrapped message
    */

--- a/packages/tsargp/lib/validator.ts
+++ b/packages/tsargp/lib/validator.ts
@@ -95,7 +95,6 @@ export const defaultConfig: ConcreteConfig = {
 
 /**
  * The naming convention rules.
- * @internal
  */
 const namingConventions: NamingRules = {
   cases: {

--- a/packages/tsargp/test/formatter/formatter.constraints.spec.ts
+++ b/packages/tsargp/test/formatter/formatter.constraints.spec.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from 'vitest';
-import { type Options, HelpFormatter, OptionValidator } from '../../lib';
+import { type Options, AnsiFormatter, OptionValidator } from '../../lib';
 import '../utils.spec'; // initialize globals
 
-describe('HelpFormatter', () => {
+describe('AnsiFormatter', () => {
   describe('formatHelp', () => {
     it('should handle a boolean option with truth names', () => {
       const options = {
@@ -13,7 +13,7 @@ describe('HelpFormatter', () => {
           truthNames: ['true', 'yes'],
         },
       } as const satisfies Options;
-      const message = new HelpFormatter(new OptionValidator(options)).formatHelp();
+      const message = new AnsiFormatter(new OptionValidator(options)).formatHelp();
       expect(message.wrap()).toEqual(
         `  -b, --boolean  <boolean>  A boolean option. Values must be one of {'true', 'yes'}.\n`,
       );
@@ -28,7 +28,7 @@ describe('HelpFormatter', () => {
           falsityNames: ['false', 'no'],
         },
       } as const satisfies Options;
-      const message = new HelpFormatter(new OptionValidator(options)).formatHelp();
+      const message = new AnsiFormatter(new OptionValidator(options)).formatHelp();
       expect(message.wrap()).toEqual(
         `  -b, --boolean  <boolean>  A boolean option. Values must be one of {'false', 'no'}.\n`,
       );
@@ -44,7 +44,7 @@ describe('HelpFormatter', () => {
           falsityNames: ['false'],
         },
       } as const satisfies Options;
-      const message = new HelpFormatter(new OptionValidator(options)).formatHelp();
+      const message = new AnsiFormatter(new OptionValidator(options)).formatHelp();
       expect(message.wrap()).toEqual(
         `  -b, --boolean  <boolean>  A boolean option. Values must be one of {'true', 'false'}.\n`,
       );
@@ -59,7 +59,7 @@ describe('HelpFormatter', () => {
           enums: ['one', 'two'],
         },
       } as const satisfies Options;
-      const message = new HelpFormatter(new OptionValidator(options)).formatHelp();
+      const message = new AnsiFormatter(new OptionValidator(options)).formatHelp();
       expect(message.wrap()).toEqual(
         `  -s, --string  <string>  A string option. Values must be one of {'one', 'two'}.\n`,
       );
@@ -74,7 +74,7 @@ describe('HelpFormatter', () => {
           regex: /\d+/s,
         },
       } as const satisfies Options;
-      const message = new HelpFormatter(new OptionValidator(options)).formatHelp();
+      const message = new AnsiFormatter(new OptionValidator(options)).formatHelp();
       expect(message.wrap()).toEqual(
         `  -s, --string  <string>  A string option. Values must match the regex /\\d+/s.\n`,
       );
@@ -89,7 +89,7 @@ describe('HelpFormatter', () => {
           enums: [1, 2],
         },
       } as const satisfies Options;
-      const message = new HelpFormatter(new OptionValidator(options)).formatHelp();
+      const message = new AnsiFormatter(new OptionValidator(options)).formatHelp();
       expect(message.wrap()).toEqual(
         `  -n, --number  <number>  A number option. Values must be one of {1, 2}.\n`,
       );
@@ -104,7 +104,7 @@ describe('HelpFormatter', () => {
           range: [0, Infinity],
         },
       } as const satisfies Options;
-      const message = new HelpFormatter(new OptionValidator(options)).formatHelp();
+      const message = new AnsiFormatter(new OptionValidator(options)).formatHelp();
       expect(message.wrap()).toEqual(
         `  -n, --number  <number>  A number option. Values must be in the range [0, Infinity].\n`,
       );
@@ -119,7 +119,7 @@ describe('HelpFormatter', () => {
           regex: /\d+/s,
         },
       } as const satisfies Options;
-      const message = new HelpFormatter(new OptionValidator(options)).formatHelp();
+      const message = new AnsiFormatter(new OptionValidator(options)).formatHelp();
       expect(message.wrap()).toEqual(
         `  -ss, --strings  <strings>...  A strings option. Accepts multiple parameters. Values must match the regex /\\d+/s.\n`,
       );
@@ -134,7 +134,7 @@ describe('HelpFormatter', () => {
           range: [0, Infinity],
         },
       } as const satisfies Options;
-      const message = new HelpFormatter(new OptionValidator(options)).formatHelp();
+      const message = new AnsiFormatter(new OptionValidator(options)).formatHelp();
       expect(message.wrap()).toEqual(
         `  -ns, --numbers  <numbers>...  A numbers option. Accepts multiple parameters. Values must be in the range [0, Infinity].\n`,
       );
@@ -149,7 +149,7 @@ describe('HelpFormatter', () => {
           limit: 2,
         },
       } as const satisfies Options;
-      const message = new HelpFormatter(new OptionValidator(options)).formatHelp();
+      const message = new AnsiFormatter(new OptionValidator(options)).formatHelp();
       expect(message.wrap()).toEqual(
         `  -ss, --strings  <strings>...  A strings option. Accepts multiple parameters. Value count is limited to 2.\n`,
       );
@@ -164,7 +164,7 @@ describe('HelpFormatter', () => {
           limit: 2,
         },
       } as const satisfies Options;
-      const message = new HelpFormatter(new OptionValidator(options)).formatHelp();
+      const message = new AnsiFormatter(new OptionValidator(options)).formatHelp();
       expect(message.wrap()).toEqual(
         `  -ns, --numbers  <numbers>...  A numbers option. Accepts multiple parameters. Value count is limited to 2.\n`,
       );
@@ -179,7 +179,7 @@ describe('HelpFormatter', () => {
           enums: ['one', 'two'],
         },
       } as const satisfies Options;
-      const message = new HelpFormatter(new OptionValidator(options)).formatHelp();
+      const message = new AnsiFormatter(new OptionValidator(options)).formatHelp();
       expect(message.wrap()).toEqual(
         `  -ss, --strings  <strings>...  A strings option. Accepts multiple parameters. Values must be one of {'one', 'two'}.\n`,
       );
@@ -194,7 +194,7 @@ describe('HelpFormatter', () => {
           enums: [1, 2],
         },
       } as const satisfies Options;
-      const message = new HelpFormatter(new OptionValidator(options)).formatHelp();
+      const message = new AnsiFormatter(new OptionValidator(options)).formatHelp();
       expect(message.wrap()).toEqual(
         `  -ns, --numbers  <numbers>...  A numbers option. Accepts multiple parameters. Values must be one of {1, 2}.\n`,
       );

--- a/packages/tsargp/test/formatter/formatter.default.spec.ts
+++ b/packages/tsargp/test/formatter/formatter.default.spec.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from 'vitest';
-import { type Options, HelpFormatter, OptionValidator } from '../../lib';
+import { type Options, AnsiFormatter, OptionValidator } from '../../lib';
 import '../utils.spec'; // initialize globals
 
-describe('HelpFormatter', () => {
+describe('AnsiFormatter', () => {
   describe('formatHelp', () => {
     it('should handle a function option with a default value', () => {
       const options = {
@@ -14,7 +14,7 @@ describe('HelpFormatter', () => {
           default: 'abc',
         },
       } as const satisfies Options;
-      const message = new HelpFormatter(new OptionValidator(options)).formatHelp();
+      const message = new AnsiFormatter(new OptionValidator(options)).formatHelp();
       expect(message.wrap()).toEqual(`  -f, --function    A function option. Defaults to 'abc'.\n`);
     });
 
@@ -28,7 +28,7 @@ describe('HelpFormatter', () => {
           default: () => 0,
         },
       } as const satisfies Options;
-      const message = new HelpFormatter(new OptionValidator(options)).formatHelp();
+      const message = new AnsiFormatter(new OptionValidator(options)).formatHelp();
       expect(message.wrap()).toEqual(
         `  -f, --function    A function option. Defaults to <() => 0>.\n`,
       );
@@ -45,7 +45,7 @@ describe('HelpFormatter', () => {
           default: true,
         },
       } as const satisfies Options;
-      const message = new HelpFormatter(new OptionValidator(options)).formatHelp();
+      const message = new AnsiFormatter(new OptionValidator(options)).formatHelp();
       expect(message.wrap()).toEqual(`  -f, --command  ...  A command option. Defaults to true.\n`);
     });
 
@@ -60,7 +60,7 @@ describe('HelpFormatter', () => {
           default: () => 0,
         },
       } as const satisfies Options;
-      const message = new HelpFormatter(new OptionValidator(options)).formatHelp();
+      const message = new AnsiFormatter(new OptionValidator(options)).formatHelp();
       expect(message.wrap()).toEqual(
         `  -f, --command  ...  A command option. Defaults to <() => 0>.\n`,
       );
@@ -75,7 +75,7 @@ describe('HelpFormatter', () => {
           default: true,
         },
       } as const satisfies Options;
-      const message = new HelpFormatter(new OptionValidator(options)).formatHelp();
+      const message = new AnsiFormatter(new OptionValidator(options)).formatHelp();
       expect(message.wrap()).toEqual(`  -f, --flag    A flag option. Defaults to true.\n`);
     });
 
@@ -88,7 +88,7 @@ describe('HelpFormatter', () => {
           default: () => true,
         },
       } as const satisfies Options;
-      const message = new HelpFormatter(new OptionValidator(options)).formatHelp();
+      const message = new AnsiFormatter(new OptionValidator(options)).formatHelp();
       expect(message.wrap()).toMatch(
         / {2}-f, --flag {4}A flag option\. Defaults to <\(\) => (true|!0)>\.\n$/,
       );
@@ -104,7 +104,7 @@ describe('HelpFormatter', () => {
         },
       } as const satisfies Options;
       options.flag.default.toString = () => 'fcn';
-      const message = new HelpFormatter(new OptionValidator(options)).formatHelp();
+      const message = new AnsiFormatter(new OptionValidator(options)).formatHelp();
       expect(message.wrap()).toEqual(`  -f, --flag    A flag option. Defaults to <fcn>.\n`);
     });
 
@@ -117,7 +117,7 @@ describe('HelpFormatter', () => {
           default: true,
         },
       } as const satisfies Options;
-      const message = new HelpFormatter(new OptionValidator(options)).formatHelp();
+      const message = new AnsiFormatter(new OptionValidator(options)).formatHelp();
       expect(message.wrap()).toEqual(
         `  -b, --boolean  <boolean>  A boolean option. Defaults to true.\n`,
       );
@@ -132,7 +132,7 @@ describe('HelpFormatter', () => {
           default: () => true,
         },
       } as const satisfies Options;
-      const message = new HelpFormatter(new OptionValidator(options)).formatHelp();
+      const message = new AnsiFormatter(new OptionValidator(options)).formatHelp();
       expect(message.wrap()).toMatch(
         / {2}-b, --boolean {2}<boolean> {2}A boolean option\. Defaults to <\(\) => (true|!0)>\.\n$/,
       );
@@ -147,7 +147,7 @@ describe('HelpFormatter', () => {
           default: '123',
         },
       } as const satisfies Options;
-      const message = new HelpFormatter(new OptionValidator(options)).formatHelp();
+      const message = new AnsiFormatter(new OptionValidator(options)).formatHelp();
       expect(message.wrap()).toEqual(
         `  -s, --string  <string>  A string option. Defaults to '123'.\n`,
       );
@@ -162,7 +162,7 @@ describe('HelpFormatter', () => {
           default: () => '123',
         },
       } as const satisfies Options;
-      const message = new HelpFormatter(new OptionValidator(options)).formatHelp();
+      const message = new AnsiFormatter(new OptionValidator(options)).formatHelp();
       expect(message.wrap()).toEqual(
         `  -s, --string  <string>  A string option. Defaults to <() => "123">.\n`,
       );
@@ -177,7 +177,7 @@ describe('HelpFormatter', () => {
           default: 123,
         },
       } as const satisfies Options;
-      const message = new HelpFormatter(new OptionValidator(options)).formatHelp();
+      const message = new AnsiFormatter(new OptionValidator(options)).formatHelp();
       expect(message.wrap()).toEqual(
         `  -n, --number  <number>  A number option. Defaults to 123.\n`,
       );
@@ -192,7 +192,7 @@ describe('HelpFormatter', () => {
           default: () => 123,
         },
       } as const satisfies Options;
-      const message = new HelpFormatter(new OptionValidator(options)).formatHelp();
+      const message = new AnsiFormatter(new OptionValidator(options)).formatHelp();
       expect(message.wrap()).toEqual(
         `  -n, --number  <number>  A number option. Defaults to <() => 123>.\n`,
       );
@@ -207,7 +207,7 @@ describe('HelpFormatter', () => {
           default: ['one', 'two'],
         },
       } as const satisfies Options;
-      const message = new HelpFormatter(new OptionValidator(options)).formatHelp();
+      const message = new AnsiFormatter(new OptionValidator(options)).formatHelp();
       expect(message.wrap()).toEqual(
         `  -ss, --strings  <strings>...  A strings option. Accepts multiple parameters. Defaults to ['one', 'two'].\n`,
       );
@@ -222,7 +222,7 @@ describe('HelpFormatter', () => {
           default: () => ['one', 'two'],
         },
       } as const satisfies Options;
-      const message = new HelpFormatter(new OptionValidator(options)).formatHelp();
+      const message = new AnsiFormatter(new OptionValidator(options)).formatHelp();
       expect(message.wrap()).toEqual(
         `  -ss, --strings  <strings>...  A strings option. Accepts multiple parameters. Defaults to <() => ["one", "two"]>.\n`,
       );
@@ -237,7 +237,7 @@ describe('HelpFormatter', () => {
           default: [1, 2],
         },
       } as const satisfies Options;
-      const message = new HelpFormatter(new OptionValidator(options)).formatHelp();
+      const message = new AnsiFormatter(new OptionValidator(options)).formatHelp();
       expect(message.wrap()).toMatch(
         `  -ns, --numbers  <numbers>...  A numbers option. Accepts multiple parameters. Defaults to [1, 2].\n`,
       );
@@ -252,7 +252,7 @@ describe('HelpFormatter', () => {
           default: () => [1, 2],
         },
       } as const satisfies Options;
-      const message = new HelpFormatter(new OptionValidator(options)).formatHelp();
+      const message = new AnsiFormatter(new OptionValidator(options)).formatHelp();
       expect(message.wrap()).toEqual(
         `  -ns, --numbers  <numbers>...  A numbers option. Accepts multiple parameters. Defaults to <() => [1, 2]>.\n`,
       );

--- a/packages/tsargp/test/formatter/formatter.formatting.spec.ts
+++ b/packages/tsargp/test/formatter/formatter.formatting.spec.ts
@@ -1,16 +1,16 @@
 import { describe, expect, it } from 'vitest';
 import type { Options, FormatterConfig } from '../../lib';
-import { HelpFormatter, OptionValidator, style, tf, fg8, ConnectiveWord } from '../../lib';
+import { AnsiFormatter, OptionValidator, style, tf, fg8, ConnectiveWord } from '../../lib';
 import { defaultConfig } from '../../lib/validator';
 import '../utils.spec'; // initialize globals
 
-describe('HelpFormatter', () => {
+describe('AnsiFormatter', () => {
   describe('formatHelp', () => {
     it('should handle an option with no names or description', () => {
       const options = {
         flag: { type: 'flag' },
       } as const satisfies Options;
-      const message = new HelpFormatter(new OptionValidator(options)).formatHelp();
+      const message = new AnsiFormatter(new OptionValidator(options)).formatHelp();
       expect(message.wrap()).toEqual('\n');
     });
 
@@ -21,7 +21,7 @@ describe('HelpFormatter', () => {
           names: [],
         },
       } as const satisfies Options;
-      const message = new HelpFormatter(new OptionValidator(options)).formatHelp();
+      const message = new AnsiFormatter(new OptionValidator(options)).formatHelp();
       expect(message.wrap()).toEqual('\n');
     });
 
@@ -32,7 +32,7 @@ describe('HelpFormatter', () => {
           names: ['-f'],
         },
       } as const satisfies Options;
-      const message = new HelpFormatter(new OptionValidator(options)).formatHelp();
+      const message = new AnsiFormatter(new OptionValidator(options)).formatHelp();
       expect(message.wrap()).toEqual('  -f\n');
     });
 
@@ -48,7 +48,7 @@ describe('HelpFormatter', () => {
           },
         },
       } as const satisfies Options;
-      const message = new HelpFormatter(new OptionValidator(options)).formatHelp();
+      const message = new AnsiFormatter(new OptionValidator(options)).formatHelp();
       expect(message.wrap()).toEqual('  -f, --flag    A flag option with custom styles\n');
     });
 
@@ -60,7 +60,7 @@ describe('HelpFormatter', () => {
           desc: `A flag option with ${style(tf.bold, fg8(123))}inline styles${style(tf.clear)}`,
         },
       } as const satisfies Options;
-      const message = new HelpFormatter(new OptionValidator(options)).formatHelp();
+      const message = new AnsiFormatter(new OptionValidator(options)).formatHelp();
       expect(message.wrap()).toEqual('  -f, --flag    A flag option with inline styles\n');
     });
 
@@ -75,7 +75,7 @@ describe('HelpFormatter', () => {
           paragraphs`,
         },
       } as const satisfies Options;
-      const message = new HelpFormatter(new OptionValidator(options)).formatHelp();
+      const message = new AnsiFormatter(new OptionValidator(options)).formatHelp();
       expect(message.wrap()).toMatch(
         /^ {2}-f, --flag {4}A flag option with line breaks, tabs and ...\n\n {16}paragraphs\n$/,
       );
@@ -92,7 +92,7 @@ describe('HelpFormatter', () => {
           1. item3`,
         },
       } as const satisfies Options;
-      const message = new HelpFormatter(new OptionValidator(options)).formatHelp();
+      const message = new AnsiFormatter(new OptionValidator(options)).formatHelp();
       expect(message.wrap()).toMatch(
         /^ {2}-f, --flag {4}A flag option with lists:\n {16}- item1\n {16}\* item2\n {16}1\. item3\n$/,
       );
@@ -107,7 +107,7 @@ describe('HelpFormatter', () => {
           hide: true,
         },
       } as const satisfies Options;
-      const message = new HelpFormatter(new OptionValidator(options)).formatHelp();
+      const message = new AnsiFormatter(new OptionValidator(options)).formatHelp();
       expect(message.wrap()).toEqual('');
     });
 
@@ -124,7 +124,7 @@ describe('HelpFormatter', () => {
         param: { breaks: -1 },
         descr: { breaks: -1 },
       };
-      const message = new HelpFormatter(new OptionValidator(options), config).formatHelp();
+      const message = new AnsiFormatter(new OptionValidator(options), config).formatHelp();
       expect(message.wrap()).toEqual('  -b, --boolean  <boolean>  A boolean option\n');
     });
 
@@ -141,7 +141,7 @@ describe('HelpFormatter', () => {
         param: { breaks: 1 },
         descr: { breaks: 1 },
       };
-      const message = new HelpFormatter(new OptionValidator(options), config).formatHelp();
+      const message = new AnsiFormatter(new OptionValidator(options), config).formatHelp();
       expect(message.wrap()).toMatch(
         /^\n {2}-b, --boolean\n {17}<boolean>\n {28}A boolean option\n$/,
       );
@@ -160,7 +160,7 @@ describe('HelpFormatter', () => {
         param: { breaks: 1, absolute: true },
         descr: { breaks: 1, absolute: true },
       };
-      const message = new HelpFormatter(new OptionValidator(options), config).formatHelp();
+      const message = new AnsiFormatter(new OptionValidator(options), config).formatHelp();
       expect(message.wrap()).toMatch(
         /^\n {2}-b, --boolean\n {2}<boolean>\n {2}A boolean option\n$/,
       );
@@ -179,7 +179,7 @@ describe('HelpFormatter', () => {
         param: { breaks: 1, indent: -1 },
         descr: { breaks: 1, indent: -1 },
       };
-      const message = new HelpFormatter(new OptionValidator(options), config).formatHelp();
+      const message = new AnsiFormatter(new OptionValidator(options), config).formatHelp();
       expect(message.wrap()).toMatch(/^\n-b, --boolean\n {12}<boolean>\n {20}A boolean option\n$/);
     });
 
@@ -192,7 +192,7 @@ describe('HelpFormatter', () => {
         },
       } as const satisfies Options;
       const config: FormatterConfig = { names: { hidden: true } };
-      const message = new HelpFormatter(new OptionValidator(options), config).formatHelp();
+      const message = new AnsiFormatter(new OptionValidator(options), config).formatHelp();
       expect(message.wrap()).toEqual('    <boolean>  A boolean option\n');
     });
 
@@ -205,7 +205,7 @@ describe('HelpFormatter', () => {
         },
       } as const satisfies Options;
       const config: FormatterConfig = { param: { hidden: true } };
-      const message = new HelpFormatter(new OptionValidator(options), config).formatHelp();
+      const message = new AnsiFormatter(new OptionValidator(options), config).formatHelp();
       expect(message.wrap()).toEqual('  -b, --boolean    A boolean option\n');
     });
 
@@ -218,7 +218,7 @@ describe('HelpFormatter', () => {
         },
       } as const satisfies Options;
       const config: FormatterConfig = { descr: { hidden: true } };
-      const message = new HelpFormatter(new OptionValidator(options), config).formatHelp();
+      const message = new AnsiFormatter(new OptionValidator(options), config).formatHelp();
       expect(message.wrap()).toEqual('  -b, --boolean  <boolean>\n');
     });
 
@@ -243,7 +243,7 @@ describe('HelpFormatter', () => {
           [ConnectiveWord.optionSep]: '',
         },
       };
-      const message = new HelpFormatter(new OptionValidator(options, valCfg), config).formatHelp();
+      const message = new AnsiFormatter(new OptionValidator(options, valCfg), config).formatHelp();
       expect(message.wrap()).toEqual(
         '  -f --flag    A flag option\n  --flag2      A flag option\n',
       );
@@ -261,7 +261,7 @@ describe('HelpFormatter', () => {
         },
       } as const satisfies Options;
       const config: FormatterConfig = { names: { align: 'left' } };
-      const message = new HelpFormatter(new OptionValidator(options), config).formatHelp();
+      const message = new AnsiFormatter(new OptionValidator(options), config).formatHelp();
       expect(message.wrap()).toEqual('  -f, --flag\n  --flag2\n');
     });
 
@@ -277,7 +277,7 @@ describe('HelpFormatter', () => {
         },
       } as const satisfies Options;
       const config: FormatterConfig = { names: { align: 'right' } };
-      const message = new HelpFormatter(new OptionValidator(options), config).formatHelp();
+      const message = new AnsiFormatter(new OptionValidator(options), config).formatHelp();
       expect(message.wrap()).toEqual('  -f, --flag\n     --flag2\n');
     });
 
@@ -300,7 +300,7 @@ describe('HelpFormatter', () => {
           [ConnectiveWord.optionSep]: '',
         },
       };
-      const message = new HelpFormatter(new OptionValidator(options, valCfg), config).formatHelp();
+      const message = new AnsiFormatter(new OptionValidator(options, valCfg), config).formatHelp();
       expect(message.wrap()).toEqual('  -f         --flag\n     --flag2\n');
     });
 
@@ -316,7 +316,7 @@ describe('HelpFormatter', () => {
         },
       } as const satisfies Options;
       const config: FormatterConfig = { names: { align: 'slot' } };
-      const message = new HelpFormatter(new OptionValidator(options), config).formatHelp();
+      const message = new AnsiFormatter(new OptionValidator(options), config).formatHelp();
       expect(message.wrap()).toEqual('  -f           --flag\n      --flag2\n');
     });
 
@@ -334,7 +334,7 @@ describe('HelpFormatter', () => {
         },
       } as const satisfies Options;
       const config: FormatterConfig = { param: { align: 'right' }, items: [] };
-      const message = new HelpFormatter(new OptionValidator(options), config).formatHelp();
+      const message = new AnsiFormatter(new OptionValidator(options), config).formatHelp();
       expect(message.wrap()).toEqual('  -ns1  1 2\n  -ns2    1\n');
     });
 
@@ -347,7 +347,7 @@ describe('HelpFormatter', () => {
         },
       } as const satisfies Options;
       const config: FormatterConfig = { descr: { align: 'right' } };
-      const message = new HelpFormatter(new OptionValidator(options), config).formatHelp();
+      const message = new AnsiFormatter(new OptionValidator(options), config).formatHelp();
       expect(message.wrap(14, false)).toEqual('  -f    A flag\n        option\n');
     });
   });

--- a/packages/tsargp/test/formatter/formatter.json.spec.ts
+++ b/packages/tsargp/test/formatter/formatter.json.spec.ts
@@ -25,6 +25,22 @@ describe('JsonFormatter', () => {
     });
   });
 
+  describe('formatGroup', () => {
+    it('should handle a flag option with a group', () => {
+      const options = {
+        flag: {
+          type: 'flag',
+          names: ['-f'],
+          group: 'Flags',
+        },
+      } as const satisfies Options;
+      const message = new JsonFormatter(new OptionValidator(options)).formatGroup('Flags');
+      expect(message?.message).toEqual(
+        `[{"type":"flag","names":["-f"],"group":"Flags","preferredName":"-f"}]`,
+      );
+    });
+  });
+
   describe('formatSections', () => {
     it('should handle help sections', () => {
       const options = {

--- a/packages/tsargp/test/formatter/formatter.json.spec.ts
+++ b/packages/tsargp/test/formatter/formatter.json.spec.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import type { Options, HelpSections } from '../../lib';
+import { JsonFormatter, OptionValidator } from '../../lib';
+import '../utils.spec'; // initialize globals
+
+describe('JsonFormatter', () => {
+  describe('formatHelp', () => {
+    it('should handle no options', () => {
+      const message = new JsonFormatter(new OptionValidator({})).formatHelp();
+      expect(message.message).toEqual('[]');
+    });
+
+    it('should handle a flag option', () => {
+      const options = {
+        flag: {
+          type: 'flag',
+          names: ['-f'],
+          required: true,
+        },
+      } as const satisfies Options;
+      const message = new JsonFormatter(new OptionValidator(options)).formatHelp();
+      expect(message.message).toEqual(
+        `[{"type":"flag","names":["-f"],"required":true,"preferredName":"-f"}]`,
+      );
+    });
+  });
+
+  describe('formatSections', () => {
+    it('should handle help sections', () => {
+      const options = {
+        flag: {
+          type: 'flag',
+          names: ['-f'],
+          required: true,
+        },
+      } as const satisfies Options;
+      const sections: HelpSections = [{ type: 'groups' }];
+      const message = new JsonFormatter(new OptionValidator(options)).formatSections(sections);
+      expect(message.message).toEqual(
+        `[{"type":"flag","names":["-f"],"required":true,"preferredName":"-f"}]`,
+      );
+    });
+  });
+});

--- a/packages/tsargp/test/formatter/formatter.normalization.spec.ts
+++ b/packages/tsargp/test/formatter/formatter.normalization.spec.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from 'vitest';
-import { type Options, HelpFormatter, OptionValidator } from '../../lib';
+import { type Options, AnsiFormatter, OptionValidator } from '../../lib';
 import '../utils.spec'; // initialize globals
 
-describe('HelpFormatter', () => {
+describe('AnsiFormatter', () => {
   describe('formatHelp', () => {
     it('should handle a string option whose values will be trimmed', () => {
       const options = {
@@ -13,7 +13,7 @@ describe('HelpFormatter', () => {
           trim: true,
         },
       } as const satisfies Options;
-      const message = new HelpFormatter(new OptionValidator(options)).formatHelp();
+      const message = new AnsiFormatter(new OptionValidator(options)).formatHelp();
       expect(message.wrap()).toEqual(
         `  -s, --string  <string>  A string option. Values will be trimmed.\n`,
       );
@@ -28,7 +28,7 @@ describe('HelpFormatter', () => {
           case: 'lower',
         },
       } as const satisfies Options;
-      const message = new HelpFormatter(new OptionValidator(options)).formatHelp();
+      const message = new AnsiFormatter(new OptionValidator(options)).formatHelp();
       expect(message.wrap()).toEqual(
         `  -s, --string  <string>  A string option. Values will be converted to lowercase.\n`,
       );
@@ -43,7 +43,7 @@ describe('HelpFormatter', () => {
           case: 'upper',
         },
       } as const satisfies Options;
-      const message = new HelpFormatter(new OptionValidator(options)).formatHelp();
+      const message = new AnsiFormatter(new OptionValidator(options)).formatHelp();
       expect(message.wrap()).toEqual(
         `  -s, --string  <string>  A string option. Values will be converted to uppercase.\n`,
       );
@@ -58,7 +58,7 @@ describe('HelpFormatter', () => {
           conv: 'trunc',
         },
       } as const satisfies Options;
-      const message = new HelpFormatter(new OptionValidator(options)).formatHelp();
+      const message = new AnsiFormatter(new OptionValidator(options)).formatHelp();
       expect(message.wrap()).toEqual(
         `  -n, --number  <number>  A number option. Values will be converted with Math.trunc.\n`,
       );
@@ -73,7 +73,7 @@ describe('HelpFormatter', () => {
           trim: true,
         },
       } as const satisfies Options;
-      const message = new HelpFormatter(new OptionValidator(options)).formatHelp();
+      const message = new AnsiFormatter(new OptionValidator(options)).formatHelp();
       expect(message.wrap()).toEqual(
         `  -ss, --strings  <strings>...  A strings option. Accepts multiple parameters. Values will be trimmed.\n`,
       );
@@ -88,7 +88,7 @@ describe('HelpFormatter', () => {
           case: 'lower',
         },
       } as const satisfies Options;
-      const message = new HelpFormatter(new OptionValidator(options)).formatHelp();
+      const message = new AnsiFormatter(new OptionValidator(options)).formatHelp();
       expect(message.wrap()).toEqual(
         `  -ss, --strings  <strings>...  A strings option. Accepts multiple parameters. Values will be converted to lowercase.\n`,
       );
@@ -103,7 +103,7 @@ describe('HelpFormatter', () => {
           case: 'upper',
         },
       } as const satisfies Options;
-      const message = new HelpFormatter(new OptionValidator(options)).formatHelp();
+      const message = new AnsiFormatter(new OptionValidator(options)).formatHelp();
       expect(message.wrap()).toEqual(
         `  -ss, --strings  <strings>...  A strings option. Accepts multiple parameters. Values will be converted to uppercase.\n`,
       );
@@ -118,7 +118,7 @@ describe('HelpFormatter', () => {
           unique: true,
         },
       } as const satisfies Options;
-      const message = new HelpFormatter(new OptionValidator(options)).formatHelp();
+      const message = new AnsiFormatter(new OptionValidator(options)).formatHelp();
       expect(message.wrap()).toEqual(
         `  -ss, --strings  <strings>...  A strings option. Accepts multiple parameters. Duplicate values will be removed.\n`,
       );
@@ -133,7 +133,7 @@ describe('HelpFormatter', () => {
           unique: true,
         },
       } as const satisfies Options;
-      const message = new HelpFormatter(new OptionValidator(options)).formatHelp();
+      const message = new AnsiFormatter(new OptionValidator(options)).formatHelp();
       expect(message.wrap()).toEqual(
         `  -ns, --numbers  <numbers>...  A numbers option. Accepts multiple parameters. Duplicate values will be removed.\n`,
       );
@@ -148,7 +148,7 @@ describe('HelpFormatter', () => {
           conv: 'trunc',
         },
       } as const satisfies Options;
-      const message = new HelpFormatter(new OptionValidator(options)).formatHelp();
+      const message = new AnsiFormatter(new OptionValidator(options)).formatHelp();
       expect(message.wrap()).toEqual(
         `  -ns, --numbers  <numbers>...  A numbers option. Accepts multiple parameters. Values will be converted with Math.trunc.\n`,
       );

--- a/packages/tsargp/test/formatter/formatter.param.spec.ts
+++ b/packages/tsargp/test/formatter/formatter.param.spec.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from 'vitest';
-import { type Options, HelpFormatter, OptionValidator } from '../../lib';
+import { type Options, AnsiFormatter, OptionValidator } from '../../lib';
 import '../utils.spec'; // initialize globals
 
-describe('HelpFormatter', () => {
+describe('AnsiFormatter', () => {
   describe('formatHelp', () => {
     it('should handle a function option with a single required parameter', () => {
       const options = {
@@ -13,7 +13,7 @@ describe('HelpFormatter', () => {
           paramCount: 1,
         },
       } as const satisfies Options;
-      const message = new HelpFormatter(new OptionValidator(options)).formatHelp();
+      const message = new AnsiFormatter(new OptionValidator(options)).formatHelp();
       expect(message.wrap()).toEqual(`  -f, --function  <param>  A function option\n`);
     });
 
@@ -26,7 +26,7 @@ describe('HelpFormatter', () => {
           paramCount: [0, 1],
         },
       } as const satisfies Options;
-      const message = new HelpFormatter(new OptionValidator(options)).formatHelp();
+      const message = new AnsiFormatter(new OptionValidator(options)).formatHelp();
       expect(message.wrap()).toEqual(`  -f, --function  [<param>]  A function option\n`);
     });
 
@@ -39,7 +39,7 @@ describe('HelpFormatter', () => {
           paramCount: 2,
         },
       } as const satisfies Options;
-      const message = new HelpFormatter(new OptionValidator(options)).formatHelp();
+      const message = new AnsiFormatter(new OptionValidator(options)).formatHelp();
       expect(message.wrap()).toEqual(
         `  -f, --function  <param>...  A function option. Accepts 2 parameters.\n`,
       );
@@ -54,7 +54,7 @@ describe('HelpFormatter', () => {
           paramCount: [1, 2],
         },
       } as const satisfies Options;
-      const message = new HelpFormatter(new OptionValidator(options)).formatHelp();
+      const message = new AnsiFormatter(new OptionValidator(options)).formatHelp();
       expect(message.wrap()).toEqual(
         `  -f, --function  <param>...  A function option. Accepts between 1 and 2 parameters.\n`,
       );
@@ -69,7 +69,7 @@ describe('HelpFormatter', () => {
           paramCount: [1, Infinity],
         },
       } as const satisfies Options;
-      const message = new HelpFormatter(new OptionValidator(options)).formatHelp();
+      const message = new AnsiFormatter(new OptionValidator(options)).formatHelp();
       expect(message.wrap()).toEqual(
         `  -f, --function  <param>...  A function option. Accepts multiple parameters.\n`,
       );
@@ -84,7 +84,7 @@ describe('HelpFormatter', () => {
           paramCount: [2, Infinity],
         },
       } as const satisfies Options;
-      const message = new HelpFormatter(new OptionValidator(options)).formatHelp();
+      const message = new AnsiFormatter(new OptionValidator(options)).formatHelp();
       expect(message.wrap()).toEqual(
         `  -f, --function  <param>...  A function option. Accepts at least 2 parameters.\n`,
       );
@@ -99,7 +99,7 @@ describe('HelpFormatter', () => {
           paramCount: [0, 2],
         },
       } as const satisfies Options;
-      const message = new HelpFormatter(new OptionValidator(options)).formatHelp();
+      const message = new AnsiFormatter(new OptionValidator(options)).formatHelp();
       expect(message.wrap()).toEqual(
         `  -f, --function  [<param>...]  A function option. Accepts at most 2 parameters.\n`,
       );
@@ -114,7 +114,7 @@ describe('HelpFormatter', () => {
           paramCount: -1,
         },
       } as const satisfies Options;
-      const message = new HelpFormatter(new OptionValidator(options)).formatHelp();
+      const message = new AnsiFormatter(new OptionValidator(options)).formatHelp();
       expect(message.wrap()).toEqual(
         `  -f, --function  [<param>...]  A function option. Accepts multiple parameters.\n`,
       );
@@ -129,7 +129,7 @@ describe('HelpFormatter', () => {
           paramCount: [0, Infinity],
         },
       } as const satisfies Options;
-      const message = new HelpFormatter(new OptionValidator(options)).formatHelp();
+      const message = new AnsiFormatter(new OptionValidator(options)).formatHelp();
       expect(message.wrap()).toEqual(
         `  -f, --function  [<param>...]  A function option. Accepts multiple parameters.\n`,
       );
@@ -145,7 +145,7 @@ describe('HelpFormatter', () => {
           paramCount: 1,
         },
       } as const satisfies Options;
-      const message = new HelpFormatter(new OptionValidator(options)).formatHelp();
+      const message = new AnsiFormatter(new OptionValidator(options)).formatHelp();
       expect(message.wrap()).toEqual(`  -f, --function  <myParam>  A function option\n`);
     });
 
@@ -158,7 +158,7 @@ describe('HelpFormatter', () => {
           paramName: 'param',
         },
       } as const satisfies Options;
-      const message = new HelpFormatter(new OptionValidator(options)).formatHelp();
+      const message = new AnsiFormatter(new OptionValidator(options)).formatHelp();
       expect(message.wrap()).toEqual(`  -b, --boolean  <param>  A boolean option\n`);
     });
 
@@ -171,7 +171,7 @@ describe('HelpFormatter', () => {
           paramName: '<token>=<value>',
         },
       } as const satisfies Options;
-      const message = new HelpFormatter(new OptionValidator(options)).formatHelp();
+      const message = new AnsiFormatter(new OptionValidator(options)).formatHelp();
       expect(message.wrap()).toEqual(`  -b, --boolean  <token>=<value>  A boolean option\n`);
     });
 
@@ -184,7 +184,7 @@ describe('HelpFormatter', () => {
           fallback: true,
         },
       } as const satisfies Options;
-      const message = new HelpFormatter(new OptionValidator(options)).formatHelp();
+      const message = new AnsiFormatter(new OptionValidator(options)).formatHelp();
       expect(message.wrap()).toEqual(
         `  -b, --boolean  [<boolean>]  A boolean option. Falls back to true if specified without parameter.\n`,
       );
@@ -199,7 +199,7 @@ describe('HelpFormatter', () => {
           example: true,
         },
       } as const satisfies Options;
-      const message = new HelpFormatter(new OptionValidator(options)).formatHelp();
+      const message = new AnsiFormatter(new OptionValidator(options)).formatHelp();
       expect(message.wrap()).toEqual(`  -b, --boolean  true  A boolean option\n`);
     });
 
@@ -212,7 +212,7 @@ describe('HelpFormatter', () => {
           fallback: '123',
         },
       } as const satisfies Options;
-      const message = new HelpFormatter(new OptionValidator(options)).formatHelp();
+      const message = new AnsiFormatter(new OptionValidator(options)).formatHelp();
       expect(message.wrap()).toEqual(
         `  -s, --string  [<string>]  A string option. Falls back to '123' if specified without parameter.\n`,
       );
@@ -227,7 +227,7 @@ describe('HelpFormatter', () => {
           example: '123',
         },
       } as const satisfies Options;
-      const message = new HelpFormatter(new OptionValidator(options)).formatHelp();
+      const message = new AnsiFormatter(new OptionValidator(options)).formatHelp();
       expect(message.wrap()).toEqual(`  -s, --string  '123'  A string option\n`);
     });
 
@@ -240,7 +240,7 @@ describe('HelpFormatter', () => {
           fallback: 123,
         },
       } as const satisfies Options;
-      const message = new HelpFormatter(new OptionValidator(options)).formatHelp();
+      const message = new AnsiFormatter(new OptionValidator(options)).formatHelp();
       expect(message.wrap()).toEqual(
         `  -n, --number  [<number>]  A number option. Falls back to 123 if specified without parameter.\n`,
       );
@@ -255,7 +255,7 @@ describe('HelpFormatter', () => {
           example: 123,
         },
       } as const satisfies Options;
-      const message = new HelpFormatter(new OptionValidator(options)).formatHelp();
+      const message = new AnsiFormatter(new OptionValidator(options)).formatHelp();
       expect(message.wrap()).toEqual(`  -n, --number  123  A number option\n`);
     });
 
@@ -268,7 +268,7 @@ describe('HelpFormatter', () => {
           fallback: ['1', '2'],
         },
       } as const satisfies Options;
-      const message = new HelpFormatter(new OptionValidator(options)).formatHelp();
+      const message = new AnsiFormatter(new OptionValidator(options)).formatHelp();
       expect(message.wrap()).toEqual(
         `  -ss, --strings  [<strings>...]  A strings option. Accepts multiple parameters. Falls back to ['1', '2'] if specified without parameter.\n`,
       );
@@ -283,7 +283,7 @@ describe('HelpFormatter', () => {
           example: ['one', 'two'],
         },
       } as const satisfies Options;
-      const message = new HelpFormatter(new OptionValidator(options)).formatHelp();
+      const message = new AnsiFormatter(new OptionValidator(options)).formatHelp();
       expect(message.wrap()).toEqual(
         `  -ss, --strings  'one' 'two'  A strings option. Accepts multiple parameters.\n`,
       );
@@ -298,7 +298,7 @@ describe('HelpFormatter', () => {
           fallback: [1, 2],
         },
       } as const satisfies Options;
-      const message = new HelpFormatter(new OptionValidator(options)).formatHelp();
+      const message = new AnsiFormatter(new OptionValidator(options)).formatHelp();
       expect(message.wrap()).toEqual(
         `  -ns, --numbers  [<numbers>...]  A numbers option. Accepts multiple parameters. Falls back to [1, 2] if specified without parameter.\n`,
       );
@@ -313,7 +313,7 @@ describe('HelpFormatter', () => {
           example: [1, 2],
         },
       } as const satisfies Options;
-      const message = new HelpFormatter(new OptionValidator(options)).formatHelp();
+      const message = new AnsiFormatter(new OptionValidator(options)).formatHelp();
       expect(message.wrap()).toEqual(
         `  -ns, --numbers  1 2  A numbers option. Accepts multiple parameters.\n`,
       );
@@ -329,7 +329,7 @@ describe('HelpFormatter', () => {
           separator: ',',
         },
       } as const satisfies Options;
-      const message = new HelpFormatter(new OptionValidator(options)).formatHelp();
+      const message = new AnsiFormatter(new OptionValidator(options)).formatHelp();
       expect(message.wrap()).toEqual(
         `  -ss, --strings  'one,two'  A strings option. Values are delimited by ','.\n`,
       );
@@ -345,7 +345,7 @@ describe('HelpFormatter', () => {
           separator: /[,;]/s,
         },
       } as const satisfies Options;
-      const message = new HelpFormatter(new OptionValidator(options)).formatHelp();
+      const message = new AnsiFormatter(new OptionValidator(options)).formatHelp();
       expect(message.wrap()).toEqual(
         `  -ss, --strings  'one[,;]two'  A strings option. Values are delimited by /[,;]/s.\n`,
       );
@@ -361,7 +361,7 @@ describe('HelpFormatter', () => {
           separator: ',',
         },
       } as const satisfies Options;
-      const message = new HelpFormatter(new OptionValidator(options)).formatHelp();
+      const message = new AnsiFormatter(new OptionValidator(options)).formatHelp();
       expect(message.wrap()).toEqual(
         `  -ns, --numbers  '1,2'  A numbers option. Values are delimited by ','.\n`,
       );
@@ -377,7 +377,7 @@ describe('HelpFormatter', () => {
           separator: /[,;]/s,
         },
       } as const satisfies Options;
-      const message = new HelpFormatter(new OptionValidator(options)).formatHelp();
+      const message = new AnsiFormatter(new OptionValidator(options)).formatHelp();
       expect(message.wrap()).toEqual(
         `  -ns, --numbers  '1[,;]2'  A numbers option. Values are delimited by /[,;]/s.\n`,
       );

--- a/packages/tsargp/test/formatter/formatter.requirements.spec.ts
+++ b/packages/tsargp/test/formatter/formatter.requirements.spec.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from 'vitest';
-import { type Options, HelpFormatter, OptionValidator, req } from '../../lib';
+import { type Options, AnsiFormatter, OptionValidator, req } from '../../lib';
 import '../utils.spec'; // initialize globals
 
-describe('HelpFormatter', () => {
+describe('AnsiFormatter', () => {
   describe('formatHelp', () => {
     it('should handle an option that requires the presence of another (1)', () => {
       const options = {
@@ -18,7 +18,7 @@ describe('HelpFormatter', () => {
           hide: true,
         },
       } as const satisfies Options;
-      const message = new HelpFormatter(new OptionValidator(options)).formatHelp();
+      const message = new AnsiFormatter(new OptionValidator(options)).formatHelp();
       expect(message.wrap()).toEqual(`  -f, --flag    A flag option. Requires -req.\n`);
     });
 
@@ -36,7 +36,7 @@ describe('HelpFormatter', () => {
           hide: true,
         },
       } as const satisfies Options;
-      const message = new HelpFormatter(new OptionValidator(options)).formatHelp();
+      const message = new AnsiFormatter(new OptionValidator(options)).formatHelp();
       expect(message.wrap()).toEqual(`  -f, --flag    A flag option. Requires -req.\n`);
     });
 
@@ -54,7 +54,7 @@ describe('HelpFormatter', () => {
           hide: true,
         },
       } as const satisfies Options;
-      const message = new HelpFormatter(new OptionValidator(options)).formatHelp();
+      const message = new AnsiFormatter(new OptionValidator(options)).formatHelp();
       expect(message.wrap()).toEqual(`  -f, --flag    A flag option. Requires no -req.\n`);
     });
 
@@ -72,7 +72,7 @@ describe('HelpFormatter', () => {
           hide: true,
         },
       } as const satisfies Options;
-      const message = new HelpFormatter(new OptionValidator(options)).formatHelp();
+      const message = new AnsiFormatter(new OptionValidator(options)).formatHelp();
       expect(message.wrap()).toEqual(`  -f, --flag    A flag option. Requires no -req.\n`);
     });
 
@@ -90,7 +90,7 @@ describe('HelpFormatter', () => {
           hide: true,
         },
       } as const satisfies Options;
-      const message = new HelpFormatter(new OptionValidator(options)).formatHelp();
+      const message = new AnsiFormatter(new OptionValidator(options)).formatHelp();
       expect(message.wrap()).toEqual(`  -f, --flag    A flag option. Requires -req == 'abc'.\n`);
     });
 
@@ -118,7 +118,7 @@ describe('HelpFormatter', () => {
           hide: true,
         },
       } as const satisfies Options;
-      const message = new HelpFormatter(new OptionValidator(options)).formatHelp();
+      const message = new AnsiFormatter(new OptionValidator(options)).formatHelp();
       expect(message.wrap()).toEqual(
         `  -f, --flag    A flag option. Requires (-req1 and (-req2 == 1 or -req3 != '2')).\n`,
       );
@@ -134,7 +134,7 @@ describe('HelpFormatter', () => {
         },
       } as const satisfies Options;
       options.flag.requires.toString = () => 'fcn';
-      const message = new HelpFormatter(new OptionValidator(options)).formatHelp();
+      const message = new AnsiFormatter(new OptionValidator(options)).formatHelp();
       expect(message.wrap()).toEqual(`  -f, --flag    A flag option. Requires <fcn>.\n`);
     });
 
@@ -148,7 +148,7 @@ describe('HelpFormatter', () => {
         },
       } as const satisfies Options;
       options.flag.requires.item.toString = () => 'fcn';
-      const message = new HelpFormatter(new OptionValidator(options)).formatHelp();
+      const message = new AnsiFormatter(new OptionValidator(options)).formatHelp();
       expect(message.wrap()).toEqual(`  -f, --flag    A flag option. Requires not <fcn>.\n`);
     });
 
@@ -166,7 +166,7 @@ describe('HelpFormatter', () => {
           hide: true,
         },
       } as const satisfies Options;
-      const message = new HelpFormatter(new OptionValidator(options)).formatHelp();
+      const message = new AnsiFormatter(new OptionValidator(options)).formatHelp();
       expect(message.wrap()).toEqual(`  -f, --flag    A flag option. Required if -req.\n`);
     });
 
@@ -184,7 +184,7 @@ describe('HelpFormatter', () => {
           hide: true,
         },
       } as const satisfies Options;
-      const message = new HelpFormatter(new OptionValidator(options)).formatHelp();
+      const message = new AnsiFormatter(new OptionValidator(options)).formatHelp();
       expect(message.wrap()).toEqual(`  -f, --flag    A flag option. Required if -req.\n`);
     });
 
@@ -202,7 +202,7 @@ describe('HelpFormatter', () => {
           hide: true,
         },
       } as const satisfies Options;
-      const message = new HelpFormatter(new OptionValidator(options)).formatHelp();
+      const message = new AnsiFormatter(new OptionValidator(options)).formatHelp();
       expect(message.wrap()).toEqual(`  -f, --flag    A flag option. Required if no -req.\n`);
     });
 
@@ -220,7 +220,7 @@ describe('HelpFormatter', () => {
           hide: true,
         },
       } as const satisfies Options;
-      const message = new HelpFormatter(new OptionValidator(options)).formatHelp();
+      const message = new AnsiFormatter(new OptionValidator(options)).formatHelp();
       expect(message.wrap()).toEqual(`  -f, --flag    A flag option. Required if no -req.\n`);
     });
 
@@ -238,7 +238,7 @@ describe('HelpFormatter', () => {
           hide: true,
         },
       } as const satisfies Options;
-      const message = new HelpFormatter(new OptionValidator(options)).formatHelp();
+      const message = new AnsiFormatter(new OptionValidator(options)).formatHelp();
       expect(message.wrap()).toEqual(`  -f, --flag    A flag option. Required if -req == 'abc'.\n`);
     });
 
@@ -266,7 +266,7 @@ describe('HelpFormatter', () => {
           hide: true,
         },
       } as const satisfies Options;
-      const message = new HelpFormatter(new OptionValidator(options)).formatHelp();
+      const message = new AnsiFormatter(new OptionValidator(options)).formatHelp();
       expect(message.wrap()).toEqual(
         `  -f, --flag    A flag option. Required if (-req1 and (-req2 == 1 or -req3 != '2')).\n`,
       );
@@ -282,7 +282,7 @@ describe('HelpFormatter', () => {
         },
       } as const satisfies Options;
       options.flag.requiredIf.toString = () => 'fcn';
-      const message = new HelpFormatter(new OptionValidator(options)).formatHelp();
+      const message = new AnsiFormatter(new OptionValidator(options)).formatHelp();
       expect(message.wrap()).toEqual(`  -f, --flag    A flag option. Required if <fcn>.\n`);
     });
 
@@ -296,7 +296,7 @@ describe('HelpFormatter', () => {
         },
       } as const satisfies Options;
       options.flag.requiredIf.item.toString = () => 'fcn';
-      const message = new HelpFormatter(new OptionValidator(options)).formatHelp();
+      const message = new AnsiFormatter(new OptionValidator(options)).formatHelp();
       expect(message.wrap()).toEqual(`  -f, --flag    A flag option. Required if not <fcn>.\n`);
     });
   });

--- a/packages/tsargp/test/formatter/formatter.sections.spec.ts
+++ b/packages/tsargp/test/formatter/formatter.sections.spec.ts
@@ -1,84 +1,84 @@
 import { describe, expect, it } from 'vitest';
 import type { Options, HelpSections } from '../../lib';
-import { HelpFormatter, OptionValidator } from '../../lib';
+import { AnsiFormatter, OptionValidator } from '../../lib';
 import '../utils.spec'; // initialize globals
 
-describe('HelpFormatter', () => {
+describe('AnsiFormatter', () => {
   describe('formatSections', () => {
     it('should handle no sections', () => {
-      const message = new HelpFormatter(new OptionValidator({})).formatSections([]);
+      const message = new AnsiFormatter(new OptionValidator({})).formatSections([]);
       expect(message.wrap()).toEqual('');
     });
 
     it('should skip a text section with no content', () => {
       const sections: HelpSections = [{ type: 'text' }];
-      const message = new HelpFormatter(new OptionValidator({})).formatSections(sections);
+      const message = new AnsiFormatter(new OptionValidator({})).formatSections(sections);
       expect(message.wrap()).toEqual('');
     });
 
     it('should render a text section', () => {
       const sections: HelpSections = [{ type: 'text', text: 'text' }];
-      const message = new HelpFormatter(new OptionValidator({})).formatSections(sections);
+      const message = new AnsiFormatter(new OptionValidator({})).formatSections(sections);
       expect(message.wrap()).toEqual('text');
     });
 
     it('should indent a text section', () => {
       const sections: HelpSections = [{ type: 'text', text: 'text', indent: 2 }];
-      const message = new HelpFormatter(new OptionValidator({})).formatSections(sections);
+      const message = new AnsiFormatter(new OptionValidator({})).formatSections(sections);
       expect(message.wrap()).toEqual('  text');
     });
 
     it('should break a text section', () => {
       const sections: HelpSections = [{ type: 'text', text: 'text', breaks: 1 }];
-      const message = new HelpFormatter(new OptionValidator({})).formatSections(sections);
+      const message = new AnsiFormatter(new OptionValidator({})).formatSections(sections);
       expect(message.wrap()).toEqual('\ntext');
     });
 
     it('should render a text section with a heading (but not indent the heading)', () => {
       const sections: HelpSections = [{ type: 'text', title: 'title', indent: 2 }];
-      const message = new HelpFormatter(new OptionValidator({})).formatSections(sections);
+      const message = new AnsiFormatter(new OptionValidator({})).formatSections(sections);
       expect(message.wrap()).toEqual('title');
     });
 
     it('should break a text section with a heading', () => {
       const sections: HelpSections = [{ type: 'text', title: 'title', breaks: 1 }];
-      const message = new HelpFormatter(new OptionValidator({})).formatSections(sections);
+      const message = new AnsiFormatter(new OptionValidator({})).formatSections(sections);
       expect(message.wrap()).toEqual('\ntitle');
     });
 
     it('should render an empty usage section', () => {
       const sections: HelpSections = [{ type: 'usage' }];
-      const message = new HelpFormatter(new OptionValidator({})).formatSections(sections);
+      const message = new AnsiFormatter(new OptionValidator({})).formatSections(sections);
       expect(message.wrap()).toEqual('');
     });
 
     it('should render a usage section with a program name', () => {
       const sections: HelpSections = [{ type: 'usage' }];
-      const message = new HelpFormatter(new OptionValidator({})).formatSections(sections, 'prog');
+      const message = new AnsiFormatter(new OptionValidator({})).formatSections(sections, 'prog');
       expect(message.wrap()).toEqual('prog');
     });
 
     it('should indent a usage section with a program name', () => {
       const sections: HelpSections = [{ type: 'usage', indent: 2 }];
-      const message = new HelpFormatter(new OptionValidator({})).formatSections(sections, 'prog');
+      const message = new AnsiFormatter(new OptionValidator({})).formatSections(sections, 'prog');
       expect(message.wrap()).toEqual('  prog');
     });
 
     it('should break a usage section with a program name', () => {
       const sections: HelpSections = [{ type: 'usage', breaks: 1 }];
-      const message = new HelpFormatter(new OptionValidator({})).formatSections(sections, 'prog');
+      const message = new AnsiFormatter(new OptionValidator({})).formatSections(sections, 'prog');
       expect(message.wrap()).toEqual('\nprog');
     });
 
     it('should render a usage section with a heading (but not indent the heading)', () => {
       const sections: HelpSections = [{ type: 'usage', title: 'title', indent: 2 }];
-      const message = new HelpFormatter(new OptionValidator({})).formatSections(sections);
+      const message = new AnsiFormatter(new OptionValidator({})).formatSections(sections);
       expect(message.wrap()).toEqual('title');
     });
 
     it('should break a usage section with a heading', () => {
       const sections: HelpSections = [{ type: 'usage', title: 'title', breaks: 1 }];
-      const message = new HelpFormatter(new OptionValidator({})).formatSections(sections);
+      const message = new AnsiFormatter(new OptionValidator({})).formatSections(sections);
       expect(message.wrap()).toEqual('\ntitle');
     });
 
@@ -91,7 +91,7 @@ describe('HelpFormatter', () => {
         },
       } as const satisfies Options;
       const sections: HelpSections = [{ type: 'usage' }];
-      const message = new HelpFormatter(new OptionValidator(options)).formatSections(sections);
+      const message = new AnsiFormatter(new OptionValidator(options)).formatSections(sections);
       expect(message.wrap()).toEqual('-f');
     });
 
@@ -103,7 +103,7 @@ describe('HelpFormatter', () => {
         },
       } as const satisfies Options;
       const sections: HelpSections = [{ type: 'usage' }];
-      const message = new HelpFormatter(new OptionValidator(options)).formatSections(sections);
+      const message = new AnsiFormatter(new OptionValidator(options)).formatSections(sections);
       expect(message.wrap()).toEqual('[(-f|--flag)]');
     });
 
@@ -116,7 +116,7 @@ describe('HelpFormatter', () => {
       } as const satisfies Options;
       const validator = new OptionValidator(options);
       const sections: HelpSections = [{ type: 'usage' }];
-      const message = new HelpFormatter(validator).formatSections(sections, 'prog');
+      const message = new AnsiFormatter(validator).formatSections(sections, 'prog');
       expect(message.wrap()).toEqual('prog [-b <boolean>]');
     });
 
@@ -130,13 +130,13 @@ describe('HelpFormatter', () => {
       } as const satisfies Options;
       const validator = new OptionValidator(options);
       const sections: HelpSections = [{ type: 'usage', title: 'title', indent: 2 }];
-      const message = new HelpFormatter(validator).formatSections(sections, 'prog');
+      const message = new AnsiFormatter(validator).formatSections(sections, 'prog');
       expect(message.wrap()).toEqual('title\n\n  prog [-b true]');
     });
 
     it('should render an empty groups section', () => {
       const sections: HelpSections = [{ type: 'groups' }];
-      const message = new HelpFormatter(new OptionValidator({})).formatSections(sections);
+      const message = new AnsiFormatter(new OptionValidator({})).formatSections(sections);
       expect(message.wrap()).toEqual('');
     });
 
@@ -149,7 +149,7 @@ describe('HelpFormatter', () => {
         },
       } as const satisfies Options;
       const sections: HelpSections = [{ type: 'groups' }];
-      const message = new HelpFormatter(new OptionValidator(options)).formatSections(sections);
+      const message = new AnsiFormatter(new OptionValidator(options)).formatSections(sections);
       expect(message.wrap()).toEqual('  -f, --flag    A flag option.');
     });
 
@@ -162,7 +162,7 @@ describe('HelpFormatter', () => {
         },
       } as const satisfies Options;
       const sections: HelpSections = [{ type: 'groups', title: 'title' }];
-      const message = new HelpFormatter(new OptionValidator(options)).formatSections(sections);
+      const message = new AnsiFormatter(new OptionValidator(options)).formatSections(sections);
       expect(message.wrap()).toEqual('title\n\n  -f, --flag    A flag option.');
     });
 
@@ -175,7 +175,7 @@ describe('HelpFormatter', () => {
         },
       } as const satisfies Options;
       const sections: HelpSections = [{ type: 'groups', breaks: 1 }];
-      const message = new HelpFormatter(new OptionValidator(options)).formatSections(sections);
+      const message = new AnsiFormatter(new OptionValidator(options)).formatSections(sections);
       expect(message.wrap()).toEqual('\n  -f, --flag    A flag option.');
     });
 
@@ -188,7 +188,7 @@ describe('HelpFormatter', () => {
         },
       } as const satisfies Options;
       const sections: HelpSections = [{ type: 'groups', title: 'title', breaks: 1 }];
-      const message = new HelpFormatter(new OptionValidator(options)).formatSections(sections);
+      const message = new AnsiFormatter(new OptionValidator(options)).formatSections(sections);
       expect(message.wrap()).toEqual('\ntitle\n\n  -f, --flag    A flag option.');
     });
 
@@ -205,7 +205,7 @@ describe('HelpFormatter', () => {
         { type: 'usage', title: 'section  title', noWrap: true },
         { type: 'groups', title: 'section  title', noWrap: true },
       ];
-      const message = new HelpFormatter(new OptionValidator(options)).formatSections(sections);
+      const message = new AnsiFormatter(new OptionValidator(options)).formatSections(sections);
       expect(message.wrap()).toEqual(
         'section  title\n\nsection  text\n\nsection  title\n\n[(-f|--flag)]\n\nsection  title\n\n  -f, --flag    A flag option.',
       );
@@ -226,7 +226,7 @@ describe('HelpFormatter', () => {
       const sections2: HelpSections = [{ type: 'usage', filter: ['flag1'], exclude: true }];
       const sections3: HelpSections = [{ type: 'usage', filter: ['flag1'], required: ['flag1'] }];
       const sections4: HelpSections = [{ type: 'usage', filter: ['flag2', 'flag1'] }];
-      const formatter = new HelpFormatter(new OptionValidator(options));
+      const formatter = new AnsiFormatter(new OptionValidator(options));
       expect(formatter.formatSections(sections1).wrap()).toEqual('[-f1]');
       expect(formatter.formatSections(sections2).wrap()).toEqual('[-f2]');
       expect(formatter.formatSections(sections3).wrap()).toEqual('-f1');
@@ -248,7 +248,7 @@ describe('HelpFormatter', () => {
       } as const satisfies Options;
       const sections1: HelpSections = [{ type: 'groups', filter: ['group1'] }];
       const sections2: HelpSections = [{ type: 'groups', filter: ['group1'], exclude: true }];
-      const formatter = new HelpFormatter(new OptionValidator(options));
+      const formatter = new AnsiFormatter(new OptionValidator(options));
       expect(formatter.formatSections(sections1).wrap()).toEqual('group1\n\n  -f1');
       expect(formatter.formatSections(sections2).wrap()).toEqual('group2\n\n  -f2');
     });

--- a/packages/tsargp/test/formatter/formatter.spec.ts
+++ b/packages/tsargp/test/formatter/formatter.spec.ts
@@ -1,12 +1,12 @@
 import { describe, expect, it } from 'vitest';
 import type { Options, FormatterConfig } from '../../lib';
-import { HelpFormatter, OptionValidator } from '../../lib';
+import { AnsiFormatter, OptionValidator } from '../../lib';
 import '../utils.spec'; // initialize globals
 
-describe('HelpFormatter', () => {
+describe('AnsiFormatter', () => {
   describe('formatHelp', () => {
     it('should handle no options', () => {
-      const message = new HelpFormatter(new OptionValidator({})).formatHelp();
+      const message = new AnsiFormatter(new OptionValidator({})).formatHelp();
       expect(message.wrap()).toEqual('');
     });
 
@@ -27,7 +27,7 @@ describe('HelpFormatter', () => {
       } as const satisfies Options;
       const validator = new OptionValidator(options);
       const config: FormatterConfig = { descr: { absolute: true }, filter: ['flag'] };
-      const message = new HelpFormatter(validator, config).formatHelp();
+      const message = new AnsiFormatter(validator, config).formatHelp();
       expect(message.wrap()).toEqual(`  -f, --flag\n  A flag option\n`);
     });
 
@@ -49,7 +49,7 @@ describe('HelpFormatter', () => {
       } as const satisfies Options;
       const validator = new OptionValidator(options);
       const config: FormatterConfig = { items: [], filter: ['-f', 'bool'] };
-      const message = new HelpFormatter(validator, config).formatHelp();
+      const message = new AnsiFormatter(validator, config).formatHelp();
       expect(message.wrap()).toEqual(`  -f, --flag\n  -b          <boolean>\n`);
     });
 
@@ -62,7 +62,7 @@ describe('HelpFormatter', () => {
           exec() {},
         },
       } as const satisfies Options;
-      const message = new HelpFormatter(new OptionValidator(options)).formatHelp();
+      const message = new AnsiFormatter(new OptionValidator(options)).formatHelp();
       expect(message.wrap()).toEqual(`  -f, --function    A function option\n`);
     });
 
@@ -76,7 +76,7 @@ describe('HelpFormatter', () => {
           exec() {},
         },
       } as const satisfies Options;
-      const message = new HelpFormatter(new OptionValidator(options)).formatHelp();
+      const message = new AnsiFormatter(new OptionValidator(options)).formatHelp();
       expect(message.wrap()).toEqual(`  -f, --command  ...  A command option\n`);
     });
 
@@ -89,7 +89,7 @@ describe('HelpFormatter', () => {
           negationNames: ['-no-f', '', '--no-flag'],
         },
       } as const satisfies Options;
-      const message = new HelpFormatter(new OptionValidator(options)).formatHelp();
+      const message = new AnsiFormatter(new OptionValidator(options)).formatHelp();
       expect(message.wrap()).toEqual(
         `  -f, --flag    A flag option. Can be negated with -no-f, --no-flag.\n`,
       );
@@ -104,7 +104,7 @@ describe('HelpFormatter', () => {
           required: true,
         },
       } as const satisfies Options;
-      const message = new HelpFormatter(new OptionValidator(options)).formatHelp();
+      const message = new AnsiFormatter(new OptionValidator(options)).formatHelp();
       expect(message.wrap()).toEqual(`  -f, --flag    A flag option. Always required.\n`);
     });
 
@@ -117,7 +117,7 @@ describe('HelpFormatter', () => {
           link: new URL('https://trulysimple.dev/tsargp/docs'),
         },
       } as const satisfies Options;
-      const message = new HelpFormatter(new OptionValidator(options)).formatHelp();
+      const message = new AnsiFormatter(new OptionValidator(options)).formatHelp();
       expect(message.wrap()).toEqual(
         `  -f, --flag    A flag option. Refer to https://trulysimple.dev/tsargp/docs for details.\n`,
       );
@@ -132,7 +132,7 @@ describe('HelpFormatter', () => {
           deprecated: 'reason',
         },
       } as const satisfies Options;
-      const message = new HelpFormatter(new OptionValidator(options)).formatHelp();
+      const message = new AnsiFormatter(new OptionValidator(options)).formatHelp();
       expect(message.wrap()).toEqual(`  -f, --flag    A flag option. Deprecated for reason.\n`);
     });
 
@@ -145,7 +145,7 @@ describe('HelpFormatter', () => {
           clusterLetters: 'fF',
         },
       } as const satisfies Options;
-      const message = new HelpFormatter(new OptionValidator(options)).formatHelp();
+      const message = new AnsiFormatter(new OptionValidator(options)).formatHelp();
       expect(message.wrap()).toEqual(
         `  -f, --flag    A flag option. Can be clustered with 'fF'.\n`,
       );
@@ -160,7 +160,7 @@ describe('HelpFormatter', () => {
           envVar: 'VAR',
         },
       } as const satisfies Options;
-      const message = new HelpFormatter(new OptionValidator(options)).formatHelp();
+      const message = new AnsiFormatter(new OptionValidator(options)).formatHelp();
       expect(message.wrap()).toEqual(
         `  -b, --boolean  <boolean>  A boolean option. Can be specified through the VAR environment variable.\n`,
       );
@@ -175,7 +175,7 @@ describe('HelpFormatter', () => {
           positional: true,
         },
       } as const satisfies Options;
-      const message = new HelpFormatter(new OptionValidator(options)).formatHelp();
+      const message = new AnsiFormatter(new OptionValidator(options)).formatHelp();
       expect(message.wrap()).toEqual(
         `  -s, --string  <string>  A string option. Accepts positional parameters.\n`,
       );
@@ -190,7 +190,7 @@ describe('HelpFormatter', () => {
           positional: '--',
         },
       } as const satisfies Options;
-      const message = new HelpFormatter(new OptionValidator(options)).formatHelp();
+      const message = new AnsiFormatter(new OptionValidator(options)).formatHelp();
       expect(message.wrap()).toEqual(
         `  -n, --number  <number>  A number option. Accepts positional parameters that may be preceded by --.\n`,
       );
@@ -206,7 +206,7 @@ describe('HelpFormatter', () => {
           separator: ',',
         },
       } as const satisfies Options;
-      const message = new HelpFormatter(new OptionValidator(options)).formatHelp();
+      const message = new AnsiFormatter(new OptionValidator(options)).formatHelp();
       expect(message.wrap()).toEqual(
         `  -ss, --strings  <strings>  A strings option. Values are delimited by ','. May be specified multiple times.\n`,
       );
@@ -222,7 +222,7 @@ describe('HelpFormatter', () => {
           separator: ',',
         },
       } as const satisfies Options;
-      const message = new HelpFormatter(new OptionValidator(options)).formatHelp();
+      const message = new AnsiFormatter(new OptionValidator(options)).formatHelp();
       expect(message.wrap()).toEqual(
         `  -ns, --numbers  <numbers>  A numbers option. Values are delimited by ','. May be specified multiple times.\n`,
       );
@@ -241,7 +241,7 @@ describe('HelpFormatter', () => {
           group: 'group',
         },
       } as const satisfies Options;
-      const groups = new HelpFormatter(new OptionValidator(options)).formatGroups();
+      const groups = new AnsiFormatter(new OptionValidator(options)).formatGroups();
       const message = groups.get('group');
       assert(message);
       expect(message.wrap()).toEqual(`  -f, --flag    A flag option\n`);

--- a/packages/tsargp/test/parser/parser.completion.spec.ts
+++ b/packages/tsargp/test/parser/parser.completion.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import type { Options, ParsingFlags } from '../../lib';
-import { ArgumentParser, CompletionMessage } from '../../lib';
+import { ArgumentParser, CompMessage } from '../../lib';
 import '../utils.spec'; // initialize globals
 
 describe('ArgumentParser', () => {
@@ -76,7 +76,7 @@ describe('ArgumentParser', () => {
           type: 'function',
           names: ['-f'],
           exec() {
-            throw new CompletionMessage('abc');
+            throw new CompMessage('abc');
           },
         },
       } as const satisfies Options;

--- a/packages/tsargp/test/parser/parser.spec.ts
+++ b/packages/tsargp/test/parser/parser.spec.ts
@@ -105,7 +105,7 @@ describe('ArgumentParser', () => {
         );
       });
 
-      it('should throw a help message with a help format', async () => {
+      it('should throw a help message with a JSON format', async () => {
         const options = {
           flag: {
             type: 'flag',
@@ -114,12 +114,14 @@ describe('ArgumentParser', () => {
           help: {
             type: 'help',
             names: ['-h'],
-            sections: [{ type: 'groups' }],
             useFormat: true,
           },
         } as const satisfies Options;
         const parser = new ArgumentParser(options);
-        await expect(parser.parse(['-h', 'ansi'])).rejects.toThrow(`  -f, --flag`);
+        await expect(parser.parse(['-h', 'json'])).rejects.toThrow(
+          `[{"type":"flag","names":["-f","--flag"],"preferredName":"-f"},` +
+            `{"type":"help","names":["-h"],"useFormat":true,"preferredName":"-h","format":"json"}]`,
+        );
       });
 
       it('should throw a help message with filtered options', async () => {

--- a/packages/tsargp/test/parser/parser.spec.ts
+++ b/packages/tsargp/test/parser/parser.spec.ts
@@ -105,6 +105,23 @@ describe('ArgumentParser', () => {
         );
       });
 
+      it('should throw a help message with a help format', async () => {
+        const options = {
+          flag: {
+            type: 'flag',
+            names: ['-f', '--flag'],
+          },
+          help: {
+            type: 'help',
+            names: ['-h'],
+            sections: [{ type: 'groups' }],
+            useFormat: true,
+          },
+        } as const satisfies Options;
+        const parser = new ArgumentParser(options);
+        await expect(parser.parse(['-h', 'ansi'])).rejects.toThrow(`  -f, --flag`);
+      });
+
       it('should throw a help message with filtered options', async () => {
         const options = {
           flag1: {

--- a/packages/tsargp/test/parser/parser.spec.ts
+++ b/packages/tsargp/test/parser/parser.spec.ts
@@ -95,7 +95,7 @@ describe('ArgumentParser', () => {
               { type: 'usage', title: 'usage  heading' },
               { type: 'groups', noWrap: true },
             ],
-            format: { names: { indent: 0 } },
+            config: { names: { indent: 0 } },
           },
         } as const satisfies Options;
         const parser = new ArgumentParser(options);

--- a/packages/tsargp/test/styles/styles.messages.spec.ts
+++ b/packages/tsargp/test/styles/styles.messages.spec.ts
@@ -63,6 +63,6 @@ describe('JsonMessage', () => {
   it('can be thrown and caught', () => {
     expect(() => {
       throw new JsonMessage({ type: 'script' });
-    }).toThrow('{"type":"script"}');
+    }).toThrow('[{"type":"script"}]');
   });
 });

--- a/packages/tsargp/test/styles/styles.messages.spec.ts
+++ b/packages/tsargp/test/styles/styles.messages.spec.ts
@@ -1,21 +1,14 @@
 import { afterAll, describe, expect, it } from 'vitest';
-import { tf, style } from '../../lib';
-import {
-  TerminalString,
-  TerminalMessage,
-  WarnMessage,
-  ErrorMessage,
-  HelpMessage,
-  CompletionMessage,
-} from '../../lib';
+import { tf, style, TerminalString } from '../../lib';
+import { AnsiMessage, JsonMessage, WarnMessage, ErrorMessage, CompMessage } from '../../lib';
 import { resetEnv } from '../utils.spec'; // initialize globals
 
-describe('TerminalMessage', () => {
+describe('AnsiMessage', () => {
   afterAll(resetEnv);
 
   it('should wrap the error message', () => {
     const str = new TerminalString().split('type script');
-    const msg = new TerminalMessage(str);
+    const msg = new AnsiMessage(str);
     expect(msg.wrap(0)).toEqual('type script');
     expect(msg.wrap(11)).toEqual('type script' + style(tf.clear));
     process.env['NO_COLOR'] = '1';
@@ -29,7 +22,7 @@ describe('TerminalMessage', () => {
   it('can be thrown and caught', () => {
     const str = new TerminalString().split('type script');
     expect(() => {
-      throw new TerminalMessage(str);
+      throw new AnsiMessage(str);
     }).toThrow('type script');
   });
 });
@@ -58,19 +51,18 @@ describe('ErrorMessage', () => {
   });
 });
 
-describe('HelpMessage', () => {
-  it('can be thrown and caught', () => {
-    const str = new TerminalString().split('type script');
-    expect(() => {
-      throw new HelpMessage(str);
-    }).toThrow('type script');
-  });
-});
-
 describe('CompletionMessage', () => {
   it('can be thrown and caught', () => {
     expect(() => {
-      throw new CompletionMessage('type', 'script');
+      throw new CompMessage('type', 'script');
     }).toThrow('type\nscript');
+  });
+});
+
+describe('JsonMessage', () => {
+  it('can be thrown and caught', () => {
+    expect(() => {
+      throw new JsonMessage({ type: 'script' });
+    }).toThrow('{"type":"script"}');
   });
 });


### PR DESCRIPTION
Added a `JsonFormatter` class that handles formatting of help messages in JSON format, as well as a `HelpFormat` type for the available help formats.

Updated the Options page to document the `config` and `format` attributes of help options. Updated Formatter page to document the new organization of formatter classes.

Closes #139 
