### PR TITLE
Issues/135

### DIFF
--- a/.changeset/chatty-birds-kick.md
+++ b/.changeset/chatty-birds-kick.md
@@ -1,0 +1,5 @@
+---
+'@trulysimple/tsargp-docs': patch
+---
+
+The Formatter page was updated to document the new `MdFormatter` class.

--- a/.changeset/ten-avocados-give.md
+++ b/.changeset/ten-avocados-give.md
@@ -1,0 +1,5 @@
+---
+'tsargp': minor
+---
+
+A new formatter class was added, `MdFormatter`, to format help messages in markdown format.

--- a/.changeset/ten-avocados-give.md
+++ b/.changeset/ten-avocados-give.md
@@ -2,4 +2,4 @@
 'tsargp': minor
 ---
 
-A new formatter class was added, `MdFormatter`, to format help messages in markdown format.
+A new formatter class was added, `MdFormatter`, to format help messages in Markdown format.

--- a/packages/docs/pages/docs/index.mdx
+++ b/packages/docs/pages/docs/index.mdx
@@ -115,7 +115,7 @@ Optionally, enable word completion:
   </Tabs.Tab>
 </Tabs>
 
-[^1]: ~34KB minified
+[^1]: ~35KB minified
 
 [SGR]: https://www.wikiwand.com/en/ANSI_escape_code#SGR_(Select_Graphic_Rendition)_parameters
 [meow]: https://www.npmjs.com/package/meow

--- a/packages/docs/pages/docs/index.mdx
+++ b/packages/docs/pages/docs/index.mdx
@@ -10,15 +10,15 @@ import { Tabs } from 'nextra/components';
 
 ## Features
 
-| Usability              | Functionality          | Presentation            |
-| ---------------------- | ---------------------- | ----------------------- |
-| Zero-dependency        | Word completion        | Help message formatting |
-| Fully declarative      | Option validation      | Text wrapping/alignment |
-| Type-checked           | Option requirements    | Paragraphs and lists    |
-| Browser-compatible     | Value normalization    | [SGR] colors and styles |
-| Moderate footprint[^1] | Name suggestions       | Custom error phrases    |
-| ESM-native             | Nested commands        | Option grouping/hiding  |
-| Online documentation   | Asynchronous callbacks | Help sections and usage |
+| Usability            | Functionality          | Presentation            |
+| -------------------- | ---------------------- | ----------------------- |
+| Zero-dependency      | Word completion        | Help message formatting |
+| Fully declarative    | Option validation      | Text wrapping/alignment |
+| Type-checked         | Option requirements    | Paragraphs and lists    |
+| Browser-compatible   | Value normalization    | [SGR] colors and styles |
+| 35KB minified        | Name suggestions       | Custom error phrases    |
+| ESM-native           | Nested commands        | Option grouping/hiding  |
+| Online documentation | Asynchronous callbacks | Help sections and usage |
 
 ## Motivation
 
@@ -114,8 +114,6 @@ Optionally, enable word completion:
     ```
   </Tabs.Tab>
 </Tabs>
-
-[^1]: ~35KB minified
 
 [SGR]: https://www.wikiwand.com/en/ANSI_escape_code#SGR_(Select_Graphic_Rendition)_parameters
 [meow]: https://www.npmjs.com/package/meow

--- a/packages/docs/pages/docs/library/formatter.mdx
+++ b/packages/docs/pages/docs/library/formatter.mdx
@@ -23,6 +23,9 @@ There are three concrete classes of formatter, each one handling a different hel
 - `CsvFormatter` -
   formats help messages in CSV format, i.e., they are meant to be transformed and exchanged with
   other applications
+- `MdFormatter` -
+  formats help messages in Markdown format, i.e., they are meant to be processed by documentation
+  tools, or to be versioned with the code
 
 <Callout type="warning">
   Everything contained in this page relates to the `AnsiFormatter` class.

--- a/packages/docs/pages/docs/library/options.mdx
+++ b/packages/docs/pages/docs/library/options.mdx
@@ -508,12 +508,16 @@ two sections are included:
 
 The `useNested` attribute is an opt-in feature that allows the next argument to be used as the name
 of a [nested command] for which the help message should be assembled. For example, the invocation
-`cli --help cmd` would throw the help of the `cmd` command, if it exists. If not, or if it does not
-have a help option, the argument may still be used as an option filter, if [enable filter] is set.
+`cli --help cmd` would throw the help of the `cmd` command, if it exists.
+
+If a nested command with the specified name does not exist or does not have a help option, the
+argument may still be used as either a help format (if [enable format] is set) or an option filter
+(if [enable filter] is set).
 
 <Callout type="default">
-  The nested command may also [enable filter] in its help option definition. For example, the
-  invocation `cli --help cmd -f` would throw the help of the `cmd` command, filtered by `-f`.
+  The nested command may also set [enable format] and [enable filter] in its help option definition.
+  For example, the invocation `cli --help cmd json -f` would throw the help of the `cmd` command in
+  JSON format, filtered by `-f`.
 </Callout>
 
 #### Enable format
@@ -521,7 +525,7 @@ have a help option, the argument may still be used as an option filter, if [enab
 The `useFormat` attribute is an opt-in feature that allows the next argument to be used as the name
 of a [help format] with which the help message should be assembled. For example, the invocation
 `cli --help json` would produce the help message in JSON format. The available formats are
-`'ansi'{:ts}` (the default), `'json'{:ts}` and `'csv'{:ts}`.
+`'ansi'{:ts}` (the default), `'json'{:ts}`, `'csv'{:ts}` and `'md'{:ts}`.
 
 #### Enable filter
 
@@ -905,6 +909,7 @@ attributes:
 [cluster letters]: #cluster-letters
 [fallback value]: #fallback-value
 [parameter count]: #parameter-count
+[enable format]: #enable-format
 [enable filter]: #enable-filter
 [skip count]: #skip-count
 [formatter]: formatter

--- a/packages/docs/pages/docs/library/styles.mdx
+++ b/packages/docs/pages/docs/library/styles.mdx
@@ -324,7 +324,7 @@ The `TextMessage` class represents a list of text lines. It is used by the libra
 
 - by the [parser] to throw [completion words], in which case it is meant to be consumed by
   completion builtins
-- by the [formatter] to create help messages in CSV [format]
+- by the [formatter] to create help messages in either CSV or Markdown [format]
 
 This message produces a string with lines separated by line feeds, and should be printed with
 `console.log` or equivalent.

--- a/packages/tsargp/lib/formatter.ts
+++ b/packages/tsargp/lib/formatter.ts
@@ -498,7 +498,9 @@ export class CsvFormatter extends BaseFormatter<TextMessage, CsvHelpEntry> {
     );
   }
   protected override format(entries: Array<CsvHelpEntry>): TextMessage {
-    entries.unshift(fieldNames);
+    if (entries.length) {
+      entries.unshift(fieldNames);
+    }
     return formatCsvEntries(entries);
   }
   formatSections(sections: HelpSections): TextMessage {
@@ -518,7 +520,10 @@ export class MdFormatter extends BaseFormatter<TextMessage, CsvHelpEntry> {
     );
   }
   protected override format(entries: Array<CsvHelpEntry>): TextMessage {
-    const help = new TextMessage(markdownHead, markdownHeadSplit);
+    const help = new TextMessage();
+    if (entries.length) {
+      help.push(markdownHead, markdownHeadSplit);
+    }
     return formatCsvEntries(entries, help, markdownSep, markdownSep);
   }
   formatSections(sections: HelpSections): TextMessage {
@@ -925,7 +930,7 @@ function formatNameSlots(
 }
 
 /**
- * Formats an ANSI help message from a list of ANSI help entries.
+ * Formats a help message from a list of ANSI help entries.
  * @param entries The help entries
  * @param result The resulting message
  * @returns The resulting message
@@ -938,26 +943,28 @@ function formatAnsiEntries(entries: Array<AnsiHelpEntry>, result = new AnsiMessa
 }
 
 /**
- * Formats a CSV help message from a list of CSV help entries.
+ * Formats a help message from a list of CSV help entries.
  * Sequences of whitespace are collapsed to a single space.
  * @param entries The help entries
  * @param result The resulting message
- * @param sep The value delimiter
- * @param quote The quote character
+ * @param itemSep The help item delimiter
+ * @param entryQuote The quote character for a whole help entry
  * @returns The resulting message
  */
 function formatCsvEntries(
   entries: Array<CsvHelpEntry>,
   result = new TextMessage(),
-  sep = '\t',
-  quote = '',
+  itemSep = '\t',
+  entryQuote = '',
 ): TextMessage {
   result.push(
     ...entries.map(
       (entry) =>
-        quote +
-        entry.map((item) => item.replace(regexps.space, ' ').replace(regexps.style, '')).join(sep) +
-        quote,
+        entryQuote +
+        entry
+          .map((item) => item.replace(regexps.space, ' ').replace(regexps.style, ''))
+          .join(itemSep) +
+        entryQuote,
     ),
   );
   return result;

--- a/packages/tsargp/lib/options.ts
+++ b/packages/tsargp/lib/options.ts
@@ -101,6 +101,7 @@ export const isOpt = {
  */
 export const fieldNames = [
   'type',
+  'group',
   'names',
   'desc',
   'negationNames',

--- a/packages/tsargp/test/formatter/formatter.formats.spec.ts
+++ b/packages/tsargp/test/formatter/formatter.formats.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { Options, HelpSections } from '../../lib';
-import { JsonFormatter, CsvFormatter, OptionValidator, style, tf } from '../../lib';
+import { JsonFormatter, CsvFormatter, MdFormatter, OptionValidator, style, tf } from '../../lib';
 import { fieldNames } from '../../lib/options';
 import '../utils.spec'; // initialize globals
 
@@ -79,6 +79,64 @@ describe('CsvFormatter', () => {
       const sections: HelpSections = [{ type: 'groups' }];
       const message = new CsvFormatter(new OptionValidator(options)).formatSections(sections);
       expect(message.message).toEqual(fieldNames.join('\t') + `\nflag\t-f` + '\t'.repeat(26));
+    });
+  });
+});
+
+describe('MdFormatter', () => {
+  describe('formatHelp', () => {
+    it('should handle a non-existent group', () => {
+      const message = new MdFormatter(new OptionValidator({})).formatHelp();
+      expect(message.message).toEqual(
+        ' | ' +
+          fieldNames.join(' | ') +
+          ` | \n | ` +
+          fieldNames.map((field) => '-'.repeat(field.length)).join(' | ') +
+          ' | ',
+      );
+    });
+
+    it('should handle a number option with a default callback', () => {
+      const options = {
+        number: {
+          type: 'number',
+          names: ['-n', '--number'],
+          desc: style(tf.clear) + 'A\n  number\t  option',
+          default: () => 1,
+        },
+      } as const satisfies Options;
+      const message = new MdFormatter(new OptionValidator(options)).formatHelp();
+      expect(message.message).toEqual(
+        ' | ' +
+          fieldNames.join(' | ') +
+          ` | \n | ` +
+          fieldNames.map((field) => '-'.repeat(field.length)).join(' | ') +
+          ` | \n | number | -n,--number | A number option` +
+          ' | '.repeat(16) +
+          '() => 1' +
+          ' | '.repeat(10),
+      );
+    });
+  });
+
+  describe('formatSections', () => {
+    it('should handle help sections', () => {
+      const options = {
+        flag: {
+          type: 'flag',
+          names: ['-f'],
+        },
+      } as const satisfies Options;
+      const sections: HelpSections = [{ type: 'groups' }];
+      const message = new MdFormatter(new OptionValidator(options)).formatSections(sections);
+      expect(message.message).toEqual(
+        ' | ' +
+          fieldNames.join(' | ') +
+          ` | \n | ` +
+          fieldNames.map((field) => '-'.repeat(field.length)).join(' | ') +
+          ` | \n | flag | -f` +
+          ' | '.repeat(27),
+      );
     });
   });
 });

--- a/packages/tsargp/test/formatter/formatter.formats.spec.ts
+++ b/packages/tsargp/test/formatter/formatter.formats.spec.ts
@@ -56,7 +56,7 @@ describe('CsvFormatter', () => {
     it('should handle zero options', () => {
       const formatter = new CsvFormatter(new OptionValidator({}));
       expect([...formatter.groupNames]).toEqual([]);
-      expect(formatter.formatHelp().message).toEqual(fieldNames.join('\t'));
+      expect(formatter.formatHelp().message).toEqual('');
     });
 
     it('should handle a number option with a group and a default callback', () => {
@@ -111,13 +111,7 @@ describe('MdFormatter', () => {
     it('should handle zero options', () => {
       const formatter = new MdFormatter(new OptionValidator({}));
       expect([...formatter.groupNames]).toEqual([]);
-      expect(formatter.formatHelp().message).toEqual(
-        ' | ' +
-          fieldNames.join(' | ') +
-          ` | \n | ` +
-          fieldNames.map((field) => '-'.repeat(field.length)).join(' | ') +
-          ' | ',
-      );
+      expect(formatter.formatHelp().message).toEqual('');
     });
 
     it('should handle a number option with a group and a default callback', () => {

--- a/packages/tsargp/test/formatter/formatter.spec.ts
+++ b/packages/tsargp/test/formatter/formatter.spec.ts
@@ -5,9 +5,10 @@ import '../utils.spec'; // initialize globals
 
 describe('AnsiFormatter', () => {
   describe('formatHelp', () => {
-    it('should handle a non-existent group', () => {
-      const message = new AnsiFormatter(new OptionValidator({})).formatHelp();
-      expect(message.wrap()).toEqual('');
+    it('should handle zero options', () => {
+      const formatter = new AnsiFormatter(new OptionValidator({}));
+      expect([...formatter.groupNames]).toEqual([]);
+      expect(formatter.formatHelp().wrap()).toEqual('');
     });
 
     it('should handle a flag option with a group', () => {
@@ -20,7 +21,7 @@ describe('AnsiFormatter', () => {
         },
       } as const satisfies Options;
       const message = new AnsiFormatter(new OptionValidator(options)).formatHelp('group');
-      expect(message?.wrap()).toEqual(`  -f, --flag    A flag option\n`);
+      expect(message.wrap()).toEqual(`  -f, --flag    A flag option\n`);
     });
 
     it('should filter options using a single regular expression', () => {


### PR DESCRIPTION
Added the `MdFormatter` class to format help messages in Markdown format.

Updated the Formatter page to document the new formatter class.

Closes #135 
