### PR TITLE
Issues/165

### DIFF
--- a/.changeset/cold-jobs-flow.md
+++ b/.changeset/cold-jobs-flow.md
@@ -1,0 +1,5 @@
+---
+'tsargp': minor
+---
+
+The `example` value is now enclosed in square brackets in the help message when the option has a fallback value, just as is done with parameter names and option types.

--- a/.changeset/tall-beds-juggle.md
+++ b/.changeset/tall-beds-juggle.md
@@ -1,0 +1,5 @@
+---
+'@trulysimple/tsargp-docs': patch
+---
+
+The Home page was updated with the new help message of the demo example.

--- a/packages/docs/pages/demo.mdx
+++ b/packages/docs/pages/demo.mdx
@@ -63,6 +63,7 @@ export const Demo = dynamic(() => import('@components/demo'), { ssr: false });
 ### Inline parameters
 
 - check if parameters can be inlined with option names (e.g., `-ss=abc`)
+- check if inline parameters can contain equal signs (e.g., `-ss==a=b`)
 - check if inline parameters are disallowed for an option (e.g., `-se=one`)
 - check if inline parameters are required for an option (e.g., `-ne 1`)
 

--- a/packages/docs/pages/index.mdx
+++ b/packages/docs/pages/index.mdx
@@ -38,15 +38,15 @@ Get started with:
 
   [95m-s[0m, [95m--stringRegex[0m  [90m<my str>[0m      [0mA string option. Values must match the regex [31m/^\d+$/[0m. Defaults to
                                    [32m'123456789'[0m. Can be clustered with [32m's'[0m.[0m
-  [95m-se[0m, [95m--stringEnum[0m  [32m'one'[0m         [0mA string option. Values must be one of {[32m'one'[0m, [32m'two'[0m}. Disallows
-                                   inline parameters.[0m
+  [95m-se[0m, [95m--stringEnum[0m  [[32m'one'[0m]       [0mA string option. Values must be one of {[32m'one'[0m, [32m'two'[0m}. Falls back
+                                   to [32m'two'[0m if specified without parameter. Disallows inline
+                                   parameters.[0m
   [95m-ss[0m, [95m--strings[0m     [90m[<strings>][0m   [0mA strings option. Values are delimited by [32m','[0m. Values will be
-                                   trimmed. Values will be converted to uppercase. Values must match
-                                   the regex [31m/^[\w-]+$/[0m. Defaults to [[32m'one'[0m, [32m'two'[0m]. Falls back to
-                                   [] if specified without parameter.[0m
+                                   trimmed. Values will be converted to uppercase. Defaults to
+                                   [[32m'one'[0m]. Falls back to [[32m'two'[0m] if specified without parameter.[0m
   [95m--stringsEnum[0m      [32m'one'[0m[90m...[0m      [0mA strings option. Accepts multiple parameters. Accepts positional
-                                   parameters that may be preceded by [95m--[0m. Values must be one of
-                                   {[32m'one'[0m, [32m'two'[0m}. Value count is limited to [33m3[0m.[0m
+                                   parameters that may be preceded by [95m--[0m. Value count is limited to
+                                   [33m3[0m.[0m
 
 [1mNumber options:[0m
 
@@ -55,17 +55,15 @@ Get started with:
   [95m-ne[0m, [95m--numberEnum[0m  =[33m1[0m            [0mA number option. Values must be one of {[33m1[0m, [33m2[0m}. Requires inline
                                    parameters.[0m
   [95m-ns[0m, [95m--numbers[0m     [90m<numbers>...[0m  [0mA numbers option. Accepts multiple parameters. Values will be
-                                   converted with Math.round. Values must be in the range [[33m0[0m,
-                                   [33mInfinity[0m]. Defaults to [[33m1[0m, [33m2[0m].[0m
+                                   converted with Math.round. Defaults to [[33m1[0m, [33m2[0m].[0m
   [95m--numbersEnum[0m      [32m'1,2'[0m         [0mA numbers option. Values are delimited by [32m','[0m. May be specified
-                                   multiple times. Values must be one of {[33m1[0m, [33m2[0m}. Duplicate values
-                                   will be removed.[0m
+                                   multiple times. Duplicate values will be removed.[0m
 
 [1mUsage:[0m
 
   [0mdemo.js[0m [0m[([95m-h[0m|[95m--help[0m)] [([95m-v[0m|[95m--version[0m)] [32m# get help[0m
   [0mdemo.js[0m [0m[95mhello[0m [90m...[0m [32m# execute the hello command[0m
-  [0mdemo.js[0m [0m[([95m-f[0m|[95m--flag[0m|[95m--no-flag[0m)] [[([95m-b[0m|[95m--boolean[0m) [90m<boolean>[0m] ([95m-se[0m|[95m--stringEnum[0m) [32m'one'[0m]
+  [0mdemo.js[0m [0m[([95m-f[0m|[95m--flag[0m|[95m--no-flag[0m)] [[([95m-b[0m|[95m--boolean[0m) [90m<boolean>[0m] ([95m-se[0m|[95m--stringEnum[0m) [[32m'one'[0m]]
           [([95m-s[0m|[95m--stringRegex[0m) [90m<my str>[0m] [([95m-n[0m|[95m--numberRange[0m) [90m<my num>[0m] [([95m-ne[0m|[95m--numberEnum[0m)=[33m1[0m]
           [([95m-ss[0m|[95m--strings[0m) [90m[<strings>][0m] [([95m-ns[0m|[95m--numbers[0m) [90m<numbers>...[0m] [[([95m--stringsEnum[0m|[95m--[0m)]
           [32m'one'[0m[90m...[0m] [[95m--numbersEnum[0m [32m'1,2'[0m][0m

--- a/packages/tsargp/examples/demo.options.ts
+++ b/packages/tsargp/examples/demo.options.ts
@@ -143,10 +143,7 @@ Report a bug: ${style(fg.brightBlack)}https://github.com/trulysimple/tsargp/issu
     default: false,
     truthNames: ['yes'],
     falsityNames: ['no'],
-    requires: req.all(
-      'stringEnum',
-      req.one({ stringsRegex: ['a', 'b'] }, req.not({ numbersRange: [3, 4] })),
-    ),
+    requires: req.all('stringEnum', req.one({ strings: ['a', 'b'] }, req.not({ numbers: [3, 4] }))),
   },
   /**
    * A string option that has a regex constraint.
@@ -184,6 +181,7 @@ Report a bug: ${style(fg.brightBlack)}https://github.com/trulysimple/tsargp/issu
     group: 'String options:',
     enums: ['one', 'two'],
     example: 'one',
+    fallback: 'two',
     inline: false,
   },
   /**
@@ -201,14 +199,13 @@ Report a bug: ${style(fg.brightBlack)}https://github.com/trulysimple/tsargp/issu
   /**
    * A strings option that has a regex constraint.
    */
-  stringsRegex: {
+  strings: {
     type: 'strings',
     names: ['-ss', '--strings'],
     desc: 'A strings option.',
     group: 'String options:',
-    regex: /^[\w-]+$/,
-    default: ['one', 'two'],
-    fallback: [],
+    default: ['one'],
+    fallback: ['two'],
     separator: ',',
     trim: true,
     case: 'upper',
@@ -216,12 +213,11 @@ Report a bug: ${style(fg.brightBlack)}https://github.com/trulysimple/tsargp/issu
   /**
    * A numbers option that has a range constraint.
    */
-  numbersRange: {
+  numbers: {
     type: 'numbers',
     names: ['-ns', '--numbers'],
     desc: 'A numbers option.',
     group: 'Number options:',
-    range: [0, Infinity],
     default: [1, 2],
     conv: 'round',
   },
@@ -233,7 +229,6 @@ Report a bug: ${style(fg.brightBlack)}https://github.com/trulysimple/tsargp/issu
     names: ['', '--stringsEnum'],
     desc: 'A strings option.',
     group: 'String options:',
-    enums: ['one', 'two'],
     example: ['one'],
     positional: '--',
     limit: 3,
@@ -246,7 +241,6 @@ Report a bug: ${style(fg.brightBlack)}https://github.com/trulysimple/tsargp/issu
     names: ['', '--numbersEnum'],
     desc: 'A numbers option.',
     group: 'Number options:',
-    enums: [1, 2],
     example: [1, 2],
     separator: ',',
     append: true,

--- a/packages/tsargp/examples/demo.ts
+++ b/packages/tsargp/examples/demo.ts
@@ -16,8 +16,8 @@ interface Values {
   numberRange: number;
   stringEnum: 'one' | 'two' | undefined;
   numberEnum: 1 | 2 | undefined;
-  stringsRegex: string[];
-  numbersRange: number[];
+  strings: string[];
+  numbers: number[];
   stringsEnum: Array<'one' | 'two'> | undefined;
   numbersEnum: Array<1 | 2> | undefined;
 }

--- a/packages/tsargp/lib/formatter.ts
+++ b/packages/tsargp/lib/formatter.ts
@@ -1,12 +1,18 @@
 //--------------------------------------------------------------------------------------------------
 // Imports
 //--------------------------------------------------------------------------------------------------
-import type { OpaqueOption, OpaqueOptions, Requires, RequiresEntry, RequiresVal } from './options';
-import type { Style, FormatStyles, ConnectiveWords, HelpMessage } from './styles';
-import type { Concrete } from './utils';
-import type { OptionValidator } from './validator';
+import type {
+  OpaqueOption,
+  OpaqueOptions,
+  Requires,
+  RequiresEntry,
+  RequiresVal,
+} from './options.js';
+import type { Style, FormatStyles, ConnectiveWords, HelpMessage } from './styles.js';
+import type { Concrete } from './utils.js';
+import type { OptionValidator } from './validator.js';
 
-import { tf, HelpItem, ConnectiveWord } from './enums';
+import { tf, HelpItem, ConnectiveWord } from './enums.js';
 import {
   RequiresAll,
   RequiresNot,
@@ -14,9 +20,9 @@ import {
   isOpt,
   getParamCount,
   getOptionNames,
-} from './options';
-import { AnsiMessage, JsonMessage, TextMessage, TerminalString, style, format } from './styles';
-import { max, combineRegExp, regexps } from './utils';
+} from './options.js';
+import { AnsiMessage, JsonMessage, TextMessage, TerminalString, style, format } from './styles.js';
+import { max, combineRegExp, regexps } from './utils.js';
 
 //--------------------------------------------------------------------------------------------------
 // Public types
@@ -1555,7 +1561,8 @@ function formatParam(option: OpaqueOption, styles: FormatStyles, result: Termina
       spec = isOpt.bool(option) ? 'b' : isOpt.str(option) ? 's' : isOpt.num(option) ? 'n' : 'v';
       value = example;
     }
-    result.format(styles, `${equals}%${spec}`, { [spec]: value });
+    const phrase = min <= 0 ? `[${equals}%${spec}]` : `${equals}%${spec}`;
+    result.format(styles, phrase, { [spec]: value });
     if (ellipsis) {
       result.setMerge().style(paramStyle, ellipsis, styles.text);
     }

--- a/packages/tsargp/lib/formatter.ts
+++ b/packages/tsargp/lib/formatter.ts
@@ -1561,8 +1561,8 @@ function formatParam(option: OpaqueOption, styles: FormatStyles, result: Termina
       spec = isOpt.bool(option) ? 'b' : isOpt.str(option) ? 's' : isOpt.num(option) ? 'n' : 'v';
       value = example;
     }
-    const phrase = min <= 0 ? `[${equals}%${spec}]` : `${equals}%${spec}`;
-    result.format(styles, phrase, { [spec]: value });
+    const phrase = `${equals}%${spec}`;
+    result.format(styles, min <= 0 ? `[${phrase}]` : `${phrase}`, { [spec]: value });
     if (ellipsis) {
       result.setMerge().style(paramStyle, ellipsis, styles.text);
     }

--- a/packages/tsargp/lib/index.ts
+++ b/packages/tsargp/lib/index.ts
@@ -1,11 +1,11 @@
-export type * from './options';
-export type * from './utils';
-export type * from './validator';
+export type * from './options.js';
+export type * from './utils.js';
+export type * from './validator.js';
 
-export * from './enums';
-export * from './formatter';
-export * from './parser';
-export * from './styles';
+export * from './enums.js';
+export * from './formatter.js';
+export * from './parser.js';
+export * from './styles.js';
 
-export { req } from './options';
-export { OptionValidator } from './validator';
+export { req } from './options.js';
+export { OptionValidator } from './validator.js';

--- a/packages/tsargp/lib/options.ts
+++ b/packages/tsargp/lib/options.ts
@@ -1,9 +1,9 @@
 //--------------------------------------------------------------------------------------------------
 // Imports
 //--------------------------------------------------------------------------------------------------
-import type { FormatterConfig, HelpSections } from './formatter';
-import type { HelpMessage, Style } from './styles';
-import type { Resolve, URL, KeyHaving, Range } from './utils';
+import type { FormatterConfig, HelpSections } from './formatter.js';
+import type { HelpMessage, Style } from './styles.js';
+import type { Resolve, URL, KeyHaving, Range } from './utils.js';
 
 //--------------------------------------------------------------------------------------------------
 // Constants

--- a/packages/tsargp/lib/parser.ts
+++ b/packages/tsargp/lib/parser.ts
@@ -1,7 +1,7 @@
 //--------------------------------------------------------------------------------------------------
 // Imports
 //--------------------------------------------------------------------------------------------------
-import type { HelpSections } from './formatter';
+import type { HelpSections } from './formatter.js';
 import type {
   Options,
   OptionValues,
@@ -11,22 +11,22 @@ import type {
   Requires,
   RequiresEntry,
   ResolveCallback,
-} from './options';
-import type { Range } from './utils';
+} from './options.js';
+import type { Range } from './utils.js';
 import type {
   OptionInfo,
   ConcreteConfig,
   ValidatorConfig,
   ValidationFlags,
   ValidationResult,
-} from './validator';
+} from './validator.js';
 
-import { ConnectiveWord, ErrorItem } from './enums';
-import { createFormatter, isHelpFormat } from './formatter';
-import { RequiresAll, RequiresNot, RequiresOne, isOpt, getParamCount } from './options';
-import { format, HelpMessage, WarnMessage, TextMessage, TerminalString } from './styles';
-import { areEqual, findSimilar, getArgs, isTrue, max, findInObject, env } from './utils';
-import { OptionValidator, defaultConfig } from './validator';
+import { ConnectiveWord, ErrorItem } from './enums.js';
+import { createFormatter, isHelpFormat } from './formatter.js';
+import { RequiresAll, RequiresNot, RequiresOne, isOpt, getParamCount } from './options.js';
+import { format, HelpMessage, WarnMessage, TextMessage, TerminalString } from './styles.js';
+import { areEqual, findSimilar, getArgs, isTrue, max, findInObject, env } from './utils.js';
+import { OptionValidator, defaultConfig } from './validator.js';
 
 //--------------------------------------------------------------------------------------------------
 // Constants

--- a/packages/tsargp/lib/styles.ts
+++ b/packages/tsargp/lib/styles.ts
@@ -1,9 +1,9 @@
 //--------------------------------------------------------------------------------------------------
 // Imports and Exports
 //--------------------------------------------------------------------------------------------------
-import type { Alias, Concrete, Enumerate, URL, ValuesOf } from './utils';
-import { cs, tf, fg, bg, ConnectiveWord } from './enums';
-import { env, max, regexps, selectAlternative } from './utils';
+import type { Alias, Concrete, Enumerate, URL, ValuesOf } from './utils.js';
+import { cs, tf, fg, bg, ConnectiveWord } from './enums.js';
+import { env, max, regexps, selectAlternative } from './utils.js';
 
 export { sequence as seq, sgr as style, foreground as fg8, background as bg8, underline as ul8 };
 export { underlineStyle as ul, formatFunctions as format };
@@ -428,19 +428,18 @@ export class TerminalString {
   /**
    * Appends a word that will be merged with the next word.
    * @param word The opening word
-   * @param pos The position of the next word
+   * @param pos The position of a previously added word
    * @returns The terminal string instance
    */
   open(word: string, pos = NaN): this {
-    if (pos >= 0) {
+    if (pos >= 0 && pos < this.count) {
       const [strings, lengths] = this.context;
-      if (pos < strings.length) {
-        strings[pos] = word + strings[pos];
-        lengths[pos] += word.length;
-      }
-      return this;
+      strings[pos] = word + strings[pos];
+      lengths[pos] += word.length;
+    } else if (word) {
+      this.word(word).setMerge();
     }
-    return word ? this.word(word).setMerge() : this;
+    return this;
   }
 
   /**

--- a/packages/tsargp/lib/validator.ts
+++ b/packages/tsargp/lib/validator.ts
@@ -1,11 +1,11 @@
 //--------------------------------------------------------------------------------------------------
 // Imports
 //--------------------------------------------------------------------------------------------------
-import type { OpaqueOption, Requires, RequiresVal, OpaqueOptions } from './options';
-import type { FormatArgs, FormattingFlags, MessageStyles } from './styles';
-import type { Concrete, NamingRules, Range } from './utils';
+import type { OpaqueOption, Requires, RequiresVal, OpaqueOptions } from './options.js';
+import type { FormatArgs, FormattingFlags, MessageStyles } from './styles.js';
+import type { Concrete, NamingRules, Range } from './utils.js';
 
-import { tf, fg, ErrorItem, ConnectiveWord } from './enums';
+import { tf, fg, ErrorItem, ConnectiveWord } from './enums.js';
 import {
   RequiresAll,
   RequiresOne,
@@ -13,9 +13,9 @@ import {
   isOpt,
   getParamCount,
   getOptionNames,
-} from './options';
-import { style, TerminalString, ErrorMessage, WarnMessage } from './styles';
-import { findSimilar, matchNamingRules } from './utils';
+} from './options.js';
+import { style, TerminalString, ErrorMessage, WarnMessage } from './styles.js';
+import { findSimilar, matchNamingRules } from './utils.js';
 
 //--------------------------------------------------------------------------------------------------
 // Constants

--- a/packages/tsargp/test/formatter/formatter.param.spec.ts
+++ b/packages/tsargp/test/formatter/formatter.param.spec.ts
@@ -249,6 +249,22 @@ describe('AnsiFormatter', () => {
       expect(message.wrap()).toEqual(`  -b, --boolean  true  A boolean option\n`);
     });
 
+    it('should handle a boolean option with fallback and example values', () => {
+      const options = {
+        boolean: {
+          type: 'boolean',
+          names: ['-b', '--boolean'],
+          desc: 'A boolean option.',
+          fallback: true,
+          example: true,
+        },
+      } as const satisfies Options;
+      const message = new AnsiFormatter(new OptionValidator(options)).format();
+      expect(message.wrap()).toEqual(
+        `  -b, --boolean  [true]  A boolean option. Falls back to true if specified without parameter.\n`,
+      );
+    });
+
     it('should handle a string option with a fallback value', () => {
       const options = {
         string: {

--- a/packages/tsargp/test/styles/styles.spec.ts
+++ b/packages/tsargp/test/styles/styles.spec.ts
@@ -71,8 +71,8 @@ describe('TerminalString', () => {
     it('should add opening words at specific positions', () => {
       const str = new TerminalString().open('"', 0).word('type').open('[', 0);
       expect(str.count).toEqual(1);
-      expect(str.lengths).toEqual([5]);
-      expect(str.strings).toEqual(['[type']);
+      expect(str.lengths).toEqual([6]);
+      expect(str.strings).toEqual(['["type']);
     });
   });
 

--- a/vitest.workspace.ts
+++ b/vitest.workspace.ts
@@ -1,0 +1,1 @@
+export default ['packages/tsargp'];


### PR DESCRIPTION
The `example` value is now enclosed in square brackets in the help message when the option has a fallback value, just as is done with parameter names and option types.

Added the `.js` extension to all library imports, to fix import issues in the `lib` export path.

Updated the Home page with the new help message of the demo example.

Closes #165 
