### PR TITLE
Issues/157

### DIFF
--- a/.changeset/quick-dolls-dress.md
+++ b/.changeset/quick-dolls-dress.md
@@ -1,0 +1,5 @@
+---
+'tsargp': minor
+---
+
+The usage section in help messages now supports option dependencies. This is related to option requirements, but somewhat different.

--- a/.changeset/quick-dolls-dress.md
+++ b/.changeset/quick-dolls-dress.md
@@ -2,4 +2,4 @@
 'tsargp': minor
 ---
 
-The usage section in help messages now supports option dependencies. This is related to option requirements, but somewhat different.
+The usage section in help messages now supports option dependencies through the `requires` attribute. This is related to option requirements, but somewhat different.

--- a/.changeset/silent-chairs-sniff.md
+++ b/.changeset/silent-chairs-sniff.md
@@ -1,0 +1,5 @@
+---
+'@trulysimple/tsargp-docs': patch
+---
+
+The Formatter page was updated to document the new `requires` attribute for help usage sections.

--- a/packages/docs/pages/docs/library/formatter.mdx
+++ b/packages/docs/pages/docs/library/formatter.mdx
@@ -172,12 +172,31 @@ In addition to the [common properties], a usage section has the following proper
 - `indent` - the level of indentation of the section content (defaults to `0{:ts}`)
 - `filter` - a list of option keys to include or exclude (defaults to including all options)
 - `exclude` - whether the filter should exclude (defaults to `false{:ts}`)
-- `required` - a list of options that should be considered required in the usage
+- `required` - a list of options that should be considered always required
+- `requires` - a map of option keys to required options (defaults to none)
 - `comment` - a commentary to append to the usage (defaults to none)
 
 <Callout type="default">
   The filter can be used to create multiple usages of the same command, with different options. In
   the case of an inclusion filter, the options are listed in the same order specified in the filter.
+</Callout>
+
+#### Option dependencies
+
+The `requires` property is equivalent to an adjacency list, except that each source option can only
+reference a single target. Mutually dependent options are supported. The following table lists some
+examples that illustrate how this works. Suppose we have options A, B and C. Then:
+
+| Dependencies                       | Usage         | If C is always required |
+| ---------------------------------- | ------------- | ----------------------- |
+| A requires B requires C            | `[[[A] B] C]` | `[[A] B] C`             |
+| A and B require each other         | `[A B] [C]`   | `[A B] C`               |
+| A requires B requires C requires A | `[A B C]`     | `A B C`                 |
+| A and C require B                  | `[[A] B [C]]` | `[A] B C`               |
+| A requires B; C requires A         | `[[A [C]] B]` | `A C B`                 |
+
+<Callout type="info">
+  Mutual exclusivity is _not_ supported. For that purpose, you have to create different usages.
 </Callout>
 
 ### Groups section

--- a/packages/tsargp/examples/demo.options.ts
+++ b/packages/tsargp/examples/demo.options.ts
@@ -85,6 +85,7 @@ export default {
         breaks: 1,
         filter: ['help', 'version', 'helpCmd', 'hello'],
         exclude: true,
+        requires: { boolean: 'stringEnum' },
       },
       {
         type: 'text',
@@ -144,7 +145,6 @@ Report a bug: ${style(tf.faint)}https://github.com/trulysimple/tsargp/issues`,
     falsityNames: ['no'],
     requires: req.all(
       'stringEnum',
-      { numberEnum: 2 },
       req.one({ stringsRegex: ['a', 'b'] }, req.not({ numbersRange: [3, 4] })),
     ),
   },

--- a/packages/tsargp/lib/formatter.ts
+++ b/packages/tsargp/lib/formatter.ts
@@ -1721,8 +1721,14 @@ function formatRequiredValue(
     const connective = negate
       ? connectives[ConnectiveWord.notEquals]
       : connectives[ConnectiveWord.equals];
-    const spec = isOpt.bool(option) ? 'b' : isOpt.str(option) ? 's' : isOpt.num(option) ? 'n' : 'v';
+    const [spec, sep] = isOpt.bool(option)
+      ? ['b']
+      : isOpt.str(option)
+        ? ['s', connectives[ConnectiveWord.stringSep]]
+        : isOpt.num(option)
+          ? ['n', connectives[ConnectiveWord.numberSep]]
+          : 'v';
     const phrase = isOpt.arr(option) ? `[%${spec}]` : `%${spec}`;
-    result.word(connective).format(styles, phrase, { [spec]: value });
+    result.word(connective).format(styles, phrase, { [spec]: value }, { sep });
   }
 }

--- a/packages/tsargp/lib/styles.ts
+++ b/packages/tsargp/lib/styles.ts
@@ -428,9 +428,18 @@ export class TerminalString {
   /**
    * Appends a word that will be merged with the next word.
    * @param word The opening word
+   * @param pos The position of the next word
    * @returns The terminal string instance
    */
-  open(word: string): this {
+  open(word: string, pos = NaN): this {
+    if (pos >= 0) {
+      const [strings, lengths] = this.context;
+      if (pos < strings.length) {
+        strings[pos] = word + strings[pos];
+        lengths[pos] += word.length;
+      }
+      return this;
+    }
     return word ? this.word(word).setMerge() : this;
   }
 

--- a/packages/tsargp/test/formatter/formatter.requirements.spec.ts
+++ b/packages/tsargp/test/formatter/formatter.requirements.spec.ts
@@ -251,7 +251,7 @@ describe('AnsiFormatter', () => {
           type: 'flag',
           names: ['-f', '--flag'],
           desc: 'A flag option.',
-          requiredIf: req.all('other1', req.one({ other2: 1 }, req.not({ other3: '2' }))),
+          requiredIf: req.all('other1', req.one({ other2: [1, 2] }, req.not({ other3: '2' }))),
         },
         other1: {
           type: 'boolean',
@@ -259,7 +259,7 @@ describe('AnsiFormatter', () => {
           hide: true,
         },
         other2: {
-          type: 'number',
+          type: 'numbers',
           names: ['-req2', '--req2'],
           hide: true,
         },
@@ -271,7 +271,7 @@ describe('AnsiFormatter', () => {
       } as const satisfies Options;
       const message = new AnsiFormatter(new OptionValidator(options)).format();
       expect(message.wrap()).toEqual(
-        `  -f, --flag    A flag option. Required if (-req1 and (-req2 == 1 or -req3 != '2')).\n`,
+        `  -f, --flag    A flag option. Required if (-req1 and (-req2 == [1, 2] or -req3 != '2')).\n`,
       );
     });
 

--- a/packages/tsargp/test/formatter/formatter.requirements.spec.ts
+++ b/packages/tsargp/test/formatter/formatter.requirements.spec.ts
@@ -100,7 +100,10 @@ describe('AnsiFormatter', () => {
           type: 'flag',
           names: ['-f', '--flag'],
           desc: 'A flag option.',
-          requires: req.all('required1', req.one({ required2: 1 }, req.not({ required3: '2' }))),
+          requires: req.all(
+            'required1',
+            req.one({ required2: [1, 2] }, req.not({ required3: '2' })),
+          ),
         },
         required1: {
           type: 'boolean',
@@ -108,7 +111,7 @@ describe('AnsiFormatter', () => {
           hide: true,
         },
         required2: {
-          type: 'number',
+          type: 'numbers',
           names: ['-req2', '--req2'],
           hide: true,
         },
@@ -120,7 +123,7 @@ describe('AnsiFormatter', () => {
       } as const satisfies Options;
       const message = new AnsiFormatter(new OptionValidator(options)).format();
       expect(message.wrap()).toEqual(
-        `  -f, --flag    A flag option. Requires (-req1 and (-req2 == 1 or -req3 != '2')).\n`,
+        `  -f, --flag    A flag option. Requires (-req1 and (-req2 == [1, 2] or -req3 != '2')).\n`,
       );
     });
 

--- a/packages/tsargp/test/formatter/formatter.sections.spec.ts
+++ b/packages/tsargp/test/formatter/formatter.sections.spec.ts
@@ -334,6 +334,7 @@ describe('AnsiFormatter', () => {
         flag3: {
           type: 'flag',
           names: ['-f3'],
+          required: true,
         },
       } as const satisfies Options;
       const case0 = {};
@@ -350,7 +351,6 @@ describe('AnsiFormatter', () => {
       const case11: HelpSections = [
         {
           type: 'usage',
-          required: ['flag3'],
           filter: ['flag3', 'flag2', 'flag1'],
           requires: { flag1: 'flag2', flag2: 'flag3' },
         },
@@ -358,45 +358,22 @@ describe('AnsiFormatter', () => {
       const case12: HelpSections = [
         {
           type: 'usage',
-          required: ['flag3'],
           filter: ['flag3', 'flag2', 'flag1'],
           requires: { flag1: 'flag2', flag3: 'flag1' },
         },
       ];
       const formatter = new AnsiFormatter(new OptionValidator(options));
-      expect(formatter.sections([{ type: 'usage', required: ['flag3'], ...case0 }]).wrap()).toEqual(
-        '[-f1] [-f2] -f3',
-      );
-      expect(formatter.sections([{ type: 'usage', required: ['flag3'], ...case1 }]).wrap()).toEqual(
-        '[[-f1] -f2] -f3',
-      );
-      expect(formatter.sections([{ type: 'usage', required: ['flag3'], ...case2 }]).wrap()).toEqual(
-        '[-f1 [-f2]] -f3',
-      );
-      expect(formatter.sections([{ type: 'usage', required: ['flag3'], ...case3 }]).wrap()).toEqual(
-        '[-f1 -f2] -f3',
-      );
-      expect(formatter.sections([{ type: 'usage', required: ['flag3'], ...case4 }]).wrap()).toEqual(
-        '[[-f1] -f2] -f3',
-      );
-      expect(formatter.sections([{ type: 'usage', required: ['flag3'], ...case5 }]).wrap()).toEqual(
-        '-f1 -f2 -f3',
-      );
-      expect(formatter.sections([{ type: 'usage', required: ['flag3'], ...case6 }]).wrap()).toEqual(
-        '[-f1] -f2 -f3',
-      );
-      expect(formatter.sections([{ type: 'usage', required: ['flag3'], ...case7 }]).wrap()).toEqual(
-        '[-f1] -f3 [-f2]',
-      );
-      expect(formatter.sections([{ type: 'usage', required: ['flag3'], ...case8 }]).wrap()).toEqual(
-        '-f1 -f3 -f2',
-      );
-      expect(formatter.sections([{ type: 'usage', required: ['flag3'], ...case9 }]).wrap()).toEqual(
-        '[-f1] -f2 -f3',
-      );
-      expect(
-        formatter.sections([{ type: 'usage', required: ['flag3'], ...case10 }]).wrap(),
-      ).toEqual('-f1 -f2 -f3');
+      expect(formatter.sections([{ type: 'usage', ...case0 }]).wrap()).toEqual('[-f1] [-f2] -f3');
+      expect(formatter.sections([{ type: 'usage', ...case1 }]).wrap()).toEqual('[[-f1] -f2] -f3');
+      expect(formatter.sections([{ type: 'usage', ...case2 }]).wrap()).toEqual('[-f1 [-f2]] -f3');
+      expect(formatter.sections([{ type: 'usage', ...case3 }]).wrap()).toEqual('[-f1 -f2] -f3');
+      expect(formatter.sections([{ type: 'usage', ...case4 }]).wrap()).toEqual('[[-f1] -f2] -f3');
+      expect(formatter.sections([{ type: 'usage', ...case5 }]).wrap()).toEqual('-f1 -f2 -f3');
+      expect(formatter.sections([{ type: 'usage', ...case6 }]).wrap()).toEqual('[-f1] -f2 -f3');
+      expect(formatter.sections([{ type: 'usage', ...case7 }]).wrap()).toEqual('[-f1] -f3 [-f2]');
+      expect(formatter.sections([{ type: 'usage', ...case8 }]).wrap()).toEqual('-f1 -f3 -f2');
+      expect(formatter.sections([{ type: 'usage', ...case9 }]).wrap()).toEqual('[-f1] -f2 -f3');
+      expect(formatter.sections([{ type: 'usage', ...case10 }]).wrap()).toEqual('-f1 -f2 -f3');
       expect(formatter.sections(case11).wrap()).toEqual('-f3 [-f2 [-f1]]');
       expect(formatter.sections(case12).wrap()).toEqual('-f3 -f1 -f2');
     });

--- a/packages/tsargp/test/formatter/formatter.sections.spec.ts
+++ b/packages/tsargp/test/formatter/formatter.sections.spec.ts
@@ -264,5 +264,141 @@ describe('AnsiFormatter', () => {
       expect(formatter.sections(sections1).wrap()).toEqual('group1\n\n  -f1');
       expect(formatter.sections(sections2).wrap()).toEqual('group2\n\n  -f2');
     });
+
+    it('should group options according to an adjacency list in a usage section', () => {
+      const options = {
+        flag1: {
+          type: 'flag',
+          names: ['-f1'],
+        },
+        flag2: {
+          type: 'flag',
+          names: ['-f2'],
+        },
+        flag3: {
+          type: 'flag',
+          names: ['-f3'],
+        },
+      } as const satisfies Options;
+      const case0 = {};
+      const case1 = { requires: { flag1: 'flag2' } };
+      const case2 = { requires: { flag2: 'flag1' } };
+      const case3 = { requires: { flag1: 'flag2', flag2: 'flag1' } };
+      const case4 = { requires: { flag1: 'flag2', flag2: 'flag3' } };
+      const case5 = { requires: { flag2: 'flag1', flag3: 'flag2' } };
+      const case6 = { requires: { flag1: 'flag2', flag3: 'flag2' } };
+      const case7 = { requires: { flag1: 'flag3', flag2: 'flag3' } };
+      const case8 = { requires: { flag1: 'flag2', flag3: 'flag1' } };
+      const case9 = { requires: { flag2: 'flag3', flag3: 'flag2' } };
+      const case10 = { requires: { flag1: 'flag2', flag2: 'flag3', flag3: 'flag1' } };
+      const case11: HelpSections = [
+        {
+          type: 'usage',
+          filter: ['flag3', 'flag2', 'flag1'],
+          requires: { flag1: 'flag2', flag2: 'flag3' },
+        },
+      ];
+      const case12: HelpSections = [
+        {
+          type: 'usage',
+          filter: ['flag3', 'flag2', 'flag1'],
+          requires: { flag1: 'flag2', flag3: 'flag1' },
+        },
+      ];
+      const formatter = new AnsiFormatter(new OptionValidator(options));
+      expect(formatter.sections([{ type: 'usage', ...case0 }]).wrap()).toEqual('[-f1] [-f2] [-f3]');
+      expect(formatter.sections([{ type: 'usage', ...case1 }]).wrap()).toEqual('[[-f1] -f2] [-f3]');
+      expect(formatter.sections([{ type: 'usage', ...case2 }]).wrap()).toEqual('[-f1 [-f2]] [-f3]');
+      expect(formatter.sections([{ type: 'usage', ...case3 }]).wrap()).toEqual('[-f1 -f2] [-f3]');
+      expect(formatter.sections([{ type: 'usage', ...case4 }]).wrap()).toEqual('[[[-f1] -f2] -f3]');
+      expect(formatter.sections([{ type: 'usage', ...case5 }]).wrap()).toEqual('[-f1 [-f2 [-f3]]]');
+      expect(formatter.sections([{ type: 'usage', ...case6 }]).wrap()).toEqual('[[-f1] -f2 [-f3]]');
+      expect(formatter.sections([{ type: 'usage', ...case7 }]).wrap()).toEqual('[[-f1] -f3 [-f2]]');
+      expect(formatter.sections([{ type: 'usage', ...case8 }]).wrap()).toEqual('[[-f1 [-f3]] -f2]');
+      expect(formatter.sections([{ type: 'usage', ...case9 }]).wrap()).toEqual('[-f1] [-f2 -f3]');
+      expect(formatter.sections([{ type: 'usage', ...case10 }]).wrap()).toEqual('[-f1 -f2 -f3]');
+      expect(formatter.sections(case11).wrap()).toEqual('[-f3 [-f2 [-f1]]]');
+      expect(formatter.sections(case12).wrap()).toEqual('[[[-f3] -f1] -f2]');
+    });
+
+    it('should group options according to an adjacency list in a usage section, when an option is always required', () => {
+      const options = {
+        flag1: {
+          type: 'flag',
+          names: ['-f1'],
+        },
+        flag2: {
+          type: 'flag',
+          names: ['-f2'],
+        },
+        flag3: {
+          type: 'flag',
+          names: ['-f3'],
+        },
+      } as const satisfies Options;
+      const case0 = {};
+      const case1 = { requires: { flag1: 'flag2' } };
+      const case2 = { requires: { flag2: 'flag1' } };
+      const case3 = { requires: { flag1: 'flag2', flag2: 'flag1' } };
+      const case4 = { requires: { flag1: 'flag2', flag2: 'flag3' } };
+      const case5 = { requires: { flag2: 'flag1', flag3: 'flag2' } };
+      const case6 = { requires: { flag1: 'flag2', flag3: 'flag2' } };
+      const case7 = { requires: { flag1: 'flag3', flag2: 'flag3' } };
+      const case8 = { requires: { flag1: 'flag2', flag3: 'flag1' } };
+      const case9 = { requires: { flag2: 'flag3', flag3: 'flag2' } };
+      const case10 = { requires: { flag1: 'flag2', flag2: 'flag3', flag3: 'flag1' } };
+      const case11: HelpSections = [
+        {
+          type: 'usage',
+          required: ['flag3'],
+          filter: ['flag3', 'flag2', 'flag1'],
+          requires: { flag1: 'flag2', flag2: 'flag3' },
+        },
+      ];
+      const case12: HelpSections = [
+        {
+          type: 'usage',
+          required: ['flag3'],
+          filter: ['flag3', 'flag2', 'flag1'],
+          requires: { flag1: 'flag2', flag3: 'flag1' },
+        },
+      ];
+      const formatter = new AnsiFormatter(new OptionValidator(options));
+      expect(formatter.sections([{ type: 'usage', required: ['flag3'], ...case0 }]).wrap()).toEqual(
+        '[-f1] [-f2] -f3',
+      );
+      expect(formatter.sections([{ type: 'usage', required: ['flag3'], ...case1 }]).wrap()).toEqual(
+        '[[-f1] -f2] -f3',
+      );
+      expect(formatter.sections([{ type: 'usage', required: ['flag3'], ...case2 }]).wrap()).toEqual(
+        '[-f1 [-f2]] -f3',
+      );
+      expect(formatter.sections([{ type: 'usage', required: ['flag3'], ...case3 }]).wrap()).toEqual(
+        '[-f1 -f2] -f3',
+      );
+      expect(formatter.sections([{ type: 'usage', required: ['flag3'], ...case4 }]).wrap()).toEqual(
+        '[[-f1] -f2] -f3',
+      );
+      expect(formatter.sections([{ type: 'usage', required: ['flag3'], ...case5 }]).wrap()).toEqual(
+        '-f1 -f2 -f3',
+      );
+      expect(formatter.sections([{ type: 'usage', required: ['flag3'], ...case6 }]).wrap()).toEqual(
+        '[-f1] -f2 -f3',
+      );
+      expect(formatter.sections([{ type: 'usage', required: ['flag3'], ...case7 }]).wrap()).toEqual(
+        '[-f1] -f3 [-f2]',
+      );
+      expect(formatter.sections([{ type: 'usage', required: ['flag3'], ...case8 }]).wrap()).toEqual(
+        '-f1 -f3 -f2',
+      );
+      expect(formatter.sections([{ type: 'usage', required: ['flag3'], ...case9 }]).wrap()).toEqual(
+        '[-f1] -f2 -f3',
+      );
+      expect(
+        formatter.sections([{ type: 'usage', required: ['flag3'], ...case10 }]).wrap(),
+      ).toEqual('-f1 -f2 -f3');
+      expect(formatter.sections(case11).wrap()).toEqual('-f3 [-f2 [-f1]]');
+      expect(formatter.sections(case12).wrap()).toEqual('-f3 -f1 -f2');
+    });
   });
 });

--- a/packages/tsargp/test/styles/styles.spec.ts
+++ b/packages/tsargp/test/styles/styles.spec.ts
@@ -67,6 +67,13 @@ describe('TerminalString', () => {
       expect(str.lengths).toEqual([4, 6]);
       expect(str.strings).toEqual(['type', 'script']);
     });
+
+    it('should add opening words at specific positions', () => {
+      const str = new TerminalString().open('"', 0).word('type').open('[', 0);
+      expect(str.count).toEqual(1);
+      expect(str.lengths).toEqual([5]);
+      expect(str.strings).toEqual(['[type']);
+    });
   });
 
   describe('other', () => {


### PR DESCRIPTION
Added a `requires` attribute in the usage section of help messages, to support option dependencies. This is related to option requirements, but somewhat different. Updated the Formatter page to document this.

Closes #157 
