### PR TITLE
Issues/152

### DIFF
--- a/.changeset/fair-ravens-know.md
+++ b/.changeset/fair-ravens-know.md
@@ -2,4 +2,4 @@
 'tsargp': minor
 ---
 
-The `noInline` attribute was renamed to `inline` and supports a new value 'always', which indicates that the option requires inline parameters. A new help item, `inline`, was added to report if an option disallows or requires inline parameters.
+The `noInline` attribute was renamed to `inline` and supports a new value `always`, which indicates that the option _requires_ inline parameters. A new help item, `inline`, was added to report if an option disallows or requires inline parameters.

--- a/.changeset/fair-ravens-know.md
+++ b/.changeset/fair-ravens-know.md
@@ -1,0 +1,5 @@
+---
+'tsargp': minor
+---
+
+The `noInline` attribute was renamed to `inline` and supports a new value 'always', which indicates that the option requires inline parameters. A new help item, `inline`, was added to report if an option disallows or requires inline parameters.

--- a/.changeset/nice-teachers-protect.md
+++ b/.changeset/nice-teachers-protect.md
@@ -1,0 +1,5 @@
+---
+'@trulysimple/tsargp-docs': patch
+---
+
+The Options page was updated to document the new behavior of the `inline` attribute for non-niladic options, which specifies the option's treatment of inline parameters.

--- a/.changeset/nice-teachers-protect.md
+++ b/.changeset/nice-teachers-protect.md
@@ -2,4 +2,4 @@
 '@trulysimple/tsargp-docs': patch
 ---
 
-The Options page was updated to document the new behavior of the `inline` attribute for non-niladic options, which specifies the option's treatment of inline parameters.
+The Options page was updated to document the new behavior of the `inline` attribute (previously `noInline`) for non-niladic options, which specifies the option's treatment of inline parameters. The Formatter page was updated to document the new `inline` help item.

--- a/packages/docs/pages/demo.mdx
+++ b/packages/docs/pages/demo.mdx
@@ -60,12 +60,23 @@ export const Demo = dynamic(() => import('@components/demo'), { ssr: false });
 - check if values get appended when an option is specified repeatedly (e.g.,
   `--numbersEnum 1 --numbersEnum 2`)
 
+### Inline parameters
+
+- check if parameters can be inlined with option names (e.g., `-ss=abc`)
+- check if inline parameters are disallowed for an option (e.g., `-se=one`)
+- check if inline parameters are required for an option (e.g., `-ne 1`)
+
+### Help format and filters
+
+- check if the help option accepts option filters (e.g., `-h -b -ne`)
+- check if the help option accepts a help format (e.g., `-h json`)
+- check if the help option accepts a nested command name (e.g., `-h hello`)
+- check if the all of the above can be combined (e.g., `-h hello json -h`)
+
 ### Miscellaneous
 
 - check if the `-f` option can be specified without a parameter, and negated with `--no-flag`
 - check if the `-b` option can be specified in combination with other options
-- check if parameters can be inlined with option names (e.g., `-ss=abc`)
-- check if the help option accepts option filters (e.g., `-h -b`)
 
 ### Nested commands
 

--- a/packages/docs/pages/docs/library/formatter.mdx
+++ b/packages/docs/pages/docs/library/formatter.mdx
@@ -270,6 +270,7 @@ and in what order. It is an array whose values can be one of the enumerators fro
 - `useNested` - whether a help option uses the next argument as the name of a [nested command]
 - `useFormat` - whether a help option uses the next argument as the name of a [help format]
 - `useFilter` - whether a help option uses the remaining arguments as [option filter]
+- `inline` - the option's treatment of [inline parameters], if enabled
 
 The default is to print all items in the order listed above.
 
@@ -304,6 +305,7 @@ following optional properties, whose keys are enumerators from `HelpItem`:
 - `useNested` - `'Uses the next argument as the name of a nested command.'{:ts}`
 - `useFormat` - `'Uses the next argument as the name of a help format.'{:ts}`
 - `useFilter` - `'Uses the remaining arguments as option filter.'{:ts}`
+- `inline` - `'(Disallows|Requires) inline parameters.'{:ts}`
 
 These phrases will be formatted according to [text formatting] rules.
 
@@ -401,6 +403,7 @@ that they may get overridden by (or combined with) an option's [display styles],
 [fallback value]: options#fallback-value
 [truth and falsity]: options#truth--falsity-names
 [nested command]: options#command-option
+[inline parameters]: parser#inline-parameters
 
 [^1]:
     _polyadic_ means that the option accepts more than one parameter, but the parameter count is

--- a/packages/docs/pages/docs/library/options.mdx
+++ b/packages/docs/pages/docs/library/options.mdx
@@ -176,6 +176,12 @@ Notes about this callback:
 - it can be asynchronous
 - it may be configured with a custom `toString` method to render it in the help message
 
+<Callout type="info">
+  Note that the help message does not use the value returned by the callback, as it may depend on
+  the values of options passed in the command-line, which are generally not available when throwing
+  the help.
+</Callout>
+
 #### Forward requirements
 
 The `requires` attribute, if present, specifies requirements that must be satisfied _if_ the option
@@ -293,6 +299,8 @@ Notice how the parameters appear "glued" to the first letter, with no intervenin
 contain characters that are not valid cluster letters. The first one _must_ be valid, otherwise the
 argument will not be considered a cluster.
 
+<Callout type="info">This feature is affected by the [inline] attribute.</Callout>
+
 ### Parameter attributes
 
 All non-niladic options share a set of attributes, which are described below.
@@ -334,9 +342,11 @@ Notes about this callback:
   the option.
 </Callout>
 
-#### Disable inline
+#### Disable | require inline
 
-The `noInline` attribute, if present, indicates that the option does not accept [inline parameters].
+The `inline` attribute, if present, indicates the option's treatment of [inline parameters]. Can be
+either `false{:ts}` to disallow or `'always'{:ts}` to always require. By default, parameters are
+allowed (but not required) to be inlined with option names.
 
 ### Known value attributes
 
@@ -437,6 +447,11 @@ Array-valued options share a set of attributes, as described below.
 The `separator` attribute, if present, specifies a delimiter by which to split the option parameter.
 If specified, the option will accept a single parameter[^4] on the command-line, not multiple
 parameters (as is the default). It can be either a string or a regular expression.
+
+<Callout type="default">
+  When _not_ using this attribute, we recommend disabling [inline] parameters for array-valued
+  options.
+</Callout>
 
 #### Remove duplicates
 
@@ -633,6 +648,15 @@ have either of the following values:
 - a numeric **range**: the option expects between a minimum and maximum count
 
 Mutually exclusive with [skip count].
+
+<Callout type="default">
+  When using this attribute, we recommend also disabling [inline] parameters.
+</Callout>
+
+<Callout type="info">
+  Notice that a function option cannot have a parameter [separator]. The latter is only intended for
+  array-valued options, as they lack the flexibility of specifying a parameter count.
+</Callout>
 
 #### Skip count
 
@@ -851,6 +875,7 @@ attributes:
 - [miscellaneous attributes]
 
 [param count]: #parameter-count
+[inline]: #disable--require-inline
 [trim]: #trim-whitespace
 [case]: #case-conversion
 [conv]: #math-conversion

--- a/packages/docs/pages/docs/library/validator.mdx
+++ b/packages/docs/pages/docs/library/validator.mdx
@@ -232,6 +232,8 @@ They are listed in the next sub-sections.
 - `invalidClusterOption` -
   when either a variadic option or a command option is specified in the middle of a [cluster
   argument]
+- `missingInlineParameter` -
+  when an option is specified without an inline parameter, despite it being required
 
 #### Validation errors
 
@@ -334,6 +336,7 @@ It has the following optional properties, whose keys are enumerators from `Error
 - `invalidNumericRange` - `'Option %o has invalid numeric range [%n].'{:ts}`
 - `invalidParamCount` - `'Option %o has invalid parameter count [%n].'{:ts}`
 - `variadicWithClusterLetter` - `'Variadic option %o may only appear as the last option in a cluster.'{:ts}`
+- `missingInlineParameter` - `'Option %o requires an inline parameter.'{:ts}`
 
 These phrases will be formatted according to [text formatting] rules.
 
@@ -377,6 +380,7 @@ message, along with a description of the corresponding value:
 | invalidNumericRange        | `%o` = the option's key; `%n` = the numeric range                                                                                          |
 | invalidParamCount          | `%o` = the option's key; `%n` = the parameter count                                                                                        |
 | variadicWithClusterLetter  | `%o` = the option's key                                                                                                                    |
+| missingInlineParameter     | `%o` = the specified option name                                                                                                           |
 
 ### Connective words
 

--- a/packages/docs/pages/docs/library/validator.mdx
+++ b/packages/docs/pages/docs/library/validator.mdx
@@ -150,8 +150,8 @@ the restrictions listed below:
   An option must not declare a requirement that references either a non-valued option (help and
   version) or an unknown-valued option (function and command) in a requirement.
 - **Invalid required value** -
-  An option must not declare a requirement that references another option that is either always
-  [required] or has a [default value], if the required value is nullish (`null{:ts}` or
+  An option must not declare a requirement that references another option that is either [always
+  required] or has a [default value], if the required value is nullish (`null{:ts}` or
   `undefined{:ts}`).
 - **Incompatible required value** -
   Since a requirement can be an object with values of any kind, the data type of these values must
@@ -220,7 +220,7 @@ They are listed in the next sub-sections.
 - `unsatisfiedRequirement` -
   when an option requirement is not satisfied
 - `missingRequiredOption` -
-  when an option that is always [required] was not specified
+  when an option that is [always required] was not specified
 - `missingParameter` -
   when an option parameter is expected but was not specified
 - `missingPackageJson` -
@@ -233,7 +233,7 @@ They are listed in the next sub-sections.
   when either a variadic option or a command option is specified in the middle of a [cluster
   argument]
 - `missingInlineParameter` -
-  when an option is specified without an inline parameter, despite it being required
+  when an option is specified without an inline parameter, despite it being [required]
 
 #### Validation errors
 
@@ -252,8 +252,8 @@ They are listed in the next sub-sections.
 - `invalidRequiredOption` -
   when an option references either a non-valued or an unknown-valued option in a requirement
 - `invalidRequiredValue` -
-  when an option uses a nullish value in a requirement referencing an option that is either always
-  [required] or has a [default value]
+  when an option uses a nullish value in a requirement referencing an option that is either [always
+  required] or has a [default value]
 - `incompatibleRequiredValue` -
   when an option is required with a value of incompatible data type
 - `emptyEnumsDefinition` -
@@ -418,7 +418,8 @@ It has the following optional properties, whose keys are enumerators from `Conne
 [name slot]: formatter#name-slots
 [nested command]: options#command-option
 [format specifiers]: styles#format-specifiers
-[required]: options#always-required
+[always required]: options#always-required
+[required]: options#disable--require-inline
 [default value]: options#default-value
 [parameter count]: options#parameter-count
 [Cluster letters]: options#cluster-letters

--- a/packages/tsargp/examples/demo.options.ts
+++ b/packages/tsargp/examples/demo.options.ts
@@ -180,6 +180,7 @@ Report a bug: ${style(tf.faint)}https://github.com/trulysimple/tsargp/issues`,
     group: 'String options:',
     enums: ['one', 'two'],
     example: 'one',
+    inline: false,
   },
   /**
    * A number option that has an enumeration constraint.
@@ -191,6 +192,7 @@ Report a bug: ${style(tf.faint)}https://github.com/trulysimple/tsargp/issues`,
     group: 'Number options:',
     enums: [1, 2],
     example: 1,
+    inline: 'always',
   },
   /**
    * A strings option that has a regex constraint.

--- a/packages/tsargp/lib/enums.ts
+++ b/packages/tsargp/lib/enums.ts
@@ -265,6 +265,10 @@ export const enum HelpItem {
    * Whether a help option uses the remaining arguments as option filter.
    */
   useFilter,
+  /**
+   * The option's treatment of inline parameters, if enabled.
+   */
+  inline,
 }
 
 /**

--- a/packages/tsargp/lib/enums.ts
+++ b/packages/tsargp/lib/enums.ts
@@ -150,6 +150,11 @@ export const enum ErrorItem {
    * Warning produced by the validator when a variadic option declares cluster letters.
    */
   variadicWithClusterLetter,
+  /**
+   * Raised by the parser when an option is specified without an inline parameter, despite it being
+   * required.
+   */
+  missingInlineParameter,
 }
 
 /**

--- a/packages/tsargp/lib/formatter.ts
+++ b/packages/tsargp/lib/formatter.ts
@@ -313,6 +313,7 @@ const defaultConfig: ConcreteFormat = {
     HelpItem.useNested,
     HelpItem.useFormat,
     HelpItem.useFilter,
+    HelpItem.inline,
   ],
   phrases: {
     [HelpItem.desc]: '%t',
@@ -341,6 +342,7 @@ const defaultConfig: ConcreteFormat = {
     [HelpItem.useNested]: 'Uses the next argument as the name of a nested command.',
     [HelpItem.useFormat]: 'Uses the next argument as the name of a help format.',
     [HelpItem.useFilter]: 'Uses the remaining arguments as option filter.',
+    [HelpItem.inline]: '(Disallows|Requires) inline parameters.',
   },
   filter: [],
 };
@@ -375,6 +377,7 @@ const helpFunctions = [
   formatUseNested,
   formatUseFormat,
   formatUseFilter,
+  formatInline,
 ] as const satisfies HelpFunctions;
 
 /**
@@ -407,6 +410,7 @@ const fieldNames = [
   'useNested',
   'useFormat',
   'useFilter',
+  'inline',
 ] as const satisfies ReadonlyArray<keyof OpaqueOption>;
 
 /**
@@ -1905,5 +1909,25 @@ function formatUseFilter(
 ) {
   if (option.useFilter) {
     result.split(phrase);
+  }
+}
+
+/**
+ * Formats a help option's inline treatment to be included in the description.
+ * @param option The option definition
+ * @param phrase The description item phrase
+ * @param context The help context
+ * @param result The resulting string
+ */
+function formatInline(
+  option: OpaqueOption,
+  phrase: string,
+  context: HelpContext,
+  result: TerminalString,
+) {
+  const inline = option.inline;
+  if (inline !== undefined) {
+    const alt = inline === false ? 0 : 1;
+    result.format(context[0], phrase, undefined, { alt });
   }
 }

--- a/packages/tsargp/lib/options.ts
+++ b/packages/tsargp/lib/options.ts
@@ -387,9 +387,9 @@ export type WithParam = {
    */
   readonly complete?: CompleteCallback;
   /**
-   * Whether inline parameters should be disallowed for this option.
+   * Whether inline parameters should be disallowed or required for this option.
    */
-  readonly noInline?: true;
+  readonly inline?: false | 'always';
 };
 
 /**

--- a/packages/tsargp/lib/validator.ts
+++ b/packages/tsargp/lib/validator.ts
@@ -77,6 +77,7 @@ export const defaultConfig: ConcreteConfig = {
     [ErrorItem.invalidParamCount]: 'Option %o has invalid parameter count [%n].',
     [ErrorItem.variadicWithClusterLetter]:
       'Variadic option %o may only appear as the last option in a cluster.',
+    [ErrorItem.missingInlineParameter]: 'Option %o requires an inline parameter.',
   },
   connectives: {
     [ConnectiveWord.and]: 'and',

--- a/packages/tsargp/test/formatter/formatter.spec.ts
+++ b/packages/tsargp/test/formatter/formatter.spec.ts
@@ -226,6 +226,36 @@ describe('AnsiFormatter', () => {
       );
     });
 
+    it('should handle a boolean option that disallows inline parameters', () => {
+      const options = {
+        boolean: {
+          type: 'boolean',
+          names: ['-b', '--boolean'],
+          desc: 'A boolean option.',
+          inline: false,
+        },
+      } as const satisfies Options;
+      const message = new AnsiFormatter(new OptionValidator(options)).format();
+      expect(message.wrap()).toEqual(
+        `  -b, --boolean  <boolean>  A boolean option. Disallows inline parameters.\n`,
+      );
+    });
+
+    it('should handle a boolean option that requires inline parameters', () => {
+      const options = {
+        boolean: {
+          type: 'boolean',
+          names: ['-b', '--boolean'],
+          desc: 'A boolean option.',
+          inline: 'always',
+        },
+      } as const satisfies Options;
+      const message = new AnsiFormatter(new OptionValidator(options)).format();
+      expect(message.wrap()).toEqual(
+        `  -b, --boolean  <boolean>  A boolean option. Requires inline parameters.\n`,
+      );
+    });
+
     it('should handle a delimited strings option that can be specified multiple times', () => {
       const options = {
         strings: {

--- a/packages/tsargp/test/parser/parser.cluster.spec.ts
+++ b/packages/tsargp/test/parser/parser.cluster.spec.ts
@@ -25,13 +25,28 @@ describe('ArgumentParser', () => {
       await expect(parser.parse(['-b=1'], flags)).resolves.toEqual({ boolean: true });
     });
 
+    it('should throw an error on boolean option with missing inline cluster parameter, despite it being required', async () => {
+      const options = {
+        boolean: {
+          type: 'boolean',
+          names: ['--bool'],
+          clusterLetters: 'b',
+          inline: 'always',
+        },
+      } as const satisfies Options;
+      const parser = new ArgumentParser(options);
+      await expect(parser.parse(['-b'], flags)).rejects.toThrow(
+        `Option --bool requires an inline parameter.`,
+      );
+    });
+
     it('should throw an error on boolean option with inline cluster parameter, despite it being disallowed', async () => {
       const options = {
         boolean: {
           type: 'boolean',
           names: ['--bool'],
           clusterLetters: 'b',
-          noInline: true,
+          inline: false,
         },
       } as const satisfies Options;
       const parser = new ArgumentParser(options);

--- a/packages/tsargp/test/parser/parser.completion.spec.ts
+++ b/packages/tsargp/test/parser/parser.completion.spec.ts
@@ -34,13 +34,25 @@ describe('ArgumentParser', () => {
       await expect(parser.parse('cmd -s a -s ', { compIndex: 12 })).rejects.toThrow(/^abc$/);
     });
 
-    it('should ignore the completion of a disallowed inline parameter during completion', async () => {
+    it('should ignore required inline parameter during completion', async () => {
+      const options = {
+        string: {
+          type: 'string',
+          names: ['-s'],
+          inline: 'always',
+        },
+      } as const satisfies Options;
+      const parser = new ArgumentParser(options);
+      await expect(parser.parse('cmd -s ', { compIndex: 9 })).rejects.toThrow(/^-s$/);
+    });
+
+    it('should ignore disallowed inline parameter during completion', async () => {
       const options = {
         string: {
           type: 'string',
           names: ['-s'],
           enums: ['one', 'two'],
-          noInline: true,
+          inline: false,
         },
       } as const satisfies Options;
       const parser = new ArgumentParser(options);

--- a/packages/tsargp/test/parser/parser.spec.ts
+++ b/packages/tsargp/test/parser/parser.spec.ts
@@ -338,7 +338,7 @@ describe('ArgumentParser', () => {
             type: 'function',
             names: ['-f'],
             paramCount: 1,
-            noInline: true,
+            inline: false,
           },
         } as const satisfies Options;
         const parser = new ArgumentParser(options);
@@ -659,12 +659,42 @@ describe('ArgumentParser', () => {
     });
 
     describe('boolean', () => {
-      it('should throw an error on boolean option specified with inline parameter, despite it being disallowed', async () => {
+      it('should accept a boolean option with fallback value with missing inline parameter, despite it being required', async () => {
         const options = {
           boolean: {
             type: 'boolean',
             names: ['-b'],
-            noInline: true,
+            inline: 'always',
+            fallback: true,
+          },
+        } as const satisfies Options;
+        const parser = new ArgumentParser(options);
+        await expect(parser.parse(['-b'])).resolves.toEqual({ boolean: true });
+      });
+
+      it('should throw an error on boolean option with missing inline parameter, despite it being required', async () => {
+        const options = {
+          boolean: {
+            type: 'boolean',
+            names: ['-b'],
+            inline: 'always',
+          },
+        } as const satisfies Options;
+        const parser = new ArgumentParser(options);
+        await expect(parser.parse(['-b'])).rejects.toThrow(
+          `Option -b requires an inline parameter.`,
+        );
+        await expect(parser.parse(['-b', '1'])).rejects.toThrow(
+          `Option -b requires an inline parameter.`,
+        );
+      });
+
+      it('should throw an error on boolean option with inline parameter, despite it being disallowed', async () => {
+        const options = {
+          boolean: {
+            type: 'boolean',
+            names: ['-b'],
+            inline: false,
           },
         } as const satisfies Options;
         const parser = new ArgumentParser(options);


### PR DESCRIPTION
Renamed the `noInline` attribute to `inline` and added support for a new value `always`, which indicates that the option _requires_ inline parameters. Updated the Options page accordingly.

Added the help item `inline` to report if an option disallows or requires inline parameters. Updated the Formatter page accordingly.

Closes #152 
