### PR TITLE
Issues/158

### DIFF
--- a/.changeset/itchy-bikes-eat.md
+++ b/.changeset/itchy-bikes-eat.md
@@ -1,0 +1,5 @@
+---
+'tsargp': minor
+---
+
+The `align` property of help columns now support a `merge` value, which instructs the formatter to merge the contents of the column with the previous one.

--- a/.changeset/mighty-timers-argue.md
+++ b/.changeset/mighty-timers-argue.md
@@ -1,0 +1,5 @@
+---
+'@trulysimple/tsargp-docs': patch
+---
+
+The formatter page was updated to document the new `merge` value of help column alignment.

--- a/packages/docs/pages/docs/library/formatter.mdx
+++ b/packages/docs/pages/docs/library/formatter.mdx
@@ -212,6 +212,11 @@ The `names.align` property supports an additional value `'slot'{:ts}`, which mea
 receives a "slot" in the column, and the name is left-aligned within that slot. See [name slots]
 for more information.
 
+The `param.align` and `descr.align` properties support an additional value `'merge'{:ts}`, which
+instructs the formatter to merge the contents of the column with the previous one. This is useful,
+for instance, if you want option parameters to be inlined with option names. When using this value,
+the `indent` and `breaks` properties are ignored.
+
 An example can better illustrate the effect of some of these settings. Suppose we have the following
 configuration:
 

--- a/packages/tsargp/examples/demo.options.ts
+++ b/packages/tsargp/examples/demo.options.ts
@@ -21,6 +21,10 @@ const helloOpts = {
     type: 'help',
     names: ['-h', '--help'],
     desc: 'The help option for the hello command. Prints this help message.',
+    config: {
+      param: { align: 'merge' },
+      descr: { indent: -10 },
+    },
     useFormat: true,
     useFilter: true,
   },

--- a/packages/tsargp/test/formatter/formatter.formatting.spec.ts
+++ b/packages/tsargp/test/formatter/formatter.formatting.spec.ts
@@ -161,9 +161,7 @@ describe('AnsiFormatter', () => {
         descr: { breaks: 1, absolute: true },
       };
       const message = new AnsiFormatter(new OptionValidator(options), config).format();
-      expect(message.wrap()).toMatch(
-        /^\n {2}-b, --boolean\n {2}<boolean>\n {2}A boolean option\n$/,
-      );
+      expect(message.wrap()).toMatch(`\n  -b, --boolean\n  <boolean>\n  A boolean option\n`);
     });
 
     it('should break columns in the help message when configured with negative indentation', () => {
@@ -245,7 +243,7 @@ describe('AnsiFormatter', () => {
       };
       const message = new AnsiFormatter(new OptionValidator(options, valCfg), config).format();
       expect(message.wrap()).toEqual(
-        '  -f --flag    A flag option\n  --flag2      A flag option\n',
+        `  -f --flag    A flag option\n  --flag2      A flag option\n`,
       );
     });
 
@@ -349,6 +347,74 @@ describe('AnsiFormatter', () => {
       const config: FormatterConfig = { descr: { align: 'right' } };
       const message = new AnsiFormatter(new OptionValidator(options), config).format();
       expect(message.wrap(14, false)).toEqual('  -f    A flag\n        option\n');
+    });
+
+    it('should merge option parameters with option names', () => {
+      const options = {
+        boolean: {
+          type: 'boolean',
+          names: ['-b', '--boolean'],
+          desc: 'A boolean option',
+        },
+        string: {
+          type: 'string',
+          desc: 'A string option.',
+          positional: true,
+        },
+      } as const satisfies Options;
+      const config: FormatterConfig = { param: { align: 'merge' } };
+      const message = new AnsiFormatter(new OptionValidator(options), config).format();
+      expect(message.wrap()).toEqual(
+        `  -b, --boolean <boolean>   A boolean option\n` +
+          `  <string>                  A string option. Accepts positional parameters.\n`,
+      );
+    });
+
+    it('should merge option descriptions with option parameters', () => {
+      const options = {
+        boolean: {
+          type: 'boolean',
+          names: ['-b', '--boolean'],
+          desc: 'A boolean option',
+        },
+        flag: {
+          type: 'flag',
+          names: ['-f', '--flag'],
+          desc: 'A flag option',
+        },
+      } as const satisfies Options;
+      const config: FormatterConfig = { descr: { align: 'merge' } };
+      const message = new AnsiFormatter(new OptionValidator(options), config).format();
+      expect(message.wrap()).toEqual(
+        `  -b, --boolean  <boolean> A boolean option\n` + `  -f, --flag     A flag option\n`,
+      );
+    });
+
+    it('should merge option descriptions with option parameters and option names', () => {
+      const options = {
+        boolean: {
+          type: 'boolean',
+          names: ['-b', '--boolean'],
+          desc: 'A boolean option',
+        },
+        string: {
+          type: 'string',
+          desc: 'A string option.',
+          positional: true,
+        },
+        flag: {
+          type: 'flag',
+          names: ['-f', '--flag'],
+          desc: 'A flag option',
+        },
+      } as const satisfies Options;
+      const config: FormatterConfig = { param: { align: 'merge' }, descr: { align: 'merge' } };
+      const message = new AnsiFormatter(new OptionValidator(options), config).format();
+      expect(message.wrap()).toEqual(
+        `  -b, --boolean <boolean> A boolean option\n` +
+          `  <string> A string option. Accepts positional parameters.\n` +
+          `  -f, --flag A flag option\n`,
+      );
     });
   });
 });

--- a/packages/tsargp/test/formatter/formatter.sections.spec.ts
+++ b/packages/tsargp/test/formatter/formatter.sections.spec.ts
@@ -134,6 +134,18 @@ describe('AnsiFormatter', () => {
       expect(message.wrap()).toEqual('title\n\n  prog [-b true]');
     });
 
+    it('should render a usage section with a nameless positional option', () => {
+      const options = {
+        boolean: {
+          type: 'boolean',
+          positional: true,
+        },
+      } as const satisfies Options;
+      const sections: HelpSections = [{ type: 'usage' }];
+      const message = new AnsiFormatter(new OptionValidator(options)).sections(sections);
+      expect(message.wrap()).toEqual('[<boolean>]');
+    });
+
     it('should render an empty groups section', () => {
       const sections: HelpSections = [{ type: 'groups' }];
       const message = new AnsiFormatter(new OptionValidator({})).sections(sections);


### PR DESCRIPTION
Added a new value `merge` for the `align` property of help columns, which instructs the formatter to merge the contents of the column with the previous one. The formatter page was updated accordingly.

Closes #158 
