### PR TITLE
Issues/176

### DIFF
--- a/.changeset/many-points-admire.md
+++ b/.changeset/many-points-admire.md
@@ -1,0 +1,5 @@
+---
+'@trulysimple/tsargp-docs': patch
+---
+
+Updated the Demo page to reflect the most recent version of the demo example. Updated the Play page to add some tips for testing validation errors and warnings.

--- a/.changeset/rude-dingos-crash.md
+++ b/.changeset/rude-dingos-crash.md
@@ -1,0 +1,5 @@
+---
+'tsargp': patch
+---
+
+Fixed the default value of the `compIndex` parsing flag when providing a set of flags without it.

--- a/packages/docs/components/play.tsx
+++ b/packages/docs/components/play.tsx
@@ -41,7 +41,7 @@ class PlayCommand extends Command<PlayProps> {
     const source = this.props.callbacks.getSource();
     const options = Function('tsargp', `'use strict';${source}`)(tsargp);
     const parser = new ArgumentParser(options);
-    const { warning } = await parser.validate();
+    const { warning } = await parser.validate({ detectNamingIssues: true });
     if (warning) {
       this.println(warning.wrap(this.state.width));
     }

--- a/packages/docs/pages/demo.mdx
+++ b/packages/docs/pages/demo.mdx
@@ -23,42 +23,41 @@ export const Demo = dynamic(() => import('@components/demo'), { ssr: false });
 
 ### Word completion
 
-- check if completion works by pressing `Tab` (it behaves slightly differently than a real bash)
-- check if an option name gets completed (e.g., `-<Tab>`, `--<Tab>`, `--h<Tab>`)
-- check if an option parameter gets completed (e.g., `o<Tab>`, `-b <Tab>`, `-se <Tab>`, `-ne <Tab>`)
+- check if completion works by pressing `<Tab>` (it behaves slightly differently than a real bash)
+- check if option names get completed (e.g., `<Tab>`, `--<Tab>`, `--h<Tab>`)
+- check if option parameters get completed (e.g., `-b <Tab>`, `-se <Tab>`, `-ne=<Tab>`)
 
 ### Positional arguments
 
 - check if positional arguments can be specified before named ones (e.g., `one -s 0`)
-- check if all arguments after `--` are recognized as positional (e.g., try `-- -f` and see that it
-  fails)
+- check if all arguments after `--` are recognized as positional (e.g., `-- -f`)
 
 ### Cluster arguments
 
 - check if cluster arguments can be specified (e.g., `-sn 1 -1`)
 - check if cluster arguments can be specified with inline parameters (e.g., `-s1` or `-n-1`)
 
-### String parameters
+### Value constraints
 
 - check if a string parameter matches the required regex (e.g., try `-s A` and see that it fails)
 - check if a string parameter matches the required enums (e.g., try `-se A` and see that it fails)
-- check if a string parameter gets normalized (e.g., `-ss abc` and see that it outputs `ABC`)
-- check if values get overridden when an option is specified repeatedly (e.g., `-s 1 -s 2`)
-
-### Number parameters
-
 - check if a number parameter matches the required range (e.g., try `-n 1` and see that it fails)
-- check if a number parameter matches the required enums (e.g., try `-ne 0` and see that it fails)
+- check if a number parameter matches the required enums (e.g., try `-ne=0` and see that it fails)
+- check if the element count is limited to a certain amount (e.g., `-- a b c d`)
+
+### Value normalization
+
+- check if a string parameter gets normalized (e.g., `-ss abc` and see that it outputs `ABC`)
 - check if a number parameter gets normalized (e.g., `-ns 1.7` and see that it outputs `2`)
-- check if values get overridden when an option is specified repeatedly (e.g., `-n -1 -n -2`)
+- check if duplicate values get removed (e.g., `--numbersUnique 1,2,1,2`)
 
-### Array parameters
+### Value overwriting/appendage
 
-- check if duplicate values get removed (e.g., `--numbersEnum 1,2,1,2`)
-- check if values get limited to a certain element count (e.g., `-- one two one two`)
-- check if values get overridden when an option is specified repeatedly (e.g., `one -- two`)
-- check if values get appended when an option is specified repeatedly (e.g.,
-  `--numbersEnum 1 --numbersEnum 2`)
+- check if values get overridden when a string option is specified repeatedly (e.g., `-s 1 -s 2`)
+- check if values get overridden when a number option is specified repeatedly (e.g., `-n -1 -n -2`)
+- check if values get overridden when an array option is specified repeatedly (e.g., `one -- two`)
+- check if values get appended when an array option is specified repeatedly (e.g.,
+  `--numbersUnique 1 --numbersUnique 2`)
 
 ### Inline parameters
 
@@ -77,7 +76,7 @@ export const Demo = dynamic(() => import('@components/demo'), { ssr: false });
 ### Miscellaneous
 
 - check if the `-f` option can be specified without a parameter, and negated with `--no-flag`
-- check if the `-b` option can be specified in combination with other options
+- check if the `-b` option can be specified in combination with required options
 
 ### Nested commands
 

--- a/packages/docs/pages/index.mdx
+++ b/packages/docs/pages/index.mdx
@@ -38,13 +38,12 @@ Get started with:
 
   [95m-s[0m, [95m--stringRegex[0m  [90m<my str>[0m      [0mA string option. Values must match the regex [31m/^\d+$/[0m. Defaults to
                                    [32m'123456789'[0m. Can be clustered with [32m's'[0m.[0m
-  [95m-se[0m, [95m--stringEnum[0m  [32m'one'[0m         [0mA string option. Values must be one of {[32m'one'[0m, [32m'two'[0m}. Falls back
-                                   to [32m'two'[0m if specified without parameter. Disallows inline
-                                   parameters.[0m
+  [95m-se[0m, [95m--stringEnum[0m  [32m'one'[0m         [0mA string option. Values must be one of {[32m'one'[0m, [32m'two'[0m}. Disallows
+                                   inline parameters.[0m
   [95m-ss[0m, [95m--strings[0m     [90m[<strings>][0m   [0mA strings option. Values are delimited by [32m','[0m. Values will be
                                    trimmed. Values will be converted to uppercase. Defaults to
                                    [[32m'one'[0m]. Falls back to [[32m'two'[0m] if specified without parameter.[0m
-  [95m--stringsEnum[0m      [32m'one'[0m[90m...[0m      [0mA strings option. Accepts multiple parameters. Accepts positional
+  [95m--stringsLimit[0m     [32m'one'[0m[90m...[0m      [0mA strings option. Accepts multiple parameters. Accepts positional
                                    parameters that may be preceded by [95m--[0m. Element count is limited
                                    to [33m3[0m.[0m
 
@@ -56,7 +55,7 @@ Get started with:
                                    parameters.[0m
   [95m-ns[0m, [95m--numbers[0m     [90m<numbers>...[0m  [0mA numbers option. Accepts multiple parameters. Values will be
                                    converted with Math.round. Defaults to [[33m1[0m, [33m2[0m].[0m
-  [95m--numbersEnum[0m      [32m'1,2'[0m         [0mA numbers option. Values are delimited by [32m','[0m. May be specified
+  [95m--numbersUnique[0m    [32m'1,2'[0m         [0mA numbers option. Values are delimited by [32m','[0m. May be specified
                                    multiple times. Duplicate values will be removed.[0m
 
 [1mUsage:[0m
@@ -65,8 +64,8 @@ Get started with:
   [0mdemo.js[0m [0m[95mhello[0m [90m...[0m [32m# execute the hello command[0m
   [0mdemo.js[0m [0m[([95m-f[0m|[95m--flag[0m|[95m--no-flag[0m)] [[([95m-b[0m|[95m--boolean[0m) [90m<boolean>[0m] ([95m-se[0m|[95m--stringEnum[0m) [32m'one'[0m]
           [([95m-s[0m|[95m--stringRegex[0m) [90m<my str>[0m] [([95m-n[0m|[95m--numberRange[0m) [90m<my num>[0m] [([95m-ne[0m|[95m--numberEnum[0m)=[33m1[0m]
-          [([95m-ss[0m|[95m--strings[0m) [90m[<strings>][0m] [([95m-ns[0m|[95m--numbers[0m) [90m<numbers>...[0m] [[([95m--stringsEnum[0m|[95m--[0m)]
-          [32m'one'[0m[90m...[0m] [[95m--numbersEnum[0m [32m'1,2'[0m][0m
+          [([95m-ss[0m|[95m--strings[0m) [90m[<strings>][0m] [([95m-ns[0m|[95m--numbers[0m) [90m<numbers>...[0m] [[([95m--stringsLimit[0m|[95m--[0m)]
+          [32m'one'[0m[90m...[0m] [[95m--numbersUnique[0m [32m'1,2'[0m][0m
 
 [0mMIT License.
 Copyright (c) 2024 [1;3mTrulySimple[0m

--- a/packages/docs/pages/play.mdx
+++ b/packages/docs/pages/play.mdx
@@ -27,3 +27,17 @@ return {
 ---
 
 <Play callbacks={callbacks} />
+
+## Things to try out
+
+### Validation errors
+
+- check if an error is reported for duplicate option names
+- check if an error is reported for duplicate enumerated values
+- check if an error is reported for duplicate positional options
+
+### Validation warnings
+
+- check if a warning is reported for option names too similar to each other (e.g. `-help1` and `-help2`)
+- check if a warning is reported for option names with mixed naming conventions (e.g. `-h` and `--b`)
+- check if a warning is reported for a variadic option with cluster letters

--- a/packages/tsargp/examples/demo.options.ts
+++ b/packages/tsargp/examples/demo.options.ts
@@ -181,7 +181,6 @@ Report a bug: ${style(fg.brightBlack)}https://github.com/trulysimple/tsargp/issu
     group: 'String options:',
     enums: ['one', 'two'],
     example: 'one',
-    fallback: 'two',
     inline: false,
   },
   /**
@@ -197,7 +196,7 @@ Report a bug: ${style(fg.brightBlack)}https://github.com/trulysimple/tsargp/issu
     inline: 'always',
   },
   /**
-   * A strings option that has a regex constraint.
+   * A delimited strings option whose values are trimmed and converted to uppercase.
    */
   strings: {
     type: 'strings',
@@ -211,7 +210,7 @@ Report a bug: ${style(fg.brightBlack)}https://github.com/trulysimple/tsargp/issu
     case: 'upper',
   },
   /**
-   * A numbers option that has a range constraint.
+   * A variadic numbers option whose values are rounded to the nearest integer.
    */
   numbers: {
     type: 'numbers',
@@ -222,11 +221,11 @@ Report a bug: ${style(fg.brightBlack)}https://github.com/trulysimple/tsargp/issu
     conv: 'round',
   },
   /**
-   * A strings option that has an enumeration constraint.
+   * A variadic strings option that accepts positional arguments, but no more than 3 values.
    */
-  stringsEnum: {
+  stringsLimit: {
     type: 'strings',
-    names: ['', '--stringsEnum'],
+    names: ['', '--stringsLimit'],
     desc: 'A strings option.',
     group: 'String options:',
     example: ['one'],
@@ -234,11 +233,11 @@ Report a bug: ${style(fg.brightBlack)}https://github.com/trulysimple/tsargp/issu
     limit: 3,
   },
   /**
-   * A numbers option that has an enumeration constraint.
+   * A delimited numbers option whose values are unique and can be specified multiple times.
    */
-  numbersEnum: {
+  numbersUnique: {
     type: 'numbers',
-    names: ['', '--numbersEnum'],
+    names: ['', '--numbersUnique'],
     desc: 'A numbers option.',
     group: 'Number options:',
     example: [1, 2],

--- a/packages/tsargp/examples/demo.ts
+++ b/packages/tsargp/examples/demo.ts
@@ -16,10 +16,10 @@ interface Values {
   numberRange: number;
   stringEnum: 'one' | 'two' | undefined;
   numberEnum: 1 | 2 | undefined;
-  strings: string[];
-  numbers: number[];
-  stringsEnum: Array<'one' | 'two'> | undefined;
-  numbersEnum: Array<1 | 2> | undefined;
+  strings: Array<string>;
+  numbers: Array<number>;
+  stringsLimit: Array<string> | undefined;
+  numbersUnique: Array<number> | undefined;
 }
 
 try {

--- a/packages/tsargp/lib/parser.ts
+++ b/packages/tsargp/lib/parser.ts
@@ -182,18 +182,19 @@ export class ArgumentParser<T extends Options = Options> {
   async parseInto(
     values: OptionValues<T>,
     cmdLine = getEnv('COMP_LINE') ?? getEnv('BUFFER') ?? process?.argv.slice(2) ?? [],
-    flags: ParsingFlags = {
-      compIndex: Number(getEnv('COMP_POINT') ?? getEnv('CURSOR')) || getEnv('BUFFER')?.length,
-    },
+    flags?: ParsingFlags,
   ): Promise<ParsingResult> {
-    const args = typeof cmdLine === 'string' ? getArgs(cmdLine, flags.compIndex) : cmdLine;
+    const compIndex =
+      flags?.compIndex ??
+      (Number(getEnv('COMP_POINT') ?? getEnv('CURSOR')) || getEnv('BUFFER')?.length);
+    const args = typeof cmdLine === 'string' ? getArgs(cmdLine, compIndex) : cmdLine;
     const context = createContext(
       this.validator,
       values,
       args,
-      !!flags.compIndex,
-      flags.progName,
-      flags.clusterPrefix,
+      !!compIndex,
+      flags?.progName,
+      flags?.clusterPrefix,
     );
     await parseArgs(context);
     const warning = context[5];
@@ -254,7 +255,7 @@ function parseCluster(context: ParseContext, index: number): boolean {
   }
   const [validator, , args, , completing, , , prefix] = context;
   const cluster = args[index++];
-  if (!prefix || !cluster.startsWith(prefix) || cluster.length === prefix.length) {
+  if (prefix === undefined || !cluster.startsWith(prefix) || cluster.length === prefix.length) {
     return false;
   }
   const letters = validator.letters;

--- a/packages/tsargp/test/parser/parser.cluster.spec.ts
+++ b/packages/tsargp/test/parser/parser.cluster.spec.ts
@@ -13,6 +13,18 @@ describe('ArgumentParser', () => {
       await expect(parser.parse(['-x'], flags)).rejects.toThrow(`Unknown option -x.`);
     });
 
+    it('should parse a flag option in a cluster argument with empty prefix', async () => {
+      const options = {
+        flag: {
+          type: 'flag',
+          names: ['--flag'],
+          clusterLetters: 'f',
+        },
+      } as const satisfies Options;
+      const parser = new ArgumentParser(options);
+      await expect(parser.parse(['f'], { clusterPrefix: '' })).resolves.toEqual({ flag: true });
+    });
+
     it('should parse a flag option in a cluster argument', async () => {
       const options = {
         flag: {


### PR DESCRIPTION
Fixed the default value of the `compIndex` parsing flag when providing a set of flags without it.

Updated the Demo page to reflect the most recent version of the demo example. Updated the Play page to add some tips for testing validation errors and warnings.

Closes #176 
