### PR TITLE
Issues/149

### DIFF
--- a/.changeset/khaki-dots-unite.md
+++ b/.changeset/khaki-dots-unite.md
@@ -1,0 +1,5 @@
+---
+'tsargp': minor
+---
+
+The `noInline` attribute was added for non-niladic options, to disallow inline parameters.

--- a/.changeset/two-geese-live.md
+++ b/.changeset/two-geese-live.md
@@ -1,0 +1,5 @@
+---
+'@trulysimple/tsargp-docs': patch
+---
+
+The Options page was updated to document the new `noInline` attribute for non-niladic options.

--- a/packages/docs/pages/docs/library/options.mdx
+++ b/packages/docs/pages/docs/library/options.mdx
@@ -334,6 +334,10 @@ Notes about this callback:
   the option.
 </Callout>
 
+#### Disable inline
+
+The `noInline` attribute, if present, indicates that the option does not accept [inline parameters].
+
 ### Known value attributes
 
 All non-niladic options that have known values share a set of attributes, which are described below.
@@ -935,6 +939,7 @@ attributes:
 [constraints validation]: validator#constraints-validation
 [help items]: formatter#help-items
 [help item]: formatter#help-items
+[inline parameters]: parser#inline-parameters
 [Set]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set
 [Math]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math
 [`import.meta.resolve`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/import.meta/resolve

--- a/packages/tsargp/lib/options.ts
+++ b/packages/tsargp/lib/options.ts
@@ -386,6 +386,10 @@ export type WithParam = {
    * If it throws an error, it is ignored, and the default completion message is thrown instead.
    */
   readonly complete?: CompleteCallback;
+  /**
+   * Whether inline parameters should be disallowed for this option.
+   */
+  readonly noInline?: true;
 };
 
 /**

--- a/packages/tsargp/lib/parser.ts
+++ b/packages/tsargp/lib/parser.ts
@@ -269,7 +269,7 @@ function parseCluster(context: ParseContext, index: number): boolean {
   }
   if (unknownIndex > 0) {
     const name = getOpt(rest[0])[2];
-    args.splice(index, 0, ...(name ? [name] : []), rest.slice(1));
+    args.splice(index, 0, (name ? name + '=' : '') + rest.slice(1));
     return true; // treat it as an inline parameter
   }
   for (let j = 0; j < rest.length && (!completing || index < args.length); ++j) {
@@ -337,13 +337,13 @@ async function parseArgs(context: ParseContext): Promise<boolean> {
       paramCount = getParamCount(option);
       const niladic = !paramCount[1];
       const hasValue = value !== undefined;
-      if (niladic || marker) {
+      if (niladic || marker || option.noInline) {
         if (comp) {
           throw new TextMessage();
         }
         if (hasValue) {
           if (completing) {
-            // ignore inline parameters of niladic options or positional marker while completing
+            // ignore disallowed inline parameters while completing
             prev[1] = undefined;
             prev[4] = false;
             continue;

--- a/packages/tsargp/test/parser/parser.cluster.spec.ts
+++ b/packages/tsargp/test/parser/parser.cluster.spec.ts
@@ -25,6 +25,21 @@ describe('ArgumentParser', () => {
       await expect(parser.parse(['-b=1'], flags)).resolves.toEqual({ boolean: true });
     });
 
+    it('should throw an error on boolean option with inline cluster parameter, despite it being disallowed', async () => {
+      const options = {
+        boolean: {
+          type: 'boolean',
+          names: ['--bool'],
+          clusterLetters: 'b',
+          noInline: true,
+        },
+      } as const satisfies Options;
+      const parser = new ArgumentParser(options);
+      await expect(parser.parse(['-b1'], flags)).rejects.toThrow(
+        `Option --bool does not accept inline parameters.`,
+      );
+    });
+
     it('should parse a boolean option with inline cluster parameter', async () => {
       const options = {
         boolean: {

--- a/packages/tsargp/test/parser/parser.completion.spec.ts
+++ b/packages/tsargp/test/parser/parser.completion.spec.ts
@@ -34,6 +34,20 @@ describe('ArgumentParser', () => {
       await expect(parser.parse('cmd -s a -s ', { compIndex: 12 })).rejects.toThrow(/^abc$/);
     });
 
+    it('should ignore the completion of a disallowed inline parameter during completion', async () => {
+      const options = {
+        string: {
+          type: 'string',
+          names: ['-s'],
+          enums: ['one', 'two'],
+          noInline: true,
+        },
+      } as const satisfies Options;
+      const parser = new ArgumentParser(options);
+      await expect(parser.parse('cmd -s=', { compIndex: 7 })).rejects.toThrow(/^$/);
+      await expect(parser.parse('cmd -s= ', { compIndex: 8 })).rejects.toThrow(/^-s$/);
+    });
+
     it('should ignore an error thrown by a fallback callback during completion', async () => {
       const options = {
         string: {

--- a/packages/tsargp/test/parser/parser.spec.ts
+++ b/packages/tsargp/test/parser/parser.spec.ts
@@ -314,7 +314,7 @@ describe('ArgumentParser', () => {
         await expect(parser.parse(['-f2', 'arg', '-f1'])).rejects.toThrow('Unknown option arg.');
       });
 
-      it('should throw an error on function option specified with value', async () => {
+      it('should throw an error on niladic function option specified with inline parameter', async () => {
         const options = {
           function: {
             type: 'function',
@@ -330,6 +330,24 @@ describe('ArgumentParser', () => {
           `Option -f does not accept inline parameters.`,
         );
         expect(options.function.exec).not.toHaveBeenCalled();
+      });
+
+      it('should throw an error on non-niladic function option specified with inline parameter, despite it being disallowed', async () => {
+        const options = {
+          function: {
+            type: 'function',
+            names: ['-f'],
+            paramCount: 1,
+            noInline: true,
+          },
+        } as const satisfies Options;
+        const parser = new ArgumentParser(options);
+        await expect(parser.parse(['-f='])).rejects.toThrow(
+          `Option -f does not accept inline parameters.`,
+        );
+        await expect(parser.parse(['-f=a'])).rejects.toThrow(
+          `Option -f does not accept inline parameters.`,
+        );
       });
 
       it('should handle a function option', async () => {
@@ -452,7 +470,7 @@ describe('ArgumentParser', () => {
         await expect(parser.parse(['-c'])).rejects.toThrow('abc');
       });
 
-      it('should throw an error on command option specified with value', async () => {
+      it('should throw an error on command option specified with inline parameter', async () => {
         const options = {
           command: {
             type: 'command',
@@ -609,7 +627,7 @@ describe('ArgumentParser', () => {
     });
 
     describe('flag', () => {
-      it('should throw an error on flag option specified with value', async () => {
+      it('should throw an error on flag option specified with inline parameter', async () => {
         const options = {
           flag: {
             type: 'flag',
@@ -641,6 +659,23 @@ describe('ArgumentParser', () => {
     });
 
     describe('boolean', () => {
+      it('should throw an error on boolean option specified with inline parameter, despite it being disallowed', async () => {
+        const options = {
+          boolean: {
+            type: 'boolean',
+            names: ['-b'],
+            noInline: true,
+          },
+        } as const satisfies Options;
+        const parser = new ArgumentParser(options);
+        await expect(parser.parse(['-b='])).rejects.toThrow(
+          `Option -b does not accept inline parameters.`,
+        );
+        await expect(parser.parse(['-b=a'])).rejects.toThrow(
+          `Option -b does not accept inline parameters.`,
+        );
+      });
+
       it('should throw an error on boolean option with missing parameter', async () => {
         const options = {
           boolean: {


### PR DESCRIPTION
Added the `noInline` attribute for non-niladic options, to disallow inline parameters.

Updated the Options page to document the new attribute for non-niladic options.

Closes #149 
